### PR TITLE
Build native ChatGPT Web harness

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,9 @@ jobs:
       matrix:
         include:
           - runner: macos-15
-            asset: codex-chatgpt-web-darwin-arm64
+            asset: codex-chatgpt-web-darwin-arm64.tar.gz
           - runner: macos-15-intel
-            asset: codex-chatgpt-web-darwin-amd64
+            asset: codex-chatgpt-web-darwin-amd64.tar.gz
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6
@@ -27,9 +27,9 @@ jobs:
       - run: bun run typecheck
       - run: bun test
       - run: bun run build
-      - run: codesign --force --sign - --timestamp=none dist/codex-chatgpt-web
+      - run: codesign --verify --deep --strict dist/runtime/runtime/bun
       - run: bun run smoke
-      - run: mv dist/codex-chatgpt-web "${{ matrix.asset }}"
+      - run: tar -czf "${{ matrix.asset }}" -C dist/runtime .
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.asset }}
@@ -62,7 +62,7 @@ jobs:
           cp LICENSES/Bun-1.3.11.md release-assets/Bun-1.3.11.md
           cp dist/THIRD_PARTY_NOTICES.txt release-assets/THIRD_PARTY_NOTICES.txt
           cd release-assets
-          sha256sum codex-chatgpt-web-darwin-* LICENSE NOTICE.md OpenCodex-MIT.txt Bun-1.3.11.md THIRD_PARTY_NOTICES.txt > checksums.txt
+          sha256sum codex-chatgpt-web-darwin-*.tar.gz LICENSE NOTICE.md OpenCodex-MIT.txt Bun-1.3.11.md THIRD_PARTY_NOTICES.txt > checksums.txt
       - name: Add installer
         run: cp scripts/install.sh release-assets/install.sh
       - name: Publish GitHub release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,8 @@ Core invariants:
 - Model selection is explicit; never silently fall back to another model or reasoning level.
 - Full mode exposes local tools only through the active outer Codex registry and official MCP
   tunnel.
-- Pro-only mode never creates a broker capability or attaches an MCP connector.
+- Browser-only mode never creates a broker capability or attaches an MCP connector; Pro remains
+  read-only in every mode.
 - Browser state, API keys, tunnel IDs, cookies, Codex history, and absolute user paths never enter
   the repository.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">codex-chatgpt-web</h1>
 
 <p align="center">
-  <strong>Use ChatGPT Pro as a native Codex model.</strong><br>
+  <strong>Use ChatGPT Web—including Pro—as one native Codex model.</strong><br>
   Keep Codex's model picker, context, compaction, images, streaming, and task history. Change the model—not your workflow.
 </p>
 
@@ -11,15 +11,16 @@
   <img src="https://img.shields.io/badge/macOS-arm64%20%7C%20Intel-black?logo=apple" alt="macOS arm64 and Intel">
 </p>
 
-<p align="center"><code>curl -fsSL https://github.com/miuuyy/codex-chatgpt-web/releases/latest/download/install.sh | sh -s -- --pro-only --acknowledge-unofficial</code></p>
+<p align="center"><code>curl -fsSL https://github.com/miuuyy/codex-chatgpt-web/releases/latest/download/install.sh | sh -s -- --browser-only --acknowledge-unofficial</code></p>
 
-<p align="center"><sub>One binary · one ChatGPT login window · no API key or tunnel in Pro-only mode</sub></p>
+<p align="center"><sub>One runtime bundle · one ChatGPT login window · no API key or tunnel in browser-only mode</sub></p>
 
 **Codex has the harness. ChatGPT has Pro. This connects them.**
 
-Open a normal Codex task, choose **ChatGPT Pro (web)** in the native model picker, and keep working
-in the same Codex UI. The bridge replays the complete task context into a fresh ChatGPT Temporary
-Chat and streams the result back through Codex's native Responses protocol.
+Open a normal Codex task, choose **ChatGPT Web** in the native model picker, select an Effort from
+Light through Pro, and keep working in the same Codex UI. The bridge replays the complete task
+context into a fresh ChatGPT Temporary Chat and streams the result back through Codex's native
+Responses protocol.
 
 ```text
 Codex task ──Responses + SSE──▶ codex-chatgpt-web ──controlled browser──▶ ChatGPT
@@ -31,21 +32,21 @@ Codex task ──Responses + SSE──▶ codex-chatgpt-web ──controlled bro
 
 | Mode | Native picker | Context and images | Local Codex tools | Tunnel |
 | --- | --- | --- | --- | --- |
-| **Pro-only** | `ChatGPT Pro (web)` | Full | No, with a visible warning | None |
-| **Full harness** | `ChatGPT 5.6 (web + Codex tools)` plus Pro | Full | Yes, in the same ChatGPT response | Official OpenAI tunnel-client |
+| **Browser-only** | `ChatGPT Web` · Light through Pro | Full | No, with a visible warning | None |
+| **Full harness** | The same `ChatGPT Web` model and efforts | Full | Light–Extra High: yes; Pro: read-only | Official OpenAI tunnel-client |
 
 Pro is intentionally read-only with respect to the local computer: it receives all context already
-collected by Codex, but it cannot request another local tool call. Full harness mode adds the
-standard ChatGPT model with the Codex tool loop; the separate Pro entry remains read-only.
+collected by Codex, but it cannot request another local tool call. Full harness mode attaches the
+Codex tool loop to Light, Medium, High, and Extra High. The selected model never changes silently.
 
-## Install Pro
+## Install without local tools
 
 Current release target: macOS arm64 and Intel. Google Chrome is the only external runtime
 dependency.
 
 ```bash
 curl -fsSL https://github.com/miuuyy/codex-chatgpt-web/releases/latest/download/install.sh \
-  | sh -s -- --pro-only --acknowledge-unofficial
+  | sh -s -- --browser-only --acknowledge-unofficial
 ```
 
 Then:
@@ -53,11 +54,12 @@ Then:
 1. Sign in to ChatGPT in the single Chrome window opened by setup.
 2. Let setup finish.
 3. Restart the Codex app once.
-4. Pick **ChatGPT Pro (web)** from the native model picker.
+4. Pick **ChatGPT Web** from the native model picker and choose the **Pro** effort.
 
-That command downloads one checksum-verified standalone executable, stores private browser state
-under `~/.codex-chatgpt-web`, installs a user launchd service, and applies a reversible Codex model
-catalog/config patch. It does **not** install Node, Bun, Go, OpenCodex, or a Playwright browser.
+That command downloads one checksum-verified, versioned runtime bundle, stores private browser
+state under `~/.codex-chatgpt-web`, installs a user launchd service, and applies a reversible Codex
+model catalog/config patch. It does **not** require a system Node/Bun/Go runtime, OpenCodex, or a
+Playwright browser download.
 
 Normal use reuses one long-lived Chrome process. It does not repeat setup or create a new browser
 window for every tool call. Run `codex-chatgpt-web login` only when the ChatGPT session expires.
@@ -136,7 +138,7 @@ When migrating from another Codex proxy whose catalog already contains routed mo
 native Codex catalog explicitly so those foreign entries are not copied into the new picker:
 
 ```bash
-codex-chatgpt-web setup --pro-only \
+codex-chatgpt-web setup --browser-only \
   --source-catalog /path/to/native-model-catalog.json \
   --replace-codex-route \
   --acknowledge-unofficial
@@ -149,8 +151,8 @@ bun install --frozen-lockfile
 bun run verify
 ```
 
-`verify` runs dependency auditing, strict TypeScript checking, 39 harness/MCP/config tests, a
-compiled standalone Responses smoke test, and a real headless launch of system Chrome. The runtime
+`verify` runs dependency auditing, strict TypeScript checking, 56 harness/MCP/config tests, a
+relocatable runtime smoke test, and a real headless launch of system Chrome. The runtime
 contains no generic provider registry, alternate LLM adapter, dashboard, or compatibility shim.
 
 Maintainer details:

--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
   },
   "overrides": {
     "@hono/node-server": "2.0.12",
+    "zod-to-json-schema": "3.25.1",
   },
   "packages": {
     "@hono/node-server": ["@hono/node-server@2.0.12", "", { "peerDependencies": { "hono": "^4" } }, "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg=="],
@@ -232,7 +233,7 @@
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
-    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
     "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,16 +17,17 @@ codex-chatgpt-web daemon
 
 ## Modes
 
-### `pro-only`
+### `browser-only`
 
-- Exposes only `chatgpt-web/gpt-5.6-sol-pro`.
-- Sends the complete Codex context and image attachments to a Temporary Chat in ChatGPT Pro.
+- Exposes one `chatgpt-web/gpt-5.6-sol` model with Light, Medium, High, Extra High, and Pro efforts.
+- Sends the complete Codex context and image attachments to a fresh ChatGPT Temporary Chat.
 - Never starts the broker, tunnel, or MCP server.
-- Emits a nonfatal Codex commentary warning that local tools are unavailable.
+- Emits a nonfatal Codex commentary warning that local tools are unavailable for the selected effort.
 
 ### `full`
 
-- Also exposes `chatgpt-web/gpt-5.6-sol` with Medium, High, and Extra High.
+- Exposes the same single model and effort list; Light through Extra High are tool-capable, while
+  Pro remains read-only.
 - ChatGPT uses a custom MCP connector backed by `openai/tunnel-client`.
 - Every connector call is bound to one outer Codex turn capability.
 - Tool calls and results remain in the same ChatGPT response while Codex executes them locally.
@@ -39,11 +40,11 @@ closed. This prevents transcript leakage without creating a new Chrome window pe
 
 ## Installation and service lifecycle
 
-The release artifact is a single Bun-compiled executable. It contains the Responses bridge,
-Playwright client code, MCP server, setup, doctor, and launchd management; it uses the user's
-installed Google Chrome and does not download a second browser. Full mode separately downloads the
-official pinned `openai/tunnel-client` release and verifies it against that release's published
-SHA-256 manifest.
+The release artifact is a versioned runtime bundle containing a pinned Bun executable and the
+bundled application. It contains the Responses bridge, Playwright client code, MCP server, setup,
+doctor, and launchd management; it uses the user's installed Google Chrome and does not download a
+second browser. Full mode separately downloads the official pinned `openai/tunnel-client` release
+and verifies it against that release's published SHA-256 manifest.
 
 Setup creates a user launchd service and only then journals and switches Codex's two integration
 keys. It never restarts an already loaded daemon implicitly. A requested stop, restart, replacement,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-chatgpt-web",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "A focused local Responses bridge that runs Codex tasks through a user-authenticated ChatGPT web session.",
   "repository": {
@@ -31,8 +31,8 @@
     "check-version": "bun run scripts/check-version.ts",
     "typecheck": "bunx tsc --noEmit",
     "licenses": "bun run scripts/generate-third-party-notices.ts",
-    "build": "bun build src/cli.ts --compile --minify --sourcemap --outfile dist/codex-chatgpt-web",
-    "smoke": "bun run scripts/smoke-release.ts dist/codex-chatgpt-web",
+    "build": "bun run scripts/build-runtime-bundle.ts",
+    "smoke": "bun run scripts/smoke-release.ts dist/runtime",
     "smoke:codex": "bun run scripts/smoke-codex-catalog.ts",
     "verify": "bun run check-version && bun run audit && bun run typecheck && bun run test && bun run build && bun run licenses && bun run smoke"
   },
@@ -54,7 +54,8 @@
     "bun": ">=1.3.11 <1.4"
   },
   "overrides": {
-    "@hono/node-server": "2.0.12"
+    "@hono/node-server": "2.0.12",
+    "zod-to-json-schema": "3.25.1"
   },
   "keywords": [
     "codex",

--- a/scripts/build-runtime-bundle.ts
+++ b/scripts/build-runtime-bundle.ts
@@ -1,0 +1,79 @@
+import { chmodSync, copyFileSync, cpSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { VERSION } from "../src/version";
+
+const root = resolve(import.meta.dir, "..");
+const output = resolve(process.argv[2] ?? join(root, "dist", "runtime"));
+const appDir = join(output, "app");
+const runtimeDir = join(output, "runtime");
+const binDir = join(output, "bin");
+
+rmSync(output, { recursive: true, force: true });
+mkdirSync(appDir, { recursive: true });
+mkdirSync(runtimeDir, { recursive: true });
+mkdirSync(binDir, { recursive: true });
+
+const build = await Bun.build({
+  entrypoints: [join(root, "src", "cli.ts")],
+  target: "bun",
+  minify: true,
+  external: ["playwright-core"],
+  packages: "external",
+  outdir: appDir,
+  naming: "cli.js",
+});
+if (!build.success) {
+  throw new Error(`Runtime bundle failed: ${build.logs.map(log => log.message).join("; ")}`);
+}
+
+copyFileSync(join(root, "package.json"), join(appDir, "package.json"));
+copyFileSync(join(root, "bun.lock"), join(appDir, "bun.lock"));
+const install = Bun.spawnSync([process.execPath, "install", "--production", "--frozen-lockfile", "--ignore-scripts"], {
+  cwd: appDir,
+  stdout: "pipe",
+  stderr: "pipe",
+});
+if (install.exitCode !== 0) {
+  throw new Error(`Runtime dependencies failed to install: ${install.stderr.toString() || install.stdout.toString()}`);
+}
+cpSync(realpathSync(process.execPath), join(runtimeDir, "bun"));
+chmodSync(join(runtimeDir, "bun"), 0o755);
+
+const launcher = `#!/bin/sh
+set -eu
+invoked="$0"
+case "$invoked" in
+  /*) ;;
+  *) invoked="$(command -v -- "$invoked")" ;;
+esac
+script="$invoked"
+while [ -L "$script" ]; do
+  target="$(readlink "$script")"
+  case "$target" in
+    /*) script="$target" ;;
+    *) script="$(dirname "$script")/$target" ;;
+  esac
+done
+bin_dir="$(CDPATH= cd -- "$(dirname "$script")" && pwd -P)"
+root="$(CDPATH= cd -- "$bin_dir/.." && pwd -P)"
+export CODEX_CHATGPT_WEB_LAUNCHER="$invoked"
+exec "$root/runtime/bun" "$root/app/cli.js" "$@"
+`;
+writeFileSync(join(binDir, "codex-chatgpt-web"), launcher, { mode: 0o755 });
+chmodSync(join(binDir, "codex-chatgpt-web"), 0o755);
+
+const packageJson = JSON.parse(readFileSync(join(root, "package.json"), "utf8")) as { version?: string };
+if (packageJson.version !== VERSION) throw new Error("package.json and runtime version are out of sync");
+const playwrightPackage = join(appDir, "node_modules", "playwright-core", "package.json");
+writeFileSync(join(output, "manifest.json"), `${JSON.stringify({
+  schemaVersion: 1,
+  appVersion: VERSION,
+  bunVersion: Bun.version,
+  platform: process.platform,
+  arch: process.arch,
+  launcher: "bin/codex-chatgpt-web",
+  entrypoint: "app/cli.js",
+  playwright: JSON.parse(readFileSync(playwrightPackage, "utf8")).version,
+}, null, 2)}\n`);
+
+process.stdout.write(`${output}\n`);

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,8 +2,10 @@
 set -eu
 
 REPOSITORY="${CODEX_CHATGPT_WEB_REPOSITORY:-miuuyy/codex-chatgpt-web}"
-VERSION="${CODEX_CHATGPT_WEB_VERSION:-0.1.0}"
-INSTALL_DIR="${CODEX_CHATGPT_WEB_BIN_DIR:-$HOME/.local/bin}"
+VERSION="${CODEX_CHATGPT_WEB_VERSION:-0.1.1}"
+BIN_DIR="${CODEX_CHATGPT_WEB_BIN_DIR:-$HOME/.local/bin}"
+LIB_DIR="${CODEX_CHATGPT_WEB_LIB_DIR:-$HOME/.local/lib/codex-chatgpt-web}"
+DOC_DIR="${CODEX_CHATGPT_WEB_DOC_DIR:-$HOME/.local/share/doc/codex-chatgpt-web}"
 
 if [ "$(uname -s)" != "Darwin" ]; then
   echo "codex-chatgpt-web 0.1 supports macOS only" >&2
@@ -16,26 +18,24 @@ case "$(uname -m)" in
   *) echo "Unsupported macOS architecture: $(uname -m)" >&2; exit 1 ;;
 esac
 
-ASSET="codex-chatgpt-web-darwin-$ARCH"
+ASSET="codex-chatgpt-web-darwin-$ARCH.tar.gz"
 BASE_URL="https://github.com/$REPOSITORY/releases/download/v$VERSION"
 TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/codex-chatgpt-web.XXXXXX")"
-trap 'rm -rf "$TEMP_DIR"' EXIT HUP INT TERM
+STAGE_DIR="$LIB_DIR/.stage-$VERSION-$$"
+TARGET_DIR="$LIB_DIR/$VERSION"
+BACKUP_DIR="$LIB_DIR/.previous-$VERSION-$$"
+trap 'rm -rf "$TEMP_DIR" "$STAGE_DIR"' EXIT HUP INT TERM
 
 curl -fsSL "$BASE_URL/$ASSET" -o "$TEMP_DIR/$ASSET"
 curl -fsSL "$BASE_URL/checksums.txt" -o "$TEMP_DIR/checksums.txt"
 
 EXPECTED="$(awk -v asset="$ASSET" '$2 == asset { print $1 }' "$TEMP_DIR/checksums.txt")"
-if [ -z "$EXPECTED" ]; then
-  echo "checksums.txt has no entry for $ASSET" >&2
-  exit 1
-fi
 ACTUAL="$(shasum -a 256 "$TEMP_DIR/$ASSET" | awk '{ print $1 }')"
-if [ "$ACTUAL" != "$EXPECTED" ]; then
+if [ -z "$EXPECTED" ] || [ "$ACTUAL" != "$EXPECTED" ]; then
   echo "SHA-256 verification failed for $ASSET" >&2
   exit 1
 fi
 
-DOC_DIR="${CODEX_CHATGPT_WEB_DOC_DIR:-$HOME/.local/share/doc/codex-chatgpt-web}"
 for DOC in LICENSE NOTICE.md OpenCodex-MIT.txt Bun-1.3.11.md THIRD_PARTY_NOTICES.txt; do
   curl -fsSL "$BASE_URL/$DOC" -o "$TEMP_DIR/$DOC"
   DOC_EXPECTED="$(awk -v asset="$DOC" '$2 == asset { print $1 }' "$TEMP_DIR/checksums.txt")"
@@ -45,15 +45,37 @@ for DOC in LICENSE NOTICE.md OpenCodex-MIT.txt Bun-1.3.11.md THIRD_PARTY_NOTICES
     exit 1
   fi
 done
-mkdir -p "$INSTALL_DIR" "$DOC_DIR"
-install -m 0755 "$TEMP_DIR/$ASSET" "$INSTALL_DIR/codex-chatgpt-web"
+
+mkdir -p "$LIB_DIR" "$BIN_DIR" "$DOC_DIR"
+mkdir "$STAGE_DIR"
+tar -xzf "$TEMP_DIR/$ASSET" -C "$STAGE_DIR"
+if [ ! -x "$STAGE_DIR/bin/codex-chatgpt-web" ] || [ ! -x "$STAGE_DIR/runtime/bun" ]; then
+  echo "Runtime archive is incomplete" >&2
+  exit 1
+fi
+if [ "$("$STAGE_DIR/bin/codex-chatgpt-web" --version)" != "$VERSION" ]; then
+  echo "Runtime archive version does not match $VERSION" >&2
+  exit 1
+fi
+
+if [ -e "$TARGET_DIR" ]; then
+  mv "$TARGET_DIR" "$BACKUP_DIR"
+fi
+if ! mv "$STAGE_DIR" "$TARGET_DIR"; then
+  if [ -e "$BACKUP_DIR" ]; then mv "$BACKUP_DIR" "$TARGET_DIR"; fi
+  exit 1
+fi
+
+ln -sfn "$TARGET_DIR/bin/codex-chatgpt-web" "$BIN_DIR/.codex-chatgpt-web.next"
+mv -f "$BIN_DIR/.codex-chatgpt-web.next" "$BIN_DIR/codex-chatgpt-web"
 for DOC in LICENSE NOTICE.md OpenCodex-MIT.txt Bun-1.3.11.md THIRD_PARTY_NOTICES.txt; do
   install -m 0644 "$TEMP_DIR/$DOC" "$DOC_DIR/$DOC"
 done
-echo "Installed $INSTALL_DIR/codex-chatgpt-web"
+if [ -e "$BACKUP_DIR" ]; then rm -rf "$BACKUP_DIR"; fi
 
+echo "Installed $TARGET_DIR"
 if [ "$#" -gt 0 ]; then
-  exec "$INSTALL_DIR/codex-chatgpt-web" setup "$@"
+  "$TARGET_DIR/bin/codex-chatgpt-web" setup "$@"
+  exit 0
 fi
-
-echo "Next: $INSTALL_DIR/codex-chatgpt-web setup --pro-only --acknowledge-unofficial"
+echo "Next: $BIN_DIR/codex-chatgpt-web setup --browser-only --acknowledge-unofficial"

--- a/scripts/smoke-codex-catalog.ts
+++ b/scripts/smoke-codex-catalog.ts
@@ -1,14 +1,27 @@
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
 import { defaultConfig, saveConfig } from "../src/config";
 import { installCodexIntegration } from "../src/codex-integration";
 import { startServer } from "../src/server";
 
 const codex = resolve(process.argv[2] ?? "/Applications/ChatGPT.app/Contents/Resources/codex");
-const bundled = Bun.spawnSync([codex, "debug", "models", "--bundled"], { stdout: "pipe", stderr: "pipe" });
-if (bundled.exitCode !== 0) throw new Error(`Could not read bundled Codex catalog: ${bundled.stderr.toString()}`);
-const sourceCatalog = JSON.parse(bundled.stdout.toString()) as { models?: unknown[] };
+function runCodex(args: string[], env = process.env): { stdout: string; stderr: string } {
+  const result = spawnSync(codex, args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    env,
+    timeout: 15_000,
+  });
+  if (result.status !== 0) {
+    throw new Error(`Codex ${args.join(" ")} failed: ${result.error?.message || result.stderr || result.signal || `exit ${result.status}`}`);
+  }
+  return { stdout: result.stdout, stderr: result.stderr };
+}
+
+const bundled = runCodex(["debug", "models", "--bundled"]);
+const sourceCatalog = JSON.parse(bundled.stdout) as { models?: unknown[] };
 if (!sourceCatalog.models?.some(model => model && typeof model === "object" && (model as { slug?: string }).slug === "gpt-5.6-sol")) {
   throw new Error("Bundled Codex catalog has no gpt-5.6-sol template");
 }
@@ -19,7 +32,7 @@ process.env.CODEX_CHATGPT_WEB_HOME = join(root, "app");
 mkdirSync(process.env.CODEX_HOME, { recursive: true });
 const source = join(root, "bundled-models.json");
 writeFileSync(source, `${JSON.stringify(sourceCatalog)}\n`);
-const config = defaultConfig("pro-only");
+const config = defaultConfig("browser-only");
 config.proAvailable = true;
 const port = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: { data() {} } });
 config.port = port.port;
@@ -29,17 +42,15 @@ saveConfig(config);
 installCodexIntegration(config, { sourceCatalogPath: source });
 const server = startServer(config);
 try {
-  const result = Bun.spawnSync([codex, "debug", "models"], {
-    env: { ...process.env, CODEX_HOME: process.env.CODEX_HOME },
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  if (result.exitCode !== 0) throw new Error(`Codex rejected the generated catalog: ${result.stderr.toString()}`);
-  const catalog = JSON.parse(result.stdout.toString()) as { models?: Array<{ slug?: string; supported_reasoning_levels?: unknown[] }> };
-  const pro = catalog.models?.find(model => model.slug === "chatgpt-web/gpt-5.6-sol-pro");
-  if (!pro) throw new Error("Codex did not expose the generated Pro model");
-  if (!Array.isArray(pro.supported_reasoning_levels) || pro.supported_reasoning_levels.length !== 0) {
-    throw new Error("Codex did not preserve the Pro no-effort model contract");
+  const result = runCodex(["debug", "models"], { ...process.env, CODEX_HOME: process.env.CODEX_HOME });
+  const catalog = JSON.parse(result.stdout) as { models?: Array<{ slug?: string; supported_reasoning_levels?: unknown[] }> };
+  const web = catalog.models?.find(model => model.slug === "chatgpt-web/gpt-5.6-sol");
+  if (!web) throw new Error("Codex did not expose the generated ChatGPT Web model");
+  const efforts = Array.isArray(web.supported_reasoning_levels)
+    ? (web.supported_reasoning_levels as Array<{ effort?: string }>).map(level => level.effort)
+    : [];
+  if (JSON.stringify(efforts) !== JSON.stringify(["light", "medium", "high", "xhigh", "pro"])) {
+    throw new Error(`Codex did not preserve the ChatGPT Web effort contract: ${JSON.stringify(efforts)}`);
   }
   process.stdout.write("NATIVE_CODEX_CATALOG_SMOKE_OK\n");
 } finally {

--- a/scripts/smoke-release.ts
+++ b/scripts/smoke-release.ts
@@ -1,10 +1,34 @@
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { cpSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
 
-const binary = resolve(process.argv[2] ?? "dist/codex-chatgpt-web");
-const root = join(tmpdir(), `codex-chatgpt-web-release-smoke-${process.pid}-${Date.now()}`);
-const appHome = join(root, "app");
+const sourceBundle = resolve(process.argv[2] ?? "dist/runtime");
+const sourceRoot = resolve(import.meta.dir, "..");
+const root = join(homedir(), `.codex-chatgpt-web-release-smoke-${process.pid}-${Date.now()}`);
+const firstLocation = join(root, "first-location");
+const runtimeRoot = join(root, "relocated-runtime");
+cpSync(sourceBundle, firstLocation, { recursive: true });
+renameSync(firstLocation, runtimeRoot);
+
+const launcher = join(runtimeRoot, "bin", "codex-chatgpt-web");
+const cliBundle = readFileSync(join(runtimeRoot, "app", "cli.js"), "utf8");
+const launcherText = readFileSync(launcher, "utf8");
+for (const forbidden of [sourceRoot, dirname(sourceBundle), "/private/tmp/codex-chatgpt-web-verify", "/tmp/codex-chatgpt-web-verify"]) {
+  if (cliBundle.includes(forbidden) || launcherText.includes(forbidden)) {
+    throw new Error(`Runtime artifact embeds an ephemeral build path: ${forbidden}`);
+  }
+}
+
+const manifest = JSON.parse(readFileSync(join(runtimeRoot, "manifest.json"), "utf8")) as Record<string, unknown>;
+if (manifest.schemaVersion !== 1 || manifest.appVersion !== "0.1.1" || manifest.playwright !== "1.62.0") {
+  throw new Error(`Unexpected runtime manifest: ${JSON.stringify(manifest)}`);
+}
+const version = Bun.spawnSync([launcher, "--version"], { stdout: "pipe", stderr: "pipe" });
+if (version.exitCode !== 0 || version.stdout.toString().trim() !== "0.1.1") {
+  throw new Error(`Relocated launcher failed: ${version.stderr.toString()}`);
+}
+
+const appHome = join(root, "app-state");
 const codexHome = join(root, "codex");
 mkdirSync(join(appHome, "browser"), { recursive: true });
 mkdirSync(codexHome, { recursive: true });
@@ -12,9 +36,9 @@ const portServer = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: { data()
 const port = portServer.port;
 portServer.stop();
 const config = {
-  version: 1,
-  releaseVersion: "0.1.0",
-  mode: "pro-only",
+  version: 2,
+  releaseVersion: "0.1.1",
+  mode: "browser-only",
   host: "127.0.0.1",
   port,
   contextWindow: 256_000,
@@ -23,16 +47,17 @@ const config = {
   storageStatePath: join(appHome, "browser", "storage-state.json"),
   brokerSocketPath: join(appHome, "runtime", "turn-broker.sock"),
   headed: true,
+  proAvailable: true,
   autoApproveToolCalls: false,
   controlToken: "release-smoke-control-token-0123456789abcdef",
-  runtimeCommand: [binary],
+  runtimeCommand: [launcher],
   acknowledgedUnofficialAt: new Date().toISOString(),
 };
 writeFileSync(join(appHome, "config.json"), `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 });
 writeFileSync(config.storageStatePath, "{}\n", { mode: 0o600 });
 
 const env = { ...process.env, CODEX_CHATGPT_WEB_HOME: appHome, CODEX_HOME: codexHome };
-const child = Bun.spawn([binary, "serve"], { env, stdout: "pipe", stderr: "pipe" });
+const child = Bun.spawn([launcher, "serve"], { env, stdout: "pipe", stderr: "pipe" });
 try {
   const deadline = Date.now() + 10_000;
   let health: Response | undefined;
@@ -43,12 +68,14 @@ try {
     } catch {}
     await Bun.sleep(50);
   }
-  if (!health?.ok) throw new Error("standalone daemon did not become healthy");
+  if (!health?.ok) throw new Error("relocated daemon did not become healthy");
   const payload = await health.json() as Record<string, unknown>;
-  if (payload.service !== "codex-chatgpt-web" || payload.mode !== "pro-only") throw new Error(`unexpected health payload: ${JSON.stringify(payload)}`);
+  if (payload.service !== "codex-chatgpt-web" || payload.mode !== "browser-only") {
+    throw new Error(`unexpected health payload: ${JSON.stringify(payload)}`);
+  }
 
   const models = await fetch(`http://127.0.0.1:${port}/v1/models`).then(response => response.json()) as { data?: Array<{ id?: string }> };
-  if (JSON.stringify(models.data?.map(model => model.id)) !== JSON.stringify(["chatgpt-web/gpt-5.6-sol-pro"])) {
+  if (JSON.stringify(models.data?.map(model => model.id)) !== JSON.stringify(["chatgpt-web/gpt-5.6-sol"])) {
     throw new Error(`unexpected model list: ${JSON.stringify(models)}`);
   }
   const invalid = await fetch(`http://127.0.0.1:${port}/v1/responses`, {
@@ -76,7 +103,7 @@ try {
   const rejectedWhileDraining = await fetch(`http://127.0.0.1:${port}/v1/responses`, {
     method: "POST",
     headers: { "content-type": "application/json" },
-    body: JSON.stringify({ model: "chatgpt-web/gpt-5.6-sol-pro", input: "test", stream: false }),
+    body: JSON.stringify({ model: "chatgpt-web/gpt-5.6-sol", reasoning: { effort: "high" }, input: "test", stream: false }),
   });
   if (rejectedWhileDraining.status !== 503) {
     throw new Error(`daemon accepted a new turn while draining: HTTP ${rejectedWhileDraining.status}`);
@@ -91,10 +118,10 @@ try {
   }
 
   if (process.platform === "darwin") {
-    const browser = Bun.spawnSync([binary, "browser", "check"], { env, stdout: "pipe", stderr: "pipe" });
-    if (browser.exitCode !== 0) throw new Error(`standalone Playwright smoke failed: ${browser.stderr.toString()}`);
+    const browser = Bun.spawnSync([launcher, "browser", "check"], { env, stdout: "pipe", stderr: "pipe" });
+    if (browser.exitCode !== 0) throw new Error(`relocated Playwright smoke failed: ${browser.stderr.toString()}`);
   }
-  process.stdout.write("STANDALONE_RELEASE_SMOKE_OK\n");
+  process.stdout.write("RELOCATABLE_RUNTIME_SMOKE_OK\n");
 } finally {
   child.kill("SIGTERM");
   await child.exited;

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -5,10 +5,10 @@ import { atomicWriteFile, expandUserPath, getConfigDir } from "../../config";
 import type { CodexProviderConfig } from "../../types";
 import { parseDataUrl } from "../image";
 import { ChatGptMarkdownStream } from "./markdown";
-import { resolveChatGptWebModelMode, type ChatGptWebModelMode } from "./model";
+import { resolveChatGptWebModelMode, type ChatGptWebCapabilities, type ChatGptWebModelMode } from "./model";
 import type { CompiledChatGptWebPrompt, ChatGptWebPromptImage } from "./prompt";
 import { assertChatGptWebInputWithinLimit, estimateCompiledChatGptWebInputTokens } from "./usage";
-import { assertAuthenticatedChatGptPage, assertTemporaryChatPage } from "../../chatgpt-session";
+import { assertAuthenticatedChatGptPage, assertTemporaryChatPage, CHATGPT_TEMPORARY_CHAT_URL } from "../../chatgpt-session";
 import { loginVerificationMarkerPath } from "../../browser-login";
 
 const workers = new Map<string, ChatGptBrowserWorker>();
@@ -17,6 +17,7 @@ export interface BrowserTurn {
   traceId: string;
   modelId: string;
   reasoning?: string;
+  capabilities: ChatGptWebCapabilities;
   contextWindowTokens?: number;
   prepare: () => Promise<CompiledChatGptWebPrompt & { release: () => void }>;
   abortSignal?: AbortSignal;
@@ -69,6 +70,17 @@ export class ChatGptCompletionTracker {
     }
     return now - this.candidate.since >= this.stableMs;
   }
+}
+
+export function chatGptEffortLabelsMatch(current: string, desired: string): boolean {
+  const normalize = (value: string) => value.replace(/\s+/g, " ").trim();
+  return normalize(current) === normalize(desired);
+}
+
+export function redactChatGptUiDiagnostic(value: string): string {
+  return value
+    .replace(/<codex_context_json>[\s\S]*?<\/codex_context_json>/gi, "<codex_context_json>[redacted]</codex_context_json>")
+    .replace(/\b(turn|binding|call)_[A-Za-z0-9_-]{12,}\b/g, "$1_[redacted]");
 }
 
 function resolveBrowserConfig(provider: CodexProviderConfig): ResolvedBrowserConfig {
@@ -144,6 +156,37 @@ export class ChatGptBrowserWorker {
     if (browser) await browser.close();
   }
 
+  private discardBrowser(): void {
+    const browser = this.browser;
+    this.browser = undefined;
+    this.context = undefined;
+    this.page = undefined;
+    if (browser) void browser.close().catch(() => {});
+  }
+
+  private async runStage<T>(traceId: string, stage: string, timeoutMs: number, action: () => Promise<T>): Promise<T> {
+    console.info(`[chatgpt-web] browser turn ${traceId} stage=${stage} started`);
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let timedOut = false;
+    try {
+      const timeout = new Promise<never>((_, rejectTimeout) => {
+        timer = setTimeout(() => {
+          timedOut = true;
+          rejectTimeout(new Error(`ChatGPT browser stage timed out: ${stage}`));
+        }, timeoutMs);
+      });
+      const value = await Promise.race([action(), timeout]);
+      console.info(`[chatgpt-web] browser turn ${traceId} stage=${stage} completed`);
+      return value;
+    } catch (error) {
+      console.error(`[chatgpt-web] browser turn ${traceId} stage=${stage} failed: ${error instanceof Error ? error.message : String(error)}`);
+      if (timedOut) this.discardBrowser();
+      throw error;
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+
   private async ensurePage(): Promise<Page> {
     if (this.page && !this.page.isClosed()) return this.page;
     if (!existsSync(this.config.storageStatePath) || !existsSync(loginVerificationMarkerPath(this.config.storageStatePath))) {
@@ -177,27 +220,63 @@ export class ChatGptBrowserWorker {
     return page;
   }
 
-  private async selectModelAndEffort(page: Page, modelId: string, reasoning: string | undefined): Promise<ChatGptWebModelMode> {
-    const mode = resolveChatGptWebModelMode(modelId, reasoning);
+  private async selectModelAndEffort(
+    page: Page,
+    modelId: string,
+    reasoning: string | undefined,
+    capabilities: ChatGptWebCapabilities,
+  ): Promise<ChatGptWebModelMode> {
+    const mode = resolveChatGptWebModelMode(modelId, reasoning, capabilities);
     const currentEffort = page.getByRole("button", {
       name: /^(?:Instant(?:\s+5\.5)?|Medium|High|Extra High|Pro)$/,
     }).last();
     await currentEffort.waitFor({ state: "visible", timeout: 15_000 });
+    if (chatGptEffortLabelsMatch(await currentEffort.innerText(), mode.uiEffortLabel)) return mode;
     await currentEffort.click();
     const effortChoice = page.getByRole("menuitem", { name: mode.uiEffortLabel, exact: true }).or(
       page.getByRole("menuitemradio", { name: mode.uiEffortLabel, exact: true }),
     ).last();
     await effortChoice.waitFor({ state: "visible", timeout: 5_000 });
     await effortChoice.click();
+    await effortChoice.waitFor({ state: "hidden", timeout: 5_000 });
     await page.getByRole("button", { name: mode.uiEffortLabel, exact: true }).last()
       .waitFor({ state: "visible", timeout: 5_000 });
     return mode;
+  }
+
+  private async attachedPromptText(page: Page): Promise<string> {
+    const composer = page.getByRole("textbox", { name: "Chat with ChatGPT" });
+    return composer.evaluate(element => {
+      const clone = element.cloneNode(true) as HTMLElement;
+      clone.querySelectorAll("[data-inline-selection-pill], [data-inline-selection-pill-cursor-target]")
+        .forEach(part => part.remove());
+      return [...clone.children]
+        .map(child => child.textContent ?? "")
+        .join("\n")
+        .trimStart();
+    }, undefined, { timeout: 10_000 });
+  }
+
+  private async assertPromptAttached(page: Page, prompt: string): Promise<void> {
+    const deadline = Date.now() + 5_000;
+    let observed = "";
+    while (Date.now() < deadline) {
+      observed = await this.attachedPromptText(page);
+      if (observed === prompt) return;
+      await new Promise(resolveSleep => setTimeout(resolveSleep, 50));
+    }
+    let commonPrefix = 0;
+    while (commonPrefix < prompt.length && prompt[commonPrefix] === observed[commonPrefix]) commonPrefix += 1;
+    throw new Error(
+      `ChatGPT composer did not preserve the complete prompt (expectedChars=${prompt.length}, actualChars=${observed.length}, commonPrefixChars=${commonPrefix})`,
+    );
   }
 
   private async attachPrompt(page: Page, prompt: string, localTools: boolean): Promise<void> {
     const composer = page.getByRole("textbox", { name: "Chat with ChatGPT" });
     if (!localTools) {
       await composer.fill(prompt);
+      await this.assertPromptAttached(page, prompt);
       return;
     }
     await composer.fill(`@${this.config.appName}`);
@@ -209,6 +288,7 @@ export class ChatGptBrowserWorker {
     await composer.focus();
     await page.keyboard.press("End");
     await page.keyboard.insertText(` ${prompt}`);
+    await this.assertPromptAttached(page, prompt);
   }
 
   private async attachImages(page: Page, images: ChatGptWebPromptImage[]): Promise<void> {
@@ -236,36 +316,88 @@ export class ChatGptBrowserWorker {
     return true;
   }
 
+  private async stalledTurnDiagnostic(page: Page): Promise<string> {
+    const assistant = page.locator('[data-message-author-role="assistant"]').last();
+    const assistantState = await assistant.count()
+      ? await assistant.evaluate(element => {
+        const root = element as HTMLElement;
+        const descriptors = [...root.querySelectorAll<HTMLElement>("[role], [data-testid], button, [aria-label]")]
+          .filter(candidate => {
+            const style = getComputedStyle(candidate);
+            return style.visibility !== "hidden" && style.display !== "none";
+          })
+          .slice(-80)
+          .map(candidate => ({
+            tag: candidate.tagName.toLowerCase(),
+            role: candidate.getAttribute("role"),
+            testId: candidate.getAttribute("data-testid"),
+            ariaLabel: candidate.getAttribute("aria-label"),
+            title: candidate.getAttribute("title"),
+            text: candidate.innerText.trim().slice(0, 500),
+          }));
+        return {
+          text: root.innerText.trim().slice(0, 2_000),
+          descriptors,
+        };
+      })
+      : { text: "", descriptors: [] };
+    const overlays = await page.locator('[role="dialog"], [role="alert"], [role="status"]').evaluateAll(elements => (
+      elements
+        .filter(element => {
+          const candidate = element as HTMLElement;
+          const style = getComputedStyle(candidate);
+          return style.visibility !== "hidden" && style.display !== "none";
+        })
+        .slice(-30)
+        .map(element => {
+          const candidate = element as HTMLElement;
+          return {
+            role: candidate.getAttribute("role"),
+            testId: candidate.getAttribute("data-testid"),
+            ariaLabel: candidate.getAttribute("aria-label"),
+            text: candidate.innerText.trim().slice(0, 1_000),
+          };
+        })
+    )).catch(() => [] as Array<Record<string, string | null>>);
+    return redactChatGptUiDiagnostic(JSON.stringify({ assistant: assistantState, overlays }));
+  }
+
   private async runExclusive(turn: BrowserTurn): Promise<string> {
     if (turn.abortSignal?.aborted) throw new DOMException("ChatGPT web turn aborted", "AbortError");
     const prepared = await turn.prepare();
     try {
       if (turn.abortSignal?.aborted) throw new DOMException("ChatGPT web turn aborted", "AbortError");
-      assertChatGptWebInputWithinLimit(
-        estimateCompiledChatGptWebInputTokens(prepared, turn.modelId),
-        turn.contextWindowTokens,
-      );
+      const estimatedInputTokens = estimateCompiledChatGptWebInputTokens(prepared, turn.modelId);
+      assertChatGptWebInputWithinLimit(estimatedInputTokens, turn.contextWindowTokens);
       const deadline = Date.now() + this.config.turnTimeoutMs;
-      const page = await this.pageForNewTurn();
-      console.info(`[chatgpt-web] browser turn ${turn.traceId} opened`);
-      await page.goto("https://chatgpt.com/?temporary-chat=true", { waitUntil: "domcontentloaded", timeout: 30_000 });
+      const page = await this.runStage(turn.traceId, "browser_page", 30_000, () => this.pageForNewTurn());
+      console.info(
+        `[chatgpt-web] browser turn ${turn.traceId} opened (promptChars=${prepared.text.length}, estimatedInputTokens=${estimatedInputTokens}, images=${prepared.images.length})`,
+      );
+      await this.runStage(turn.traceId, "temporary_chat_navigation", 35_000, () => (
+        page.goto(CHATGPT_TEMPORARY_CHAT_URL, { waitUntil: "domcontentloaded", timeout: 30_000 }).then(() => undefined)
+      ));
       const composer = page.getByRole("textbox", { name: "Chat with ChatGPT" });
       try {
-        await composer.waitFor({ state: "visible", timeout: 15_000 });
+        await this.runStage(turn.traceId, "composer_ready", 20_000, () => composer.waitFor({ state: "visible", timeout: 15_000 }));
       } catch {
         throw new Error("ChatGPT web login is expired or the Temporary Chat surface is unavailable");
       }
-      await assertAuthenticatedChatGptPage(page);
-      await assertTemporaryChatPage(page);
-      const mode = await this.selectModelAndEffort(page, turn.modelId, turn.reasoning);
-      await this.attachPrompt(page, prepared.text, mode.localTools);
-      await this.attachImages(page, prepared.images);
+      await this.runStage(turn.traceId, "session_verification", 20_000, async () => {
+        await assertAuthenticatedChatGptPage(page);
+        await assertTemporaryChatPage(page);
+      });
+      const mode = await this.runStage(turn.traceId, "effort_selection", 20_000, () => (
+        this.selectModelAndEffort(page, turn.modelId, turn.reasoning, turn.capabilities)
+      ));
+      await this.runStage(turn.traceId, "prompt_attachment", 30_000, () => this.attachPrompt(page, prepared.text, mode.localTools));
+      await this.runStage(turn.traceId, "image_attachment", 45_000, () => this.attachImages(page, prepared.images));
       const completionActions = page.locator('[data-testid="copy-turn-action-button"], button[aria-label="Copy response"]');
       const initialCompletionActionCount = await completionActions.count();
       const assistantMessages = page.locator('[data-message-author-role="assistant"]');
       const initialAssistant = assistantMessages.last().locator(".markdown").last();
       const initialAssistantText = await initialAssistant.count() ? (await initialAssistant.innerText()).trim() : "";
-      await page.getByTestId("send-button").click();
+      await this.runStage(turn.traceId, "send", 10_000, () => page.getByTestId("send-button").click());
 
       let lastHeartbeat = 0;
       let finalText = "";
@@ -349,8 +481,11 @@ export class ChatGptBrowserWorker {
           }
           if (!loggedCompletionWait && Date.now() - sentAt >= 30_000) {
             loggedCompletionWait = true;
+            const diagnostic = await this.stalledTurnDiagnostic(page).catch(error => JSON.stringify({
+              diagnosticError: error instanceof Error ? error.message : String(error),
+            }));
             console.warn(
-              `[chatgpt-web] waiting for completed-turn evidence (running=${running}, sawRunning=${sawRunning}, textChars=${snapshot.visibleText.length}, completionActions=${completionActionCount}, initialCompletionActions=${initialCompletionActionCount})`,
+              `[chatgpt-web] waiting for completed-turn evidence (running=${running}, sawRunning=${sawRunning}, textChars=${snapshot.visibleText.length}, completionActions=${completionActionCount}, initialCompletionActions=${initialCompletionActionCount}, ui=${diagnostic})`,
             );
           }
         }

--- a/src/adapters/chatgpt-web/environment.ts
+++ b/src/adapters/chatgpt-web/environment.ts
@@ -69,6 +69,69 @@ function environmentBeforeUser(input: unknown[], userIndex: number, expectedTurn
   return undefined;
 }
 
+function sandboxTypeFromEnvironment(text: string): ChatGptSandboxPolicy["type"] | undefined {
+  const unrestricted = /<permission_profile\s+type=["']disabled["'][^>]*>[\s\S]*?<file_system\s+type=["']unrestricted["'][^>]*\/?\s*>/i.test(text)
+    || /<sandbox_mode>danger-full-access<\/sandbox_mode>/i.test(text);
+  const workspaceWrite = /<sandbox_mode>workspace-write<\/sandbox_mode>/i.test(text);
+  const readOnly = /<sandbox_mode>read-only<\/sandbox_mode>/i.test(text);
+  if (Number(unrestricted) + Number(workspaceWrite) + Number(readOnly) !== 1) return undefined;
+  return unrestricted ? "dangerFullAccess" : workspaceWrite ? "workspaceWrite" : "readOnly";
+}
+
+function sandboxTypeFromMetadata(value: unknown): ChatGptSandboxPolicy["type"] | undefined {
+  if (typeof value !== "string") return undefined;
+  switch (value.trim().toLowerCase().replaceAll("_", "-")) {
+    case "none":
+    case "unrestricted":
+    case "danger-full-access":
+      return "dangerFullAccess";
+    case "workspace-write":
+      return "workspaceWrite";
+    case "read-only":
+      return "readOnly";
+    default:
+      return undefined;
+  }
+}
+
+function workspaceMetadataEnvironmentBeforeUser(
+  input: unknown[],
+  userIndex: number,
+  metadata: Record<string, unknown> | undefined,
+): string | undefined {
+  if (userIndex <= 0 || !metadata) return undefined;
+  const workspaces = record(metadata.workspaces);
+  const metadataSandbox = sandboxTypeFromMetadata(metadata.sandbox);
+  if (!workspaces || !metadataSandbox) return undefined;
+  const metadataRoots = Object.keys(workspaces);
+  if (metadataRoots.length === 0 || metadataRoots.some(path => !isAbsolute(path))) return undefined;
+  const normalizedMetadataRoots = [...new Set(metadataRoots.map(path => resolve(path)))];
+
+  const user = record(input[userIndex]);
+  const candidate = record(input[userIndex - 1]);
+  if (user?.type !== "message" || user.role !== "user" || typeof user.id !== "string") return undefined;
+  if (candidate?.type !== "message" || candidate.role !== "user" || typeof candidate.id !== "string") return undefined;
+
+  const content = Array.isArray(candidate.content) ? candidate.content : [];
+  for (const part of content) {
+    const text = record(part)?.text;
+    if (typeof text !== "string") continue;
+    const trimmed = text.trim();
+    if (!/^<environment_context>[\s\S]*<\/environment_context>$/.test(trimmed)) continue;
+
+    const cwdMatches = [...trimmed.matchAll(/<cwd>([^<]+)<\/cwd>/g)].map(match => decodeXmlText(match[1]!.trim()));
+    if (cwdMatches.length !== 1 || !isAbsolute(cwdMatches[0]!)) continue;
+    const rootMatches = [...trimmed.matchAll(/<workspace_roots>[\s\S]*?<\/workspace_roots>/g)]
+      .flatMap(section => [...section[0].matchAll(/<root>([^<]+)<\/root>/g)].map(match => decodeXmlText(match[1]!.trim())));
+    const declaredRoots = [...new Set((rootMatches.length > 0 ? rootMatches : cwdMatches).map(path => resolve(path)))];
+    if (declaredRoots.some(path => !normalizedMetadataRoots.includes(path))) continue;
+    if (!normalizedMetadataRoots.some(root => matchesPath(root, resolve(cwdMatches[0]!)))) continue;
+    if (sandboxTypeFromEnvironment(trimmed) !== metadataSandbox) continue;
+    return trimmed;
+  }
+  return undefined;
+}
+
 function hasAssistantOutputBetween(input: unknown[], startIndex: number, endIndex: number): boolean {
   for (let index = startIndex; index < endIndex; index += 1) {
     const item = record(input[index]);
@@ -94,6 +157,9 @@ function rawEnvironmentText(parsed: CodexParsedRequest): string | undefined {
     const current = environmentBeforeUser(input, activeUserIndex, turnId);
     if (current) return current;
   }
+
+  const current = workspaceMetadataEnvironmentBeforeUser(input, activeUserIndex, clientTurnMetadata(parsed));
+  if (current) return current;
 
   const replayPrefixLen = Math.min(parsed._replayPrefixLen ?? 0, input.length);
   for (let index = replayPrefixLen - 1; index > 0; index -= 1) {
@@ -162,20 +228,17 @@ export function extractChatGptTurnEnvironment(parsed: CodexParsedRequest): ChatG
     throw new Error("ChatGPT web cwd is outside the trusted Codex workspace roots");
   }
 
-  const unrestricted = /<permission_profile\s+type=["']disabled["'][^>]*>[\s\S]*?<file_system\s+type=["']unrestricted["'][^>]*\/?\s*>/i.test(text)
-    || /<sandbox_mode>danger-full-access<\/sandbox_mode>/i.test(text);
-  const workspaceWrite = /<sandbox_mode>workspace-write<\/sandbox_mode>/i.test(text);
-  const readOnly = /<sandbox_mode>read-only<\/sandbox_mode>/i.test(text);
+  const sandboxType = sandboxTypeFromEnvironment(text);
   const networkAccess = /<network_access>enabled<\/network_access>/i.test(text)
     || /network access is enabled/i.test(text);
 
-  if (Number(unrestricted) + Number(workspaceWrite) + Number(readOnly) !== 1) {
+  if (!sandboxType) {
     throw new Error("ChatGPT web turn requires one explicit trusted Codex sandbox mode");
   }
-  if (unrestricted) {
+  if (sandboxType === "dangerFullAccess") {
     return { cwd, roots, writableRoots: roots, sandboxPolicy: { type: "dangerFullAccess" }, tools: parsed.context.tools ?? [] };
   }
-  if (workspaceWrite) {
+  if (sandboxType === "workspaceWrite") {
     return {
       cwd,
       roots,

--- a/src/adapters/chatgpt-web/index.ts
+++ b/src/adapters/chatgpt-web/index.ts
@@ -6,8 +6,8 @@ import type { ProviderAdapter } from "../base";
 import { parseDataUrl } from "../image";
 import { ChatGptBrowserWorker } from "./browser-worker";
 import { extractChatGptTurnEnvironment, extractChatGptTurnIdentity } from "./environment";
-import { resolveChatGptWebModelMode } from "./model";
-import { chatGptProContextWarning, compileChatGptWebPrompt } from "./prompt";
+import { resolveChatGptWebModelMode, type ChatGptWebCapabilities } from "./model";
+import { chatGptReadOnlyContextWarning, compileChatGptWebPrompt } from "./prompt";
 import { TurnBroker, type BrokerToolRequest, type BrokerToolResult } from "./turn-broker";
 import { ChatGptReasoningFeed, ChatGptTextFeed, chatGptTurnExecutionKey, chatGptTurnSessions, type ChatGptBrowserOutcome, type ChatGptTurnRuntime, type ChatGptTurnSession } from "./turn-execution";
 import { estimateChatGptWebUsage } from "./usage";
@@ -112,8 +112,12 @@ function emitTextDeltas(deltas: string[], emit: (event: AdapterEvent) => void): 
   for (const text of deltas) emit({ type: "text_delta", text, phase: "final_answer" });
 }
 
-function emitProContextWarning(parsed: CodexParsedRequest, emit: (event: AdapterEvent) => void): void {
-  const warning = chatGptProContextWarning(parsed);
+function emitProContextWarning(
+  parsed: CodexParsedRequest,
+  capabilities: ChatGptWebCapabilities,
+  emit: (event: AdapterEvent) => void,
+): void {
+  const warning = chatGptReadOnlyContextWarning(parsed, capabilities);
   if (!warning) return;
   emit({ type: "assistant_boundary" });
   emit({ type: "text_delta", text: warning, phase: "commentary" });
@@ -147,6 +151,10 @@ export function createChatGptWebAdapter(provider: CodexProviderConfig): Provider
   const worker = ChatGptBrowserWorker.forProvider(provider);
   const broker = TurnBroker.forSocket(brokerSocketPath(provider));
   const timeoutMs = provider.chatgptWeb?.turnTimeoutMs ?? 20 * 60_000;
+  const capabilities: ChatGptWebCapabilities = {
+    localToolsEnabled: provider.chatgptWeb?.localToolsEnabled === true,
+    proAvailable: provider.chatgptWeb?.proAvailable === true,
+  };
   const executionNamespace = createHash("sha256").update(JSON.stringify({
     baseUrl: provider.baseUrl,
     chatgptWeb: provider.chatgptWeb ?? {},
@@ -157,7 +165,7 @@ export function createChatGptWebAdapter(provider: CodexProviderConfig): Provider
     environment: ReturnType<typeof extractChatGptTurnEnvironment> | undefined,
     traceId: string,
   ): ChatGptTurnRuntime => {
-    const mode = resolveChatGptWebModelMode(parsed.modelId, parsed.options.reasoning);
+    const mode = resolveChatGptWebModelMode(parsed.modelId, parsed.options.reasoning, capabilities);
     const browserAbort = new AbortController();
     const reasoning = new ChatGptReasoningFeed();
     const text = new ChatGptTextFeed();
@@ -166,8 +174,9 @@ export function createChatGptWebAdapter(provider: CodexProviderConfig): Provider
         traceId,
         modelId: parsed.modelId,
         reasoning: parsed.options.reasoning,
+        capabilities,
         contextWindowTokens: provider.modelContextWindows?.[parsed.modelId] ?? provider.contextWindow,
-        prepare: async () => ({ ...compileChatGptWebPrompt(parsed), release: () => {} }),
+        prepare: async () => ({ ...compileChatGptWebPrompt(parsed, capabilities), release: () => {} }),
         abortSignal: browserAbort.signal,
         onReasoningSummary: summary => reasoning.push(summary),
         onTextDelta: delta => text.push(delta),
@@ -188,6 +197,7 @@ export function createChatGptWebAdapter(provider: CodexProviderConfig): Provider
       traceId,
       modelId: parsed.modelId,
       reasoning: parsed.options.reasoning,
+      capabilities,
       contextWindowTokens: provider.modelContextWindows?.[parsed.modelId] ?? provider.contextWindow,
       prepare: async () => {
         const turnToken = await broker.register(environment, timeoutMs + 60_000);
@@ -195,7 +205,7 @@ export function createChatGptWebAdapter(provider: CodexProviderConfig): Provider
         tokenSettled = true;
         token.resolve(turnToken);
         try {
-          const compiled = compileChatGptWebPrompt(parsed, turnToken);
+          const compiled = compileChatGptWebPrompt(parsed, capabilities, turnToken);
           return { ...compiled, release: () => {} };
         } catch (error) {
           broker.revoke(turnToken);
@@ -228,7 +238,7 @@ export function createChatGptWebAdapter(provider: CodexProviderConfig): Provider
   return {
     name: "chatgpt-web",
     async runTurn(parsed, incoming, emit) {
-      const mode = resolveChatGptWebModelMode(parsed.modelId, parsed.options.reasoning);
+      const mode = resolveChatGptWebModelMode(parsed.modelId, parsed.options.reasoning, capabilities);
       let environment: ReturnType<typeof extractChatGptTurnEnvironment> | undefined;
       if (mode.localTools) {
         try {
@@ -261,7 +271,7 @@ export function createChatGptWebAdapter(provider: CodexProviderConfig): Provider
                 events.push(event);
                 emit(event);
               };
-              emitProContextWarning(parsed, emitCaptured);
+              emitProContextWarning(parsed, capabilities, emitCaptured);
               reasoning = session.runtime.reasoning.drain();
               emitReasoningSummaries(reasoning, emitCaptured);
               emitTextDeltas(session.runtime.text.drain(), emitCaptured);
@@ -271,7 +281,7 @@ export function createChatGptWebAdapter(provider: CodexProviderConfig): Provider
               session.setFinalReasoning(reasoning);
               session.setFinalEvents(events);
             }
-            emitBrowserCompletion(settled, estimateChatGptWebUsage(parsed, { answer: settled.answer, reasoning }), emit);
+            emitBrowserCompletion(settled, estimateChatGptWebUsage(parsed, { answer: settled.answer, reasoning }, capabilities), emit);
             return;
           }
 
@@ -287,7 +297,7 @@ export function createChatGptWebAdapter(provider: CodexProviderConfig): Provider
               if (results.length === 0) {
                 const reasoning = session.reasoningForOutstandingReplay();
                 replayEvents(session.eventsForOutstandingReplay(), emit);
-                emitToolBatch(outstanding, estimateChatGptWebUsage(parsed, { reasoning, toolRequests: outstanding }), emit);
+                emitToolBatch(outstanding, estimateChatGptWebUsage(parsed, { reasoning, toolRequests: outstanding }, capabilities), emit);
                 return;
               }
               if (results.length !== outstanding.length) {
@@ -299,7 +309,7 @@ export function createChatGptWebAdapter(provider: CodexProviderConfig): Provider
               }
             }
           } else if (session.outstanding().length > 0) {
-            throw new Error("Read-only ChatGPT Pro runtime cannot own local tool calls");
+            throw new Error("Read-only ChatGPT Web runtime cannot own local tool calls");
           }
 
           const toolWaitAbort = new AbortController();
@@ -315,7 +325,7 @@ export function createChatGptWebAdapter(provider: CodexProviderConfig): Provider
               emitReasoningSummaries(summaries, emitRound);
             };
             const emitNewText = (deltas: string[]) => emitTextDeltas(deltas, emitRound);
-            emitProContextWarning(parsed, emitRound);
+            emitProContextWarning(parsed, capabilities, emitRound);
             emitNewReasoning(session.runtime.reasoning.drain());
             emitNewText(session.runtime.text.drain());
             const nextTools = turnToken
@@ -356,20 +366,20 @@ export function createChatGptWebAdapter(provider: CodexProviderConfig): Provider
                 }
                 emitBrowserCompletion(
                   next.outcome,
-                  estimateChatGptWebUsage(parsed, { answer: next.outcome.answer, reasoning: roundReasoning }),
+                  estimateChatGptWebUsage(parsed, { answer: next.outcome.answer, reasoning: roundReasoning }, capabilities),
                   emit,
                 );
                 return;
               }
               if (!turnToken || session.runtime.mode !== "tools") {
-                throw new Error("Read-only ChatGPT Pro runtime received a broker tool batch");
+                throw new Error("Read-only ChatGPT Web runtime received a broker tool batch");
               }
               if (next.requests.length === 0) throw new Error("ChatGPT tool bridge returned an empty batch");
               validateBatchTools(parsed, next.requests);
               session.setOutstanding(next.requests, roundReasoning, roundEvents);
               emitToolBatch(
                 next.requests,
-                estimateChatGptWebUsage(parsed, { reasoning: roundReasoning, toolRequests: next.requests }),
+                estimateChatGptWebUsage(parsed, { reasoning: roundReasoning, toolRequests: next.requests }, capabilities),
                 emit,
               );
               return;

--- a/src/adapters/chatgpt-web/mcp-server.ts
+++ b/src/adapters/chatgpt-web/mcp-server.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import * as z from "zod/v4";
@@ -16,6 +17,36 @@ interface ResolvedTurn {
 
 const bindingSchema = z.string().min(20).max(256).describe("Opaque binding_id returned by codex_bind_turn.");
 const jsonArgumentsSchema = z.record(z.string(), z.unknown()).default({});
+
+function scopeHash(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 12);
+}
+
+function requestScopeSummary(extra: {
+  sessionId?: string;
+  requestId: string | number;
+  _meta?: unknown;
+  requestInfo?: unknown;
+}): string {
+  const meta = extra._meta && typeof extra._meta === "object" && !Array.isArray(extra._meta)
+    ? Object.entries(extra._meta as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, value]) => ({
+        key,
+        type: value === null ? "null" : Array.isArray(value) ? "array" : typeof value,
+        ...(typeof value === "string" ? { chars: value.length, hash: scopeHash(value) } : {}),
+      }))
+    : [];
+  const requestInfoKeys = extra.requestInfo && typeof extra.requestInfo === "object"
+    ? Object.keys(extra.requestInfo as Record<string, unknown>).sort()
+    : [];
+  return JSON.stringify({
+    requestId: String(extra.requestId),
+    session: extra.sessionId ? { chars: extra.sessionId.length, hash: scopeHash(extra.sessionId) } : null,
+    meta,
+    requestInfoKeys,
+  });
+}
 
 function result(value: Record<string, unknown>, isError = false) {
   return {
@@ -134,7 +165,8 @@ export async function runChatGptMcpServer(options: { brokerSocketPath: string })
       inputSchema: { turn_token: z.string().min(20).max(256) },
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
-    async ({ turn_token }) => {
+    async ({ turn_token }, extra) => {
+      console.error(`[chatgpt-web-mcp] codex_bind_turn scope=${requestScopeSummary(extra)}`);
       const claimed = await callTurnBroker<ClaimedTurn>(options.brokerSocketPath, { method: "claim", token: turn_token });
       const commandTool = exactTool(claimed.environment, "exec_command") ?? exactTool(claimed.environment, "shell_command");
       const gateway = execGateway(claimed.environment);
@@ -170,7 +202,8 @@ export async function runChatGptMcpServer(options: { brokerSocketPath: string })
       },
       annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false },
     },
-    async ({ binding_id, cmd, workdir, yield_time_ms, max_output_tokens, tty }) => {
+    async ({ binding_id, cmd, workdir, yield_time_ms, max_output_tokens, tty }, extra) => {
+      console.error(`[chatgpt-web-mcp] codex_exec scope=${requestScopeSummary(extra)}`);
       const bound = await environment(binding_id);
       const tool = exactTool(bound, "exec_command") ?? exactTool(bound, "shell_command");
       if (!tool) throw new Error("This Codex turn did not advertise a native command tool");

--- a/src/adapters/chatgpt-web/model.ts
+++ b/src/adapters/chatgpt-web/model.ts
@@ -1,34 +1,39 @@
-export const CHATGPT_WEB_STANDARD_MODEL_ID = "gpt-5.6-sol";
-export const CHATGPT_WEB_PRO_MODEL_ID = "gpt-5.6-sol-pro";
+export const CHATGPT_WEB_MODEL_ID = "gpt-5.6-sol";
+
+export interface ChatGptWebCapabilities {
+  localToolsEnabled: boolean;
+  proAvailable: boolean;
+}
 
 export interface ChatGptWebModelMode {
   modelId: string;
-  uiModelLabel: "GPT-5.6 Sol";
-  uiEffortLabel: "Medium" | "High" | "Extra High" | "Pro";
+  effort: "light" | "medium" | "high" | "xhigh" | "pro";
+  uiEffortLabel: "Instant 5.5" | "Medium" | "High" | "Extra High" | "Pro";
   localTools: boolean;
 }
 
-/** Resolve the Codex-facing model id to one exact ChatGPT UI mode. Unknown combinations fail closed. */
-export function resolveChatGptWebModelMode(modelId: string, reasoning?: string): ChatGptWebModelMode {
-  if (modelId === CHATGPT_WEB_PRO_MODEL_ID) {
-    return {
-      modelId,
-      uiModelLabel: "GPT-5.6 Sol",
-      uiEffortLabel: "Pro",
-      localTools: false,
-    };
-  }
-  if (modelId !== CHATGPT_WEB_STANDARD_MODEL_ID) {
+export function resolveChatGptWebModelMode(
+  modelId: string,
+  reasoning: string | undefined,
+  capabilities: ChatGptWebCapabilities,
+): ChatGptWebModelMode {
+  if (modelId !== CHATGPT_WEB_MODEL_ID) {
     throw new Error(`ChatGPT web model is not supported: ${modelId}`);
   }
-  switch (reasoning ?? "high") {
+  const effort = reasoning ?? "high";
+  switch (effort) {
+    case "light":
+      return { modelId, effort, uiEffortLabel: "Instant 5.5", localTools: capabilities.localToolsEnabled };
     case "medium":
-      return { modelId, uiModelLabel: "GPT-5.6 Sol", uiEffortLabel: "Medium", localTools: true };
+      return { modelId, effort, uiEffortLabel: "Medium", localTools: capabilities.localToolsEnabled };
     case "high":
-      return { modelId, uiModelLabel: "GPT-5.6 Sol", uiEffortLabel: "High", localTools: true };
+      return { modelId, effort, uiEffortLabel: "High", localTools: capabilities.localToolsEnabled };
     case "xhigh":
-      return { modelId, uiModelLabel: "GPT-5.6 Sol", uiEffortLabel: "Extra High", localTools: true };
+      return { modelId, effort, uiEffortLabel: "Extra High", localTools: capabilities.localToolsEnabled };
+    case "pro":
+      if (!capabilities.proAvailable) throw new Error("ChatGPT Pro effort is not available for this account");
+      return { modelId, effort, uiEffortLabel: "Pro", localTools: false };
     default:
-      throw new Error(`ChatGPT web reasoning effort is not supported for ${modelId}: ${reasoning ?? "undefined"}`);
+      throw new Error(`ChatGPT web effort is not supported: ${effort}`);
   }
 }

--- a/src/adapters/chatgpt-web/prompt.ts
+++ b/src/adapters/chatgpt-web/prompt.ts
@@ -1,6 +1,6 @@
 import type { CodexAssistantContentPart, CodexContentPart, CodexMessage, CodexParsedRequest } from "../../types";
 import { isReadableCompactionSummaryText } from "../../responses/compaction";
-import { resolveChatGptWebModelMode } from "./model";
+import { resolveChatGptWebModelMode, type ChatGptWebCapabilities } from "./model";
 
 export interface ChatGptWebPromptImage {
   ref: string;
@@ -48,26 +48,34 @@ function messageEnvelope(message: CodexMessage, images: ChatGptWebPromptImage[])
   return { role: message.role, content: inputContent(message.content, images) };
 }
 
-export function chatGptProContextWarning(parsed: CodexParsedRequest): string | undefined {
-  const mode = resolveChatGptWebModelMode(parsed.modelId, parsed.options.reasoning);
+export function chatGptReadOnlyContextWarning(
+  parsed: CodexParsedRequest,
+  capabilities: ChatGptWebCapabilities,
+): string | undefined {
+  const mode = resolveChatGptWebModelMode(parsed.modelId, parsed.options.reasoning, capabilities);
   if (mode.localTools) return undefined;
+  const label = mode.effort === "pro" ? "ChatGPT Pro" : `ChatGPT Web ${mode.uiEffortLabel}`;
   const hasLocalEvidence = parsed.context.messages.some(message =>
     message.role === "toolResult"
     || (message.role === "user" && isReadableCompactionSummaryText(message.content))
   );
   if (hasLocalEvidence) {
-    return "⚠️ ChatGPT Pro runs without local tools/MCP. It receives the complete accumulated task context, including earlier tool results or their compaction summary and attachments, but it cannot read or modify the computer further.";
+    return `⚠️ ${label} runs without local tools/MCP. It receives the complete accumulated task context, including earlier tool results or their compaction summary and attachments, but it cannot read or modify the computer further.`;
   }
-  return "⚠️ ChatGPT Pro runs without local tools/MCP. The accumulated context does not contain local tool results yet: Pro will see instructions and attachments, but not workspace contents. Prepare the context with GPT-5.6 Sol Extra High first, then switch to Pro.";
+  return `⚠️ ${label} runs without local tools/MCP. The accumulated context does not contain local tool results yet: it will see instructions and attachments, but not workspace contents. Prepare the context with a tool-capable ChatGPT Web effort first, then switch back.`;
 }
 
-export function compileChatGptWebPrompt(parsed: CodexParsedRequest, turnToken?: string): CompiledChatGptWebPrompt {
-  const mode = resolveChatGptWebModelMode(parsed.modelId, parsed.options.reasoning);
+export function compileChatGptWebPrompt(
+  parsed: CodexParsedRequest,
+  capabilities: ChatGptWebCapabilities,
+  turnToken?: string,
+): CompiledChatGptWebPrompt {
+  const mode = resolveChatGptWebModelMode(parsed.modelId, parsed.options.reasoning, capabilities);
   if (mode.localTools && !turnToken) {
     throw new Error("Tool-capable ChatGPT web mode requires a broker turn token");
   }
   if (!mode.localTools && turnToken !== undefined) {
-    throw new Error("ChatGPT Pro must not receive a local-tool capability token");
+    throw new Error("A read-only ChatGPT Web effort must not receive a local-tool capability token");
   }
   const images: ChatGptWebPromptImage[] = [];
   const envelope = {
@@ -84,7 +92,7 @@ export function compileChatGptWebPrompt(parsed: CodexParsedRequest, turnToken?: 
   const transportContract = mode.localTools
     ? [
       "For local files, commands, processes, images, user interaction, and configured MCP/apps, use the attached Codex Native plugin inside this same response.",
-      `Before the first local operation call codex_bind_turn with turn_token ${turnToken}.`,
+      `Before commentary, an answer, or any other tool call, call codex_bind_turn with turn_token ${turnToken}. This bind is mandatory on every response, even when the request appears not to need a local operation.`,
       "Use its returned binding_id on every later Codex Native call. Do not reveal either capability value in the answer.",
       "Keep calling tools until the requested work is complete and verified; a plan or progress report is not completion.",
       "Use codex_apply_patch for targeted edits, codex_exec for commands, and codex_write_stdin for sessions returned by codex_exec.",
@@ -93,11 +101,23 @@ export function compileChatGptWebPrompt(parsed: CodexParsedRequest, turnToken?: 
       "Never serialize a proposed tool call as assistant text. Make the actual MCP call and use its returned evidence.",
     ]
     : [
-      "This is ChatGPT Pro read-only Codex mode. No local computer tool, MCP app, or Codex Native plugin is attached to this response.",
+      `This is ChatGPT Web ${mode.uiEffortLabel} in read-only Codex mode. No local computer tool, MCP app, or Codex Native plugin is attached to this response.`,
       "Use only evidence already present in the complete envelope and the attached images. Prior tool results are authoritative snapshots of earlier local work.",
       "Do not claim to inspect, execute, edit, or verify anything that is not evidenced in that supplied context.",
       "If the latest request requires missing local evidence or a computer mutation, state the exact missing evidence or action instead of inventing success.",
       "Within those boundaries, perform the full analysis or synthesis requested; do not stop at a plan or progress report.",
+    ];
+  const transportResume = mode.localTools
+    ? [
+      "<codex_transport_resume>",
+      `The context envelope is complete. Your first action now must be the actual Codex Native codex_bind_turn call with turn_token ${turnToken}; emit no commentary or answer before its real result.`,
+      "After binding, execute the latest active user request under the preserved envelope instructions and keep using the returned binding_id for Codex Native calls.",
+      "</codex_transport_resume>",
+    ]
+    : [
+      "<codex_transport_resume>",
+      "The context envelope is complete. Execute the latest active user request now under the read-only transport contract above.",
+      "</codex_transport_resume>",
     ];
   const text = [
     ...sharedContract,
@@ -106,6 +126,7 @@ export function compileChatGptWebPrompt(parsed: CodexParsedRequest, turnToken?: 
     "<codex_context_json>",
     JSON.stringify(envelope),
     "</codex_context_json>",
+    ...transportResume,
   ].join("\n");
   return { text, images };
 }

--- a/src/adapters/chatgpt-web/turn-broker.ts
+++ b/src/adapters/chatgpt-web/turn-broker.ts
@@ -1,6 +1,7 @@
 import { randomBytes } from "node:crypto";
-import { chmodSync, existsSync, lstatSync, unlinkSync } from "node:fs";
+import { chmodSync, existsSync, lstatSync, mkdirSync, unlinkSync } from "node:fs";
 import { createConnection, createServer, type Server, type Socket } from "node:net";
+import { dirname } from "node:path";
 import type { ChatGptTurnEnvironment } from "./environment";
 
 interface PendingTurn extends ChatGptTurnEnvironment {
@@ -170,13 +171,19 @@ export class TurnBroker {
     this.server = undefined;
     this.startPromise = undefined;
     brokers.delete(this.socketPath);
-    if (server) await new Promise<void>((resolveClose, rejectClose) => server.close(error => error ? rejectClose(error) : resolveClose()));
+    if (server?.listening) {
+      await new Promise<void>((resolveClose, rejectClose) => server.close(error => {
+        if (!error || (error as NodeJS.ErrnoException).code === "ERR_SERVER_NOT_RUNNING") resolveClose();
+        else rejectClose(error);
+      }));
+    }
     if (existsSync(this.socketPath) && lstatSync(this.socketPath).isSocket()) unlinkSync(this.socketPath);
   }
 
   private start(): Promise<void> {
     if (this.startPromise) return this.startPromise;
     this.startPromise = new Promise<void>((resolveStart, rejectStart) => {
+      mkdirSync(dirname(this.socketPath), { recursive: true, mode: 0o700 });
       const listen = () => {
         const server = createServer(socket => this.handleSocket(socket));
         this.server = server;
@@ -266,6 +273,7 @@ export class TurnBroker {
       const token = request.token?.trim();
       if (!token) throw new Error("turn token is required");
       const channel = this.channels.get(token);
+      console.error(`[chatgpt-web] broker claim received (tokenChars=${token.length}, valid=${Boolean(channel)})`);
       if (!channel) throw new Error("turn token is invalid, expired, or revoked");
       if (channel.bindingId) {
         const existing = this.bindings.get(channel.bindingId);

--- a/src/adapters/chatgpt-web/usage.ts
+++ b/src/adapters/chatgpt-web/usage.ts
@@ -2,7 +2,7 @@ import { estimateTokens } from "../../lib/token-estimate";
 import type { CodexParsedRequest, CodexUsage } from "../../types";
 import type { CompiledChatGptWebPrompt } from "./prompt";
 import { compileChatGptWebPrompt } from "./prompt";
-import { resolveChatGptWebModelMode } from "./model";
+import { resolveChatGptWebModelMode, type ChatGptWebCapabilities } from "./model";
 import type { BrokerToolRequest } from "./turn-broker";
 
 // The real capability has the same length. Keeping it out of usage accounting would make
@@ -45,10 +45,13 @@ export function estimateCompiledChatGptWebInputTokens(
     + imageTokens;
 }
 
-export function estimateChatGptWebInputTokens(parsed: CodexParsedRequest): number {
-  const mode = resolveChatGptWebModelMode(parsed.modelId, parsed.options.reasoning);
+export function estimateChatGptWebInputTokens(
+  parsed: CodexParsedRequest,
+  capabilities: ChatGptWebCapabilities,
+): number {
+  const mode = resolveChatGptWebModelMode(parsed.modelId, parsed.options.reasoning, capabilities);
   return estimateCompiledChatGptWebInputTokens(
-    compileChatGptWebPrompt(parsed, mode.localTools ? ESTIMATE_TURN_TOKEN : undefined),
+    compileChatGptWebPrompt(parsed, capabilities, mode.localTools ? ESTIMATE_TURN_TOKEN : undefined),
     parsed.modelId,
   );
 }
@@ -72,8 +75,9 @@ function roundEvidenceText(evidence: ChatGptWebRoundEvidence): string {
 export function estimateChatGptWebUsage(
   parsed: CodexParsedRequest,
   evidence: ChatGptWebRoundEvidence,
+  capabilities: ChatGptWebCapabilities,
 ): CodexUsage {
-  const inputTokens = estimateChatGptWebInputTokens(parsed);
+  const inputTokens = estimateChatGptWebInputTokens(parsed, capabilities);
   const outputTokens = conservativeTextTokens(roundEvidenceText(evidence), parsed.modelId);
   return {
     inputTokens,

--- a/src/browser-login.ts
+++ b/src/browser-login.ts
@@ -4,7 +4,12 @@ import { dirname, join } from "node:path";
 import { chromium, type BrowserContextOptions } from "playwright-core";
 import type { AppConfig } from "./config";
 import { atomicWriteFile } from "./config";
-import { assertAuthenticatedChatGptPage, assertTemporaryChatPage, detectChatGptProCapability } from "./chatgpt-session";
+import {
+  assertAuthenticatedChatGptPage,
+  assertTemporaryChatPage,
+  CHATGPT_TEMPORARY_CHAT_URL,
+  detectChatGptProCapability,
+} from "./chatgpt-session";
 
 export interface BrowserLoginResult {
   storageStatePath: string;
@@ -47,7 +52,7 @@ async function inspectStoredState(
     const verifierContext = await verifierBrowser.newContext({ storageState });
     try {
       const verifierPage = await verifierContext.newPage();
-      await verifierPage.goto("https://chatgpt.com/?temporary-chat=true", { waitUntil: "domcontentloaded", timeout: 30_000 });
+      await verifierPage.goto(CHATGPT_TEMPORARY_CHAT_URL, { waitUntil: "domcontentloaded", timeout: 30_000 });
       await verifierPage.getByRole("textbox", { name: "Chat with ChatGPT" }).waitFor({ state: "visible", timeout: 30_000 });
       await assertAuthenticatedChatGptPage(verifierPage);
       await assertTemporaryChatPage(verifierPage);
@@ -95,7 +100,7 @@ export async function loginToChatGpt(
     "--disable-background-mode",
     "--no-first-run",
     "--no-default-browser-check",
-    "https://chatgpt.com/?temporary-chat=true",
+    CHATGPT_TEMPORARY_CHAT_URL,
   ], { env: process.env, stdio: "ignore" });
   const loginExit = await new Promise<number>((resolveExit, rejectExit) => {
     loginBrowser.once("error", rejectExit);
@@ -114,7 +119,7 @@ export async function loginToChatGpt(
   });
   try {
     const page = context.pages()[0] ?? await context.newPage();
-    await page.goto("https://chatgpt.com/?temporary-chat=true", {
+    await page.goto(CHATGPT_TEMPORARY_CHAT_URL, {
       waitUntil: "domcontentloaded",
       timeout: 30_000,
     });

--- a/src/chatgpt-session.ts
+++ b/src/chatgpt-session.ts
@@ -1,5 +1,7 @@
 import type { Locator, Page } from "playwright-core";
 
+export const CHATGPT_TEMPORARY_CHAT_URL = "https://chatgpt.com/?temporary-chat=true";
+
 async function anyVisible(locator: Locator): Promise<boolean> {
   const count = await locator.count();
   for (let index = 0; index < count; index += 1) {
@@ -23,8 +25,9 @@ export async function assertAuthenticatedChatGptPage(page: Page): Promise<void> 
 
 export async function assertTemporaryChatPage(page: Page): Promise<void> {
   const url = new URL(page.url());
-  if (url.searchParams.get("temporary-chat") !== "true") {
-    throw new Error(`ChatGPT did not retain temporary-chat=true (${page.url()})`);
+  const expected = new URL(CHATGPT_TEMPORARY_CHAT_URL);
+  if (url.origin !== expected.origin || url.pathname !== expected.pathname || url.searchParams.get("temporary-chat") !== "true") {
+    throw new Error(`ChatGPT left the isolated Temporary Chat surface (${page.url()})`);
   }
   await page.getByRole("heading", { name: "Temporary Chat", exact: true }).waitFor({ state: "visible", timeout: 10_000 });
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,7 +20,7 @@ const HELP = `codex-chatgpt-web ${VERSION}
 Focused ChatGPT web-backed models for the native Codex harness.
 
 Usage:
-  codex-chatgpt-web setup --pro-only [options]
+  codex-chatgpt-web setup --browser-only [options]
   codex-chatgpt-web setup --full --tunnel-id ID --runtime-key-file PATH [options]
   codex-chatgpt-web login
   codex-chatgpt-web doctor [--json]
@@ -33,7 +33,7 @@ Usage:
   codex-chatgpt-web uninstall --yes
 
 Setup options:
-  --pro-only                   Pro model, full context/images, no local tools or tunnel
+  --browser-only               One ChatGPT Web model, full context/images, no local tools or tunnel
   --full                       Standard tool-capable model plus Pro
   --port NUMBER                Loopback Responses port (default: 17841)
   --chrome PATH                Google Chrome executable
@@ -104,13 +104,13 @@ function assertNoArgs(args: string[]): void {
 }
 
 async function setupCommand(args: string[]): Promise<void> {
-  const proOnly = takeFlag(args, "--pro-only");
+  const browserOnly = takeFlag(args, "--browser-only");
   const full = takeFlag(args, "--full");
-  if (proOnly === full) throw new Error("Choose exactly one setup mode: --pro-only or --full");
+  if (browserOnly === full) throw new Error("Choose exactly one setup mode: --browser-only or --full");
   const portRaw = takeOption(args, "--port");
   let acknowledged = takeFlag(args, "--acknowledge-unofficial");
   const options: SetupOptions = {
-    mode: full ? "full" : "pro-only",
+    mode: full ? "full" : "browser-only",
     ...(portRaw ? { port: Number(portRaw) } : {}),
   };
   const appName = takeOption(args, "--app-name");

--- a/src/codex-integration.ts
+++ b/src/codex-integration.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -90,54 +91,112 @@ function reasoningLevel(template: JsonObject, effort: string, fallbackDescriptio
   return source ? cloneObject(source) : { effort, description: fallbackDescription };
 }
 
+function validateSourceCatalog(source: unknown, label: string): JsonObject {
+  const catalog = asObject(source, label);
+  if (!Array.isArray(catalog.models)) throw new Error(`${label} is missing a models array`);
+  if (!catalog.models.some(model => modelSlug(model) === "gpt-5.6-sol")) {
+    throw new Error(`${label} is missing the native gpt-5.6-sol entry`);
+  }
+  return catalog;
+}
+
+function bundledCatalogSnapshotPath(): string {
+  return join(getConfigDir(), "codex", "source-model-catalog.bundled.json");
+}
+
+function codexCommandCandidates(): string[] {
+  const configured = process.env.CODEX_CHATGPT_WEB_CODEX_BINARY?.trim();
+  return [
+    ...(configured ? [configured] : []),
+    "/Applications/ChatGPT.app/Contents/Resources/codex",
+    "codex",
+  ];
+}
+
+function readJsonCatalogFile(path: string): { path: string; source: JsonObject } {
+  if (!existsSync(path)) throw new Error(`Codex source model catalog does not exist: ${path}`);
+  return { path, source: validateSourceCatalog(JSON.parse(readFileSync(path, "utf8")), `Codex source model catalog at ${path}`) };
+}
+
+function readBundledCodexCatalog(): { path: string; source: JsonObject } {
+  const errors: string[] = [];
+  for (const command of codexCommandCandidates()) {
+    const result = spawnSync(command, ["debug", "models", "--bundled"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 15_000,
+    });
+    if (result.status !== 0) {
+      const detail = result.error?.message || result.stderr || result.signal || `exit ${result.status}`;
+      errors.push(`${command}: ${detail.trim()}`);
+      continue;
+    }
+    try {
+      const source = validateSourceCatalog(JSON.parse(result.stdout), `bundled Codex catalog from ${command}`);
+      const path = bundledCatalogSnapshotPath();
+      atomicWriteFile(path, `${JSON.stringify(source, null, 2)}\n`);
+      return { path, source };
+    } catch (error) {
+      errors.push(`${command}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+  throw new Error(
+    "Could not read Codex's bundled model catalog. "
+    + "Install or update the ChatGPT app, or pass --source-catalog PATH explicitly. "
+    + `Attempts: ${errors.join("; ")}`,
+  );
+}
+
+function readPreservedSourceCatalog(
+  existingJournal: CodexIntegrationJournal | undefined,
+): { path: string; source: JsonObject } | undefined {
+  if (!existingJournal) return undefined;
+  const previous = existingJournal.previous.model_catalog_json;
+  if (!previous.present) return undefined;
+  if (!previous.value) {
+    throw new Error("Codex integration journal is missing the preserved pre-install model catalog path");
+  }
+  const path = resolve(previous.value);
+  if (path === resolve(getManagedCatalogPath())) {
+    throw new Error("Codex integration journal points its preserved source at the managed catalog; refusing recursive catalog generation");
+  }
+  return readJsonCatalogFile(path);
+}
+
 export function buildManagedCatalog(source: unknown, config: AppConfig): JsonObject {
-  const catalog = cloneObject(asObject(source, "Codex model catalog"));
-  if (!Array.isArray(catalog.models)) throw new Error("Codex model catalog is missing a models array");
-  const models = catalog.models.filter(model => modelSlug(model) !== STANDARD_MODEL && modelSlug(model) !== PRO_MODEL);
+  const catalog = cloneObject(validateSourceCatalog(source, "Codex model catalog"));
+  const sourceModels = catalog.models as unknown[];
+  const models = sourceModels.filter(model => modelSlug(model) !== STANDARD_MODEL && modelSlug(model) !== PRO_MODEL);
   const template = models.find(model => modelSlug(model) === "gpt-5.6-sol");
   if (!template || typeof template !== "object" || Array.isArray(template)) {
     throw new Error("The native gpt-5.6-sol catalog entry is missing. Update Codex, then rerun setup.");
   }
   const native = template as JsonObject;
   const compactLimit = Math.floor(config.contextWindow * 0.9);
-  const common: JsonObject = {
+  const webModel: JsonObject = {
     ...cloneObject(native),
+    slug: STANDARD_MODEL,
+    display_name: "ChatGPT Web",
+    description: "ChatGPT web through one native Codex model surface. Effort selects Light, Medium, High, Extra High, or account-gated Pro.",
     context_window: config.contextWindow,
     max_context_window: config.contextWindow,
     auto_compact_token_limit: compactLimit,
     input_modalities: ["text", "image"],
     visibility: "list",
     supported_in_api: false,
-    tool_mode: null,
+    tool_mode: config.mode === "full" ? native.tool_mode : null,
     upgrade: null,
+    default_reasoning_level: "high",
+    supported_reasoning_levels: [
+      { effort: "light", description: "Light — ChatGPT Instant 5.5" },
+      reasoningLevel(native, "medium", "Medium"),
+      reasoningLevel(native, "high", "High"),
+      reasoningLevel(native, "xhigh", "Extra High"),
+      ...(config.proAvailable ? [{ effort: "pro", description: "Pro" }] : []),
+    ],
   };
-  const pro: JsonObject = {
-    ...cloneObject(common),
-    slug: PRO_MODEL,
-    display_name: "ChatGPT Pro (web)",
-    description: "ChatGPT Pro through a private browser turn. Full Codex context and images; local tools are unavailable.",
-    supported_reasoning_levels: [],
-  };
-  delete pro.default_reasoning_level;
-  delete pro.availability_nux;
-
-  const injected: JsonObject[] = [];
-  if (config.mode === "full") {
-    injected.push({
-      ...cloneObject(common),
-      slug: STANDARD_MODEL,
-      display_name: "ChatGPT 5.6 (web + Codex tools)",
-      description: "ChatGPT web reasoning with the native Codex tool harness through a turn-bound MCP connector.",
-      default_reasoning_level: "high",
-      supported_reasoning_levels: [
-        reasoningLevel(native, "medium", "Balances speed and reasoning depth"),
-        reasoningLevel(native, "high", "Greater reasoning depth for complex tasks"),
-        reasoningLevel(native, "xhigh", "Extra high reasoning depth for complex tasks"),
-      ],
-    });
-  }
-  if (config.proAvailable) injected.push(pro);
-  catalog.models = [...injected, ...models];
+  delete webModel.availability_nux;
+  catalog.models = [webModel, ...models];
   catalog.etag = null;
   catalog.fetched_at = new Date().toISOString();
   return catalog;
@@ -208,6 +267,14 @@ function findTopLevelAssignment(lines: string[], key: string): AssignmentLocatio
 }
 
 type ManagedAssignmentKey = "model_provider" | "model_catalog_json";
+
+function migrateLegacyDefaultModel(text: string): string {
+  const lines = text.length > 0 ? text.replace(/\n$/, "").split("\n") : [];
+  const current = findTopLevelAssignment(lines, "model");
+  if (current.index === undefined || current.value !== PRO_MODEL) return text;
+  lines[current.index] = `model = ${JSON.stringify(STANDARD_MODEL)}`;
+  return `${lines.join("\n")}${text.endsWith("\n") || lines.length > 0 ? "\n" : ""}`;
+}
 
 function setTopLevelAssignments(
   text: string,
@@ -309,14 +376,6 @@ function readJournal(): CodexIntegrationJournal | undefined {
   return value as CodexIntegrationJournal;
 }
 
-function sourceCatalogFrom(configText: string, explicit?: string): string {
-  if (explicit) return resolve(explicit);
-  const lines = configText.length > 0 ? configText.replace(/\n$/, "").split("\n") : [];
-  const configured = findTopLevelAssignment(lines, "model_catalog_json");
-  if (configured.value && resolve(configured.value) !== getManagedCatalogPath()) return resolve(configured.value);
-  return join(getCodexHome(), "models_cache.json");
-}
-
 export function installCodexIntegration(
   config: AppConfig,
   options: InstallCodexIntegrationOptions = {},
@@ -338,9 +397,11 @@ export function installCodexIntegration(
     }
   }
 
-  const sourceCatalogPath = resolve(options.sourceCatalogPath || existingJournal?.sourceCatalogPath || sourceCatalogFrom(configText));
-  if (!existsSync(sourceCatalogPath)) throw new Error(`Codex source model catalog does not exist: ${sourceCatalogPath}`);
-  const source = JSON.parse(readFileSync(sourceCatalogPath, "utf8")) as unknown;
+  const loadedSource = options.sourceCatalogPath
+    ? readJsonCatalogFile(resolve(options.sourceCatalogPath))
+    : readPreservedSourceCatalog(existingJournal) ?? readBundledCodexCatalog();
+  const sourceCatalogPath = loadedSource.path;
+  const source = loadedSource.source;
   const managed = `${JSON.stringify(buildManagedCatalog(source, config), null, 2)}\n`;
   const catalogPath = getManagedCatalogPath();
   const installed = {
@@ -356,7 +417,7 @@ export function installCodexIntegration(
     );
   }
 
-  const patched = setTopLevelAssignments(configText, installed);
+  const patched = setTopLevelAssignments(migrateLegacyDefaultModel(configText), installed);
   const block = providerBlock(config);
   const installedText = installProviderBlock(patched.text, block, existingJournal?.providerBlock);
   const journal: CodexIntegrationJournal = {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,11 +1,12 @@
 import { randomBytes } from "node:crypto";
 import { chmodSync, mkdirSync, openSync, closeSync, renameSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
 import { homedir } from "node:os";
-import { basename, dirname, join, resolve } from "node:path";
+import { basename, dirname, isAbsolute, join, resolve, sep } from "node:path";
+import { tmpdir } from "node:os";
 import type { CodexProviderConfig } from "./types";
 import { VERSION } from "./version";
 
-export type RuntimeMode = "pro-only" | "full";
+export type RuntimeMode = "browser-only" | "full";
 
 export interface TunnelConfig {
   binaryPath: string;
@@ -17,7 +18,7 @@ export interface TunnelConfig {
 }
 
 export interface AppConfig {
-  version: 1;
+  version: 2;
   releaseVersion: string;
   mode: RuntimeMode;
   host: "127.0.0.1";
@@ -69,10 +70,10 @@ export function atomicWriteFile(path: string, data: string | Uint8Array): void {
   try { chmodSync(path, 0o600); } catch { /* Windows ACLs are managed by the installer. */ }
 }
 
-export function defaultConfig(mode: RuntimeMode = "pro-only"): AppConfig {
+export function defaultConfig(mode: RuntimeMode = "browser-only"): AppConfig {
   const home = getConfigDir();
   return {
-    version: 1,
+    version: 2,
     releaseVersion: VERSION,
     mode,
     host: "127.0.0.1",
@@ -91,6 +92,12 @@ export function defaultConfig(mode: RuntimeMode = "pro-only"): AppConfig {
 }
 
 export function currentRuntimeCommand(): string[] {
+  const launcher = process.env.CODEX_CHATGPT_WEB_LAUNCHER?.trim();
+  if (launcher) {
+    const command = [resolve(launcher)];
+    assertDurableRuntimeCommand(command);
+    return command;
+  }
   const executable = resolve(process.execPath);
   const executableName = basename(executable).toLowerCase();
   if (executableName === "bun" || executableName === "bun.exe") {
@@ -101,6 +108,26 @@ export function currentRuntimeCommand(): string[] {
     return [executable, resolve(entry)];
   }
   return [executable];
+}
+
+function inside(path: string, root: string): boolean {
+  const normalizedPath = resolve(path);
+  const normalizedRoot = resolve(root);
+  return normalizedPath === normalizedRoot || normalizedPath.startsWith(`${normalizedRoot}${sep}`);
+}
+
+export function assertDurableRuntimeCommand(command: string[]): void {
+  if (command.length === 0) throw new Error("Runtime command is empty");
+  const executable = command[0]!;
+  if (!isAbsolute(executable)) throw new Error(`Runtime executable must be absolute: ${executable}`);
+  const ephemeralRoots = [tmpdir(), "/tmp", "/private/tmp", "/var/tmp", "/private/var/tmp"];
+  for (const part of command) {
+    if (!isAbsolute(part)) continue;
+    if (ephemeralRoots.some(root => inside(part, root))) {
+      throw new Error(`Runtime command must not reference an ephemeral path: ${part}`);
+    }
+  }
+  if (!existsSync(executable)) throw new Error(`Runtime executable does not exist: ${executable}`);
 }
 
 function defaultChromeExecutable(): string {
@@ -116,10 +143,26 @@ function defaultChromeExecutable(): string {
 export function loadConfig(): AppConfig {
   const path = getConfigPath();
   if (!existsSync(path)) throw new Error(`Configuration is missing: ${path}. Run codex-chatgpt-web setup first.`);
-  const parsed = JSON.parse(readFileSync(path, "utf8")) as Partial<AppConfig>;
-  if (parsed.version !== 1) throw new Error(`Unsupported configuration version in ${path}`);
+  return parseConfig(JSON.parse(readFileSync(path, "utf8")), path);
+}
+
+export function loadConfigForSetup(): AppConfig {
+  const path = getConfigPath();
+  if (!existsSync(path)) throw new Error(`Configuration is missing: ${path}. Run codex-chatgpt-web setup first.`);
+  const raw = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+  if (raw.version === 1 && raw.mode === "pro-only") {
+    raw.version = 2;
+    raw.mode = "browser-only";
+  }
+  return parseConfig(raw, path);
+}
+
+function parseConfig(value: unknown, path: string): AppConfig {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`Invalid configuration object in ${path}`);
+  const parsed = value as Partial<AppConfig>;
+  if (parsed.version !== 2) throw new Error(`Unsupported configuration version in ${path}; rerun setup to migrate it`);
   if (typeof parsed.releaseVersion !== "string" || !parsed.releaseVersion.trim()) throw new Error(`Missing releaseVersion in ${path}`);
-  if (parsed.mode !== "pro-only" && parsed.mode !== "full") throw new Error(`Invalid runtime mode in ${path}`);
+  if (parsed.mode !== "browser-only" && parsed.mode !== "full") throw new Error(`Invalid runtime mode in ${path}`);
   if (parsed.host !== "127.0.0.1") throw new Error("The Responses proxy must bind to 127.0.0.1");
   if (!Number.isInteger(parsed.port) || parsed.port! < 1 || parsed.port! > 65_535) throw new Error(`Invalid port in ${path}`);
   const requiredStrings: Array<keyof AppConfig> = [
@@ -134,6 +177,7 @@ export function loadConfig(): AppConfig {
     || parsed.runtimeCommand.some(part => typeof part !== "string" || !part.trim())) {
     throw new Error(`Invalid runtimeCommand in ${path}`);
   }
+  assertDurableRuntimeCommand(parsed.runtimeCommand as string[]);
   if (parsed.proAvailable !== undefined && typeof parsed.proAvailable !== "boolean") {
     throw new Error(`Invalid proAvailable in ${path}`);
   }
@@ -145,31 +189,27 @@ export function saveConfig(config: AppConfig): void {
 }
 
 export function providerConfig(config: AppConfig): CodexProviderConfig {
-  const models = [
-    ...(config.mode === "full" ? ["gpt-5.6-sol"] : []),
-    ...(config.proAvailable ? ["gpt-5.6-sol-pro"] : []),
-  ];
-  if (models.length === 0) throw new Error("No ChatGPT web models are enabled for this account");
+  const models = ["gpt-5.6-sol"];
+  const efforts = ["light", "medium", "high", "xhigh", ...(config.proAvailable ? ["pro"] : [])];
   return {
     adapter: "chatgpt-web",
     baseUrl: "https://chatgpt.com",
     models,
     liveModels: false,
-    defaultModel: config.mode === "full" ? "gpt-5.6-sol" : "gpt-5.6-sol-pro",
+    defaultModel: "gpt-5.6-sol",
     contextWindow: config.contextWindow,
     modelInputModalities: Object.fromEntries(models.map(model => [model, ["text", "image"]])),
-    modelReasoningEfforts: {
-      ...(config.mode === "full" ? { "gpt-5.6-sol": ["medium", "high", "xhigh"] } : {}),
-      ...(config.proAvailable ? { "gpt-5.6-sol-pro": [] } : {}),
-    },
-    modelDefaultReasoningEfforts: config.mode === "full" ? { "gpt-5.6-sol": "high" } : {},
-    noReasoningModels: config.proAvailable ? ["gpt-5.6-sol-pro"] : [],
+    modelReasoningEfforts: { "gpt-5.6-sol": efforts },
+    modelDefaultReasoningEfforts: { "gpt-5.6-sol": "high" },
+    noReasoningModels: [],
     chatgptWeb: {
       appName: config.appName,
       storageStatePath: config.storageStatePath,
       chromeExecutablePath: config.chromeExecutablePath,
       brokerSocketPath: config.brokerSocketPath,
       headed: config.headed,
+      localToolsEnabled: config.mode === "full",
+      proAvailable: config.proAvailable,
       autoApproveToolCalls: config.autoApproveToolCalls,
     },
   };

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -121,7 +121,7 @@ export async function runDoctor(): Promise<DoctorReport> {
       detail: "Verify it once at https://chatgpt.com/#settings/Connectors while the tunnel is ready.",
     });
   } else {
-    checks.push({ id: "tools", status: "warning", message: "Pro-only mode intentionally has no local tools or MCP tunnel" });
+    checks.push({ id: "tools", status: "warning", message: "Browser-only mode intentionally has no local tools or MCP tunnel" });
   }
 
   return {

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,20 +14,20 @@ import { namespacedToolName, type AdapterEvent, type CodexParsedRequest } from "
 import { VERSION } from "./version";
 
 const ROUTED_PREFIX = "chatgpt-web/";
-const STANDARD_MODEL = "gpt-5.6-sol";
-const PRO_MODEL = "gpt-5.6-sol-pro";
+const WEB_MODEL = "gpt-5.6-sol";
 
-function modelList(config: AppConfig): Array<Record<string, unknown>> {
-  const ids = config.mode === "full" ? [STANDARD_MODEL, PRO_MODEL] : [PRO_MODEL];
-  return ids.map(id => ({ id: `${ROUTED_PREFIX}${id}`, object: "model", created: 0, owned_by: "chatgpt-web" }));
+function modelList(): Array<Record<string, unknown>> {
+  return [{ id: `${ROUTED_PREFIX}${WEB_MODEL}`, object: "model", created: 0, owned_by: "chatgpt-web" }];
 }
 
 function routeModel(parsed: CodexParsedRequest, config: AppConfig): string {
   const requested = parsed.modelId.startsWith(ROUTED_PREFIX)
     ? parsed.modelId.slice(ROUTED_PREFIX.length)
     : parsed.modelId;
-  const allowed = config.mode === "full" ? new Set([STANDARD_MODEL, PRO_MODEL]) : new Set([PRO_MODEL]);
-  if (!allowed.has(requested)) throw new Error(`Model is not enabled in ${config.mode} mode: ${parsed.modelId}`);
+  if (requested !== WEB_MODEL) throw new Error(`ChatGPT web model is not enabled: ${parsed.modelId}`);
+  if (parsed.options.reasoning === "pro" && !config.proAvailable) {
+    throw new Error("ChatGPT Pro effort is not available for this account");
+  }
   parsed.modelId = requested;
   if (parsed._rawBody && typeof parsed._rawBody === "object") {
     (parsed._rawBody as { model?: string }).model = requested;
@@ -245,7 +245,7 @@ export function startServer(config: AppConfig): ReturnType<typeof Bun.serve> {
         return Response.json({ status: "ok", accepting_turns: !draining, ...activity() });
       }
       if (req.method === "GET" && url.pathname === "/v1/models") {
-        return Response.json({ object: "list", data: modelList(config) });
+        return Response.json({ object: "list", data: modelList() });
       }
       if (req.method === "POST" && url.pathname === "/v1/responses") {
         if (draining) return formatErrorResponse(503, "server_error", "codex-chatgpt-web is draining for a requested service operation");

--- a/src/service.ts
+++ b/src/service.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { homedir, userInfo } from "node:os";
 import { dirname, join } from "node:path";
 import type { AppConfig } from "./config";
-import { atomicWriteFile, getConfigDir } from "./config";
+import { assertDurableRuntimeCommand, atomicWriteFile, getConfigDir } from "./config";
 import { runCommand, runChecked } from "./process";
 
 const LABEL = "io.github.codex-chatgpt-web.daemon";
@@ -34,6 +34,18 @@ function launchDomain(): string {
 
 function serviceTarget(): string {
   return `${launchDomain()}/${LABEL}`;
+}
+
+async function bootstrapService(path: string, timeoutMs = 20_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError = "unknown launchctl bootstrap failure";
+  while (Date.now() < deadline) {
+    const result = runCommand("launchctl", ["bootstrap", launchDomain(), path]);
+    if (result.status === 0) return;
+    lastError = result.stderr.trim() || result.stdout.trim() || `exit status ${result.status}`;
+    await new Promise(resolveWait => setTimeout(resolveWait, 100));
+  }
+  throw new Error(`launchctl bootstrap ${launchDomain()} ${path} failed after ${timeoutMs}ms: ${lastError}`);
 }
 
 function plist(config: AppConfig): string {
@@ -92,6 +104,7 @@ export function getServiceStatus(): ServiceStatus {
 
 export function installService(config: AppConfig): ServiceStatus {
   assertMacOs();
+  assertDurableRuntimeCommand(config.runtimeCommand);
   const path = plistPath();
   mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
   mkdirSync(join(getConfigDir(), "logs"), { recursive: true, mode: 0o700 });
@@ -163,12 +176,23 @@ export async function restartService(config: AppConfig): Promise<ServiceStatus> 
   if (!getServiceStatus().loaded) return startService();
   const lease = await acquireDrain(config);
   try {
-    runChecked("launchctl", ["kickstart", "-k", serviceTarget()]);
+    runChecked("launchctl", ["bootout", serviceTarget()]);
+    await bootstrapService(plistPath());
   } catch (error) {
     await lease.release().catch(() => {});
     throw error;
   }
   return getServiceStatus();
+}
+
+export function removeLegacyRuntimeArtifacts(config: AppConfig): void {
+  const legacyWrapper = join(getConfigDir(), "bin", "serve-with-playwright.sh");
+  const legacyVendor = join(getConfigDir(), "vendor");
+  if (config.runtimeCommand.some(part => part === legacyWrapper || part.startsWith(`${legacyVendor}/`))) {
+    throw new Error("Refusing to remove legacy runtime artifacts while the active service still references them");
+  }
+  rmSync(legacyWrapper, { force: true });
+  rmSync(legacyVendor, { recursive: true, force: true });
 }
 
 export async function stopService(config: AppConfig): Promise<ServiceStatus> {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,7 +1,7 @@
 import { existsSync } from "node:fs";
 import { createServer } from "node:net";
 import type { AppConfig, RuntimeMode } from "./config";
-import { currentRuntimeCommand, defaultConfig, getConfigPath, loadConfig, saveConfig } from "./config";
+import { currentRuntimeCommand, defaultConfig, getConfigPath, loadConfigForSetup, saveConfig } from "./config";
 import {
   browserLoginStateExists,
   inspectBrowserLoginCapabilities,
@@ -9,7 +9,7 @@ import {
   storedBrowserLoginCapabilities,
 } from "./browser-login";
 import { installCodexIntegration } from "./codex-integration";
-import { assertServiceIdle, getServiceStatus, installService, restartService } from "./service";
+import { assertServiceIdle, getServiceStatus, installService, removeLegacyRuntimeArtifacts, restartService } from "./service";
 import { connectTunnel, createTunnelConfig, installRuntimeKey, installRuntimeKeyBytes, installTunnelClient, managedRuntimeKeyPath, waitForTunnelReady } from "./tunnel";
 import { VERSION } from "./version";
 
@@ -41,7 +41,7 @@ export interface SetupResult {
 
 function loadExistingConfig(): AppConfig | undefined {
   if (!existsSync(getConfigPath())) return undefined;
-  return loadConfig();
+  return loadConfigForSetup();
 }
 
 function meaningfulRuntimeChange(before: AppConfig, after: AppConfig): boolean {
@@ -130,7 +130,7 @@ function baseConfig(existing: AppConfig | undefined, options: SetupOptions): App
 }
 
 async function configureTunnel(config: AppConfig, existing: AppConfig | undefined, options: SetupOptions): Promise<void> {
-  if (config.mode === "pro-only") {
+  if (config.mode === "browser-only") {
     delete config.tunnel;
     return;
   }
@@ -186,10 +186,6 @@ export async function setup(options: SetupOptions): Promise<SetupResult> {
     proAvailable = (await inspectBrowserLoginCapabilities(config)).proAvailable;
   }
   config.proAvailable = proAvailable === true;
-  if (config.mode === "pro-only" && !config.proAvailable) {
-    throw new Error("This ChatGPT account is authenticated but does not have the Pro reasoning tier required by --pro-only");
-  }
-
   const explicitTunnelChange = Boolean(options.tunnelId || options.runtimeKeyFile || options.runtimeKeyValue);
   const preliminaryChange = Boolean(existing && (meaningfulRuntimeChange(existing, config) || explicitTunnelChange || options.forceLogin));
   if (beforeService.loaded && preliminaryChange && !options.restartService) {
@@ -215,6 +211,7 @@ export async function setup(options: SetupOptions): Promise<SetupResult> {
   installService(config);
   if (changedWhileLoaded && options.restartService && existing) await restartService(existing);
   await waitForProxy(config);
+  removeLegacyRuntimeArtifacts(config);
 
   let tunnelReady: boolean | null = null;
   if (config.mode === "full") {

--- a/src/types.ts
+++ b/src/types.ts
@@ -308,6 +308,10 @@ export interface CodexProviderConfig {
     turnTimeoutMs?: number;
     /** Keep the single controlled browser visible. */
     headed?: boolean;
+    /** Attach the turn-bound Codex MCP capability for non-Pro efforts. */
+    localToolsEnabled?: boolean;
+    /** Account capability proven by the authenticated browser probe. */
+    proAvailable?: boolean;
     /** Authorize per-call "Allow once" confirmation clicks for this connector. */
     autoApproveToolCalls?: boolean;
   };

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.1.0";
+export const VERSION = "0.1.1";

--- a/tests/browser-login.test.ts
+++ b/tests/browser-login.test.ts
@@ -3,6 +3,7 @@ import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { browserLoginStateExists, loginToChatGpt, loginVerificationMarkerPath } from "../src/browser-login";
+import { CHATGPT_TEMPORARY_CHAT_URL } from "../src/chatgpt-session";
 import { defaultConfig } from "../src/config";
 
 test("login starts with normal Chrome and captures state in a headed Keychain-aware context", async () => {
@@ -14,7 +15,7 @@ test("login starts with normal Chrome and captures state in a headed Keychain-aw
   const previousLog = process.env.CODEX_LOGIN_ARG_LOG;
   process.env.CODEX_LOGIN_ARG_LOG = argsLog;
   try {
-    const config = defaultConfig("pro-only");
+    const config = defaultConfig("browser-only");
     config.chromeExecutablePath = executable;
     config.storageStatePath = join(root, "browser", "storage-state.json");
     await loginToChatGpt(config, { timeoutMs: 100 }).catch(() => {});
@@ -23,7 +24,7 @@ test("login starts with normal Chrome and captures state in a headed Keychain-aw
     const firstLaunch = launches[0] ?? "";
     expect(firstLaunch).toContain("--new-window");
     expect(firstLaunch).toContain("--user-data-dir=");
-    expect(firstLaunch).toContain("https://chatgpt.com/?temporary-chat=true");
+    expect(firstLaunch).toContain(CHATGPT_TEMPORARY_CHAT_URL);
     expect(firstLaunch).not.toContain("--remote-debugging-pipe");
     expect(launches[1]).not.toContain("--headless");
   } finally {
@@ -36,7 +37,7 @@ test("login starts with normal Chrome and captures state in a headed Keychain-aw
 test("a storage-state file is not trusted without a verification marker", () => {
   const root = mkdtempSync(join(tmpdir(), "codex-chatgpt-web-login-state-"));
   try {
-    const config = defaultConfig("pro-only");
+    const config = defaultConfig("browser-only");
     config.storageStatePath = join(root, "storage-state.json");
     writeFileSync(config.storageStatePath, "{}\n", { mode: 0o600 });
     expect(browserLoginStateExists(config)).toBe(false);

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "bun:test";
+import { chatGptEffortLabelsMatch, redactChatGptUiDiagnostic } from "../src/adapters/chatgpt-web/browser-worker";
+
+test("effort selection is idempotent across rendered whitespace", () => {
+  expect(chatGptEffortLabelsMatch("High", "High")).toBe(true);
+  expect(chatGptEffortLabelsMatch("Instant\n5.5", "Instant 5.5")).toBe(true);
+  expect(chatGptEffortLabelsMatch("High", "Extra High")).toBe(false);
+});
+
+test("browser diagnostics redact context envelopes and capability values", () => {
+  const diagnostic = redactChatGptUiDiagnostic(
+    "<codex_context_json>private context</codex_context_json> turn_12345678901234567890 binding_12345678901234567890",
+  );
+  expect(diagnostic).not.toContain("private context");
+  expect(diagnostic).not.toContain("12345678901234567890");
+  expect(diagnostic).toContain("<codex_context_json>[redacted]</codex_context_json>");
+});

--- a/tests/chatgpt-web-harness.test.ts
+++ b/tests/chatgpt-web-harness.test.ts
@@ -10,8 +10,8 @@ import { ChatGptBrowserWorker, type BrowserTurn } from "../src/adapters/chatgpt-
 import { extractChatGptTurnEnvironment, extractChatGptTurnIdentity } from "../src/adapters/chatgpt-web/environment";
 import { createChatGptWebAdapter } from "../src/adapters/chatgpt-web/index";
 import { chatGptHtmlToMarkdown, ChatGptMarkdownStream } from "../src/adapters/chatgpt-web/markdown";
-import { CHATGPT_WEB_PRO_MODEL_ID, CHATGPT_WEB_STANDARD_MODEL_ID, resolveChatGptWebModelMode } from "../src/adapters/chatgpt-web/model";
-import { chatGptProContextWarning, compileChatGptWebPrompt } from "../src/adapters/chatgpt-web/prompt";
+import { CHATGPT_WEB_MODEL_ID, resolveChatGptWebModelMode } from "../src/adapters/chatgpt-web/model";
+import { chatGptReadOnlyContextWarning, compileChatGptWebPrompt } from "../src/adapters/chatgpt-web/prompt";
 import { ChatGptReasoningFeed, ChatGptTextFeed, ChatGptTurnSessions, chatGptTurnExecutionKey } from "../src/adapters/chatgpt-web/turn-execution";
 import { callTurnBroker, TurnBroker, type BrokerToolResult } from "../src/adapters/chatgpt-web/turn-broker";
 import { assertChatGptWebInputWithinLimit, estimateChatGptWebUsage } from "../src/adapters/chatgpt-web/usage";
@@ -35,10 +35,12 @@ const environmentXml = `<environment_context>
   <cwd>${tempRoot}</cwd>
   <filesystem><workspace_roots><root>${tempRoot}</root></workspace_roots><permission_profile type="disabled"><file_system type="unrestricted" /></permission_profile></filesystem>
 </environment_context>`;
+const toolCapabilities = { localToolsEnabled: true, proAvailable: true };
+const readOnlyCapabilities = { localToolsEnabled: false, proAvailable: true };
 
 function parsed(developerText?: string): CodexParsedRequest {
   return {
-    modelId: "gpt-5.6-sol",
+    modelId: CHATGPT_WEB_MODEL_ID,
     stream: true,
     context: {
       tools,
@@ -80,7 +82,7 @@ function rawWireRequest(environmentText: string): CodexParsedRequest {
 
 function proRequest(environmentText = environmentXml): CodexParsedRequest {
   const request = rawWireRequest(environmentText);
-  request.modelId = CHATGPT_WEB_PRO_MODEL_ID;
+  request.options.reasoning = "pro";
   return request;
 }
 
@@ -254,7 +256,7 @@ describe("ChatGPT outer-native harness v3", () => {
       { type: "text", text: "Inspect this image" },
       { type: "image", imageUrl, detail: "high" },
     ];
-    const compiled = compileChatGptWebPrompt(request, "turn_123456789012345678901234");
+    const compiled = compileChatGptWebPrompt(request, toolCapabilities, "turn_123456789012345678901234");
     expect(compiled.text).not.toContain(imageUrl);
     expect(compiled.text).toContain('"attachment_ref":"codex-input-image-1"');
     expect(compiled.text).toContain('"version":3');
@@ -264,19 +266,22 @@ describe("ChatGPT outer-native harness v3", () => {
     expect(files[0]?.buffer.length).toBeGreaterThan(0);
   });
 
-  test("maps the separate Pro model to the real Pro UI mode and fails closed on invalid combinations", () => {
-    expect(resolveChatGptWebModelMode(CHATGPT_WEB_PRO_MODEL_ID, "high")).toEqual({
-      modelId: CHATGPT_WEB_PRO_MODEL_ID,
-      uiModelLabel: "GPT-5.6 Sol",
+  test("maps one ChatGPT Web model to explicit effort modes and fails closed on invalid combinations", () => {
+    expect(resolveChatGptWebModelMode(CHATGPT_WEB_MODEL_ID, "pro", toolCapabilities)).toEqual({
+      modelId: CHATGPT_WEB_MODEL_ID,
+      effort: "pro",
       uiEffortLabel: "Pro",
       localTools: false,
     });
-    expect(resolveChatGptWebModelMode(CHATGPT_WEB_STANDARD_MODEL_ID, "xhigh")).toMatchObject({
+    expect(resolveChatGptWebModelMode(CHATGPT_WEB_MODEL_ID, "xhigh", toolCapabilities)).toMatchObject({
       uiEffortLabel: "Extra High",
       localTools: true,
     });
-    expect(() => resolveChatGptWebModelMode(CHATGPT_WEB_STANDARD_MODEL_ID, "pro")).toThrow("not supported");
-    expect(() => resolveChatGptWebModelMode("unknown", "high")).toThrow("model is not supported");
+    expect(() => resolveChatGptWebModelMode(CHATGPT_WEB_MODEL_ID, "pro", {
+      localToolsEnabled: false,
+      proAvailable: false,
+    })).toThrow("Pro effort is not available");
+    expect(() => resolveChatGptWebModelMode("unknown", "high", toolCapabilities)).toThrow("model is not supported");
   });
 
   test("builds a context-complete Pro prompt without exposing any local-tool capability", () => {
@@ -302,8 +307,8 @@ describe("ChatGPT outer-native harness v3", () => {
       },
     ];
 
-    const compiled = compileChatGptWebPrompt(request);
-    expect(compiled.text).toContain("ChatGPT Pro read-only Codex mode");
+    const compiled = compileChatGptWebPrompt(request, readOnlyCapabilities);
+    expect(compiled.text).toContain("ChatGPT Web Pro in read-only Codex mode");
     expect(compiled.text).toContain("prepared workspace evidence");
     expect(compiled.text).toContain('"system":["system-rule","repo-rule"]');
     expect(compiled.text).toContain('"attachment_ref":"codex-input-image-1"');
@@ -311,24 +316,24 @@ describe("ChatGPT outer-native harness v3", () => {
     expect(compiled.text).not.toContain("codex_bind_turn");
     expect(compiled.text).not.toContain("turn_token");
     expect(compiled.text).not.toContain("Use the attached Codex Native plugin");
-    expect(() => compileChatGptWebPrompt(request, "turn_forbidden")).toThrow("must not receive");
+    expect(() => compileChatGptWebPrompt(request, readOnlyCapabilities, "turn_forbidden")).toThrow("must not receive");
 
-    expect(chatGptProContextWarning(request)).toContain("complete accumulated task context");
+    expect(chatGptReadOnlyContextWarning(request, readOnlyCapabilities)).toContain("complete accumulated task context");
     request.context.messages = [{ role: "user", content: "No preparation yet", timestamp: 3 }];
-    expect(chatGptProContextWarning(request)).toContain("does not contain local tool results yet");
+    expect(chatGptReadOnlyContextWarning(request, readOnlyCapabilities)).toContain("does not contain local tool results yet");
     request.context.messages = [{
       role: "user",
       content: `${SUMMARY_PREFIX}\n\nWorkspace files and tests were inspected before compaction.`,
       timestamp: 4,
     }];
-    expect(chatGptProContextWarning(request)).toContain("compaction summary");
-    expect(chatGptProContextWarning(parsed())).toBeUndefined();
-    expect(() => compileChatGptWebPrompt(parsed())).toThrow("requires a broker turn token");
+    expect(chatGptReadOnlyContextWarning(request, readOnlyCapabilities)).toContain("compaction summary");
+    expect(chatGptReadOnlyContextWarning(parsed(), toolCapabilities)).toBeUndefined();
+    expect(() => compileChatGptWebPrompt(parsed(), toolCapabilities)).toThrow("requires a broker turn token");
   });
 
   test("reports conservative nonzero usage for browser text and image context", () => {
     const textRequest = parsed();
-    const textUsage = estimateChatGptWebUsage(textRequest, { answer: "done" });
+    const textUsage = estimateChatGptWebUsage(textRequest, { answer: "done" }, toolCapabilities);
     expect(textUsage).toMatchObject({ estimated: true });
     expect(textUsage.inputTokens).toBeGreaterThan(8_000);
     expect(textUsage.outputTokens).toBeGreaterThan(0);
@@ -339,7 +344,7 @@ describe("ChatGPT outer-native harness v3", () => {
       { type: "text", text: "Inspect this image" },
       { type: "image", imageUrl: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==", detail: "high" },
     ];
-    const imageUsage = estimateChatGptWebUsage(imageRequest, { answer: "done" });
+    const imageUsage = estimateChatGptWebUsage(imageRequest, { answer: "done" }, toolCapabilities);
     expect(imageUsage.inputTokens).toBeGreaterThanOrEqual(textUsage.inputTokens + 3_500);
   });
 
@@ -351,7 +356,7 @@ describe("ChatGPT outer-native harness v3", () => {
   test("returns one native compaction item with preserved estimated usage", () => {
     const request = parsed();
     const summary = "Completed the tool loop; continue with the deployment check.";
-    const usage = estimateChatGptWebUsage(request, { answer: summary });
+    const usage = estimateChatGptWebUsage(request, { answer: summary }, toolCapabilities);
     const response = buildResponseJSON([
       { type: "text_delta", text: "Completed the tool loop; ", phase: "final_answer" },
       { type: "text_delta", text: "continue with the deployment check.", phase: "final_answer" },
@@ -440,7 +445,7 @@ describe("ChatGPT outer-native harness v3", () => {
       },
       { role: "user", content: "continue", timestamp: 5 },
     ];
-    const compiled = compileChatGptWebPrompt(request, "turn_123456789012345678901234");
+    const compiled = compileChatGptWebPrompt(request, toolCapabilities, "turn_123456789012345678901234");
     const encoded = compiled.text.match(/<codex_context_json>\n(.+)\n<\/codex_context_json>/s)?.[1];
     const envelope = JSON.parse(encoded!) as { version: number; system: string[]; messages: Array<Record<string, unknown>> };
     expect(envelope.version).toBe(3);
@@ -540,7 +545,7 @@ describe("ChatGPT outer-native harness v3", () => {
     const provider: CodexProviderConfig = {
       adapter: "chatgpt-web",
       baseUrl: "browser://chatgpt",
-      chatgptWeb: { brokerSocketPath: socketPath, turnTimeoutMs: 30_000 },
+      chatgptWeb: { brokerSocketPath: socketPath, turnTimeoutMs: 30_000, localToolsEnabled: true, proAvailable: true },
     };
     const worker = ChatGptBrowserWorker.forProvider(provider);
     const originalRun = worker.run.bind(worker);
@@ -647,17 +652,17 @@ describe("ChatGPT outer-native harness v3", () => {
       adapter: "chatgpt-web",
       baseUrl: "browser://chatgpt-pro-test",
       contextWindow: 256_000,
-      chatgptWeb: { brokerSocketPath: socketPath, turnTimeoutMs: 30_000 },
+      chatgptWeb: { brokerSocketPath: socketPath, turnTimeoutMs: 30_000, localToolsEnabled: false, proAvailable: true },
     };
     const worker = ChatGptBrowserWorker.forProvider(provider);
     const originalRun = worker.run.bind(worker);
     let browserStarts = 0;
     (worker as unknown as { run: (turn: BrowserTurn) => Promise<string> }).run = async turn => {
       browserStarts += 1;
-      expect(turn.modelId).toBe(CHATGPT_WEB_PRO_MODEL_ID);
+      expect(turn.modelId).toBe(CHATGPT_WEB_MODEL_ID);
       const prepared = await turn.prepare();
       try {
-        expect(prepared.text).toContain("ChatGPT Pro read-only Codex mode");
+        expect(prepared.text).toContain("ChatGPT Web Pro in read-only Codex mode");
         expect(prepared.text).not.toContain("turn_token");
         expect(prepared.text).not.toContain("codex_bind_turn");
         turn.onReasoningSummary?.("Reviewed the accumulated task evidence");
@@ -714,7 +719,7 @@ describe("ChatGPT outer-native harness v3", () => {
         .toBe("## Pro result\n\nPrepared context synthesized.");
       expect(events.at(-1)).toMatchObject({ type: "done", stopReason: "stop", endTurn: true });
 
-      const response = buildResponseJSON(events, CHATGPT_WEB_PRO_MODEL_ID) as {
+      const response = buildResponseJSON(events, CHATGPT_WEB_MODEL_ID) as {
         output: Array<{ type: string; phase?: string; content?: Array<{ text?: string }> }>;
       };
       const warning = response.output.find(item => item.type === "message" && item.phase === "commentary");

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -10,7 +10,7 @@ test("setup accepts an explicit native source catalog before runtime validation"
       process.execPath,
       resolve(import.meta.dir, "../src/cli.ts"),
       "setup",
-      "--pro-only",
+      "--browser-only",
       "--port",
       "0",
       "--source-catalog",

--- a/tests/codex-integration.test.ts
+++ b/tests/codex-integration.test.ts
@@ -52,28 +52,35 @@ afterEach(() => {
 });
 
 describe("Codex catalog and reversible config integration", () => {
-  test("pro-only advertises exactly one injected model and preserves native entries", () => {
+  test("browser-only advertises one ChatGPT Web model with capability-gated efforts", () => {
     const { source } = fixture();
-    const config = defaultConfig("pro-only");
+    const config = defaultConfig("browser-only");
     config.proAvailable = true;
     const catalog = buildManagedCatalog(JSON.parse(readFileSync(source, "utf8")), config);
     const models = catalog.models as Array<Record<string, unknown>>;
     expect(models.map(model => model.slug)).toEqual([
-      "chatgpt-web/gpt-5.6-sol-pro",
+      "chatgpt-web/gpt-5.6-sol",
       "gpt-5.6-sol",
       "native-other",
     ]);
     expect(models[0]).toMatchObject({
-      display_name: "ChatGPT Pro (web)",
+      display_name: "ChatGPT Web",
       context_window: 256_000,
       auto_compact_token_limit: 230_400,
-      supported_reasoning_levels: [],
+      default_reasoning_level: "high",
       supported_in_api: false,
     });
-    expect(models[0]).not.toHaveProperty("default_reasoning_level");
+    expect(models[1]).toMatchObject({
+      slug: "gpt-5.6-sol",
+      context_window: 372_000,
+      max_context_window: 372_000,
+      auto_compact_token_limit: 334_800,
+    });
+    expect((models[0]!.supported_reasoning_levels as Array<{ effort: string }>).map(level => level.effort))
+      .toEqual(["light", "medium", "high", "xhigh", "pro"]);
   });
 
-  test("full mode injects standard reasoning efforts and the separate Pro model", () => {
+  test("full mode keeps one model and enables local tools for non-Pro efforts", () => {
     const { source } = fixture();
     const config = defaultConfig("full");
     config.proAvailable = true;
@@ -81,10 +88,11 @@ describe("Codex catalog and reversible config integration", () => {
     const models = catalog.models as Array<Record<string, unknown>>;
     expect(models.slice(0, 2).map(model => model.slug)).toEqual([
       "chatgpt-web/gpt-5.6-sol",
-      "chatgpt-web/gpt-5.6-sol-pro",
+      "gpt-5.6-sol",
     ]);
     expect((models[0]!.supported_reasoning_levels as Array<{ effort: string }>).map(level => level.effort))
-      .toEqual(["medium", "high", "xhigh"]);
+      .toEqual(["light", "medium", "high", "xhigh", "pro"]);
+    expect(models[0]!.tool_mode).toBe("code_mode_only");
   });
 
   test("full mode omits Pro when the authenticated account lacks that capability", () => {
@@ -105,7 +113,7 @@ describe("Codex catalog and reversible config integration", () => {
     const configPath = join(codexHome, "config.toml");
     const original = `model = "gpt-5.6-sol"\nmodel_provider = "existing-provider"\nopenai_base_url = "http://127.0.0.1:9999/v1"\n\n[features]\ngoals = true\n`;
     writeFileSync(configPath, original);
-    const config = defaultConfig("pro-only");
+    const config = defaultConfig("browser-only");
     config.proAvailable = true;
     expect(() => installCodexIntegration(config, { sourceCatalogPath: source })).toThrow("--replace-codex-route");
 
@@ -117,18 +125,64 @@ describe("Codex catalog and reversible config integration", () => {
     expect(installed).toContain("supports_websockets = false");
     expect(installed).toContain('openai_base_url = "http://127.0.0.1:9999/v1"');
     expect(installed).toContain(`model_catalog_json = ${JSON.stringify(journal.catalogPath)}`);
-    expect(readFileSync(journal.catalogPath, "utf8")).toContain("chatgpt-web/gpt-5.6-sol-pro");
+    expect(readFileSync(journal.catalogPath, "utf8")).toContain("chatgpt-web/gpt-5.6-sol");
 
     expect(uninstallCodexIntegration()).toEqual({ changed: true, removedCatalog: true });
     expect(readFileSync(configPath, "utf8")).toBe(original);
     expect(uninstallCodexIntegration()).toEqual({ changed: false, removedCatalog: false });
   });
 
+  test("migrates the removed legacy Pro model slug without touching native defaults", () => {
+    const { codexHome, source } = fixture();
+    const configPath = join(codexHome, "config.toml");
+    writeFileSync(configPath, 'model = "chatgpt-web/gpt-5.6-sol-pro"\n');
+    const config = defaultConfig("browser-only");
+    config.proAvailable = true;
+
+    installCodexIntegration(config, { sourceCatalogPath: source });
+    expect(readFileSync(configPath, "utf8")).toContain('model = "chatgpt-web/gpt-5.6-sol"');
+
+    uninstallCodexIntegration();
+    writeFileSync(configPath, 'model = "gpt-5.6-sol"\n');
+    installCodexIntegration(config, { sourceCatalogPath: source });
+    expect(readFileSync(configPath, "utf8")).toContain('model = "gpt-5.6-sol"');
+  });
+
+  test("updates from the preserved pre-install catalog instead of a polluted prior setup source", () => {
+    const { codexHome, source } = fixture();
+    const configPath = join(codexHome, "config.toml");
+    writeFileSync(configPath, `model = "gpt-5.6-sol"\nmodel_catalog_json = ${JSON.stringify(source)}\n`);
+    const polluted = join(codexHome, "model-catalog-700000.json");
+    const pollutedCatalog = JSON.parse(readFileSync(source, "utf8")) as {
+      models: Array<Record<string, unknown>>;
+    };
+    const native = pollutedCatalog.models.find(model => model.slug === "gpt-5.6-sol")!;
+    native.context_window = 736_843;
+    native.max_context_window = 736_843;
+    delete native.auto_compact_token_limit;
+    writeFileSync(polluted, JSON.stringify(pollutedCatalog));
+
+    const config = defaultConfig("browser-only");
+    config.proAvailable = true;
+    installCodexIntegration(config, { sourceCatalogPath: polluted, replaceExistingRoute: true });
+    const journal = installCodexIntegration(config);
+
+    expect(journal.sourceCatalogPath).toBe(source);
+    const managed = JSON.parse(readFileSync(journal.catalogPath, "utf8")) as {
+      models: Array<Record<string, unknown>>;
+    };
+    expect(managed.models.find(model => model.slug === "gpt-5.6-sol")).toMatchObject({
+      context_window: 372_000,
+      max_context_window: 372_000,
+      auto_compact_token_limit: 334_800,
+    });
+  });
+
   test("uninstall fails closed when a managed value changed after setup", () => {
     const { codexHome, source } = fixture();
     const configPath = join(codexHome, "config.toml");
     writeFileSync(configPath, "model = \"gpt-5.6-sol\"\n");
-    const config = defaultConfig("pro-only");
+    const config = defaultConfig("browser-only");
     config.proAvailable = true;
     installCodexIntegration(config, { sourceCatalogPath: source });
     const changed = readFileSync(configPath, "utf8").replace("17841", "17842");

--- a/tests/environment.test.ts
+++ b/tests/environment.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
+import { extractChatGptTurnEnvironment } from "../src/adapters/chatgpt-web/environment";
+import type { CodexParsedRequest } from "../src/types";
+
+const root = resolve(process.cwd());
+const environmentXml = `<environment_context>
+  <cwd>${root}</cwd>
+  <filesystem><workspace_roots><root>${root}</root></workspace_roots><permission_profile type="disabled"><file_system type="unrestricted" /></permission_profile></filesystem>
+</environment_context>`;
+
+function currentWire(options: { workspace?: string; sandbox?: string; includeIds?: boolean } = {}): CodexParsedRequest {
+  const workspace = options.workspace ?? root;
+  const sandbox = options.sandbox ?? "none";
+  const includeIds = options.includeIds ?? true;
+  const turnMetadata = {
+    thread_id: "thread_current",
+    turn_id: "turn_current",
+    sandbox,
+    workspaces: { [workspace]: { has_changes: true } },
+  };
+  return {
+    modelId: "chatgpt-web/gpt-5.6-sol",
+    stream: true,
+    context: { messages: [{ role: "user", content: "Inspect the workspace", timestamp: 1 }] },
+    options: { reasoning: "high" },
+    _rawBody: {
+      client_metadata: { "x-codex-turn-metadata": JSON.stringify(turnMetadata) },
+      input: [
+        {
+          type: "message",
+          ...(includeIds ? { id: "msg_context" } : {}),
+          role: "user",
+          content: [
+            { type: "input_text", text: "<app-context>native app context</app-context>" },
+            { type: "input_text", text: environmentXml },
+          ],
+        },
+        {
+          type: "message",
+          ...(includeIds ? { id: "msg_active" } : {}),
+          role: "user",
+          content: [{ type: "input_text", text: "Inspect the workspace" }],
+        },
+      ],
+    },
+  };
+}
+
+describe("trusted current Codex environment envelope", () => {
+  test("accepts the v0.146 split envelope when workspace and sandbox metadata agree", () => {
+    expect(extractChatGptTurnEnvironment(currentWire())).toEqual({
+      cwd: root,
+      roots: [root],
+      writableRoots: [root],
+      sandboxPolicy: { type: "dangerFullAccess" },
+      tools: [],
+    });
+  });
+
+  test("rejects a workspace mismatch", () => {
+    expect(() => extractChatGptTurnEnvironment(currentWire({ workspace: resolve(root, "elsewhere") })))
+      .toThrow("missing cwd");
+  });
+
+  test("rejects a sandbox mismatch", () => {
+    expect(() => extractChatGptTurnEnvironment(currentWire({ sandbox: "read-only" })))
+      .toThrow("missing cwd");
+  });
+
+  test("rejects unprovenanced adjacent user content without native item ids", () => {
+    expect(() => extractChatGptTurnEnvironment(currentWire({ includeIds: false })))
+      .toThrow("missing cwd");
+  });
+});

--- a/tests/http-body.test.ts
+++ b/tests/http-body.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test";
 import { readJsonRequestBody } from "../src/http-body";
 
 test("decodes Codex zstd-compressed JSON request bodies", async () => {
-  const body = { model: "chatgpt-web/gpt-5.6-sol-pro", input: [{ role: "user", content: "hello" }] };
+  const body = { model: "chatgpt-web/gpt-5.6-sol", reasoning: { effort: "pro" }, input: [{ role: "user", content: "hello" }] };
   const compressed = Bun.zstdCompressSync(Buffer.from(JSON.stringify(body)));
   const encoded = new ArrayBuffer(compressed.byteLength);
   new Uint8Array(encoded).set(compressed);

--- a/tests/model-contract.test.ts
+++ b/tests/model-contract.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "bun:test";
+import { CHATGPT_WEB_MODEL_ID, resolveChatGptWebModelMode } from "../src/adapters/chatgpt-web/model";
+
+test("one ChatGPT Web model maps explicit efforts to the visible ChatGPT modes", () => {
+  const capabilities = { localToolsEnabled: true, proAvailable: true };
+  expect(resolveChatGptWebModelMode(CHATGPT_WEB_MODEL_ID, "light", capabilities)).toMatchObject({
+    uiEffortLabel: "Instant 5.5",
+    localTools: true,
+  });
+  expect(resolveChatGptWebModelMode(CHATGPT_WEB_MODEL_ID, "medium", capabilities)).toMatchObject({
+    uiEffortLabel: "Medium",
+    localTools: true,
+  });
+  expect(resolveChatGptWebModelMode(CHATGPT_WEB_MODEL_ID, "high", capabilities)).toMatchObject({
+    uiEffortLabel: "High",
+    localTools: true,
+  });
+  expect(resolveChatGptWebModelMode(CHATGPT_WEB_MODEL_ID, "xhigh", capabilities)).toMatchObject({
+    uiEffortLabel: "Extra High",
+    localTools: true,
+  });
+  expect(resolveChatGptWebModelMode(CHATGPT_WEB_MODEL_ID, "pro", capabilities)).toMatchObject({
+    uiEffortLabel: "Pro",
+    localTools: false,
+  });
+});
+
+test("capabilities gate tools and Pro explicitly without changing the selected model", () => {
+  expect(resolveChatGptWebModelMode(CHATGPT_WEB_MODEL_ID, "high", {
+    localToolsEnabled: false,
+    proAvailable: true,
+  })).toMatchObject({ localTools: false });
+  expect(() => resolveChatGptWebModelMode(CHATGPT_WEB_MODEL_ID, "pro", {
+    localToolsEnabled: false,
+    proAvailable: false,
+  })).toThrow("Pro effort is not available");
+  expect(() => resolveChatGptWebModelMode("unknown", "high", {
+    localToolsEnabled: false,
+    proAvailable: true,
+  })).toThrow("model is not supported");
+  expect(() => resolveChatGptWebModelMode(CHATGPT_WEB_MODEL_ID, "turbo", {
+    localToolsEnabled: false,
+    proAvailable: true,
+  })).toThrow("effort is not supported");
+});

--- a/tests/native-passthrough.test.ts
+++ b/tests/native-passthrough.test.ts
@@ -38,6 +38,34 @@ test("forwards native Codex requests verbatim to the official backend", async ()
   expect(await response.text()).toBe("data: native\n\n");
 });
 
+test("forwards native Codex compaction requests to the official compact endpoint", async () => {
+  const originalBody = Bun.zstdCompressSync(Buffer.from('{"model":"gpt-5.6-sol","input":[]}'));
+  const encoded = new ArrayBuffer(originalBody.byteLength);
+  new Uint8Array(encoded).set(originalBody);
+  const request = new Request("http://127.0.0.1:17841/v1/responses/compact", {
+    method: "POST",
+    headers: {
+      authorization: "Bearer codex-oauth-token",
+      "content-type": "application/json",
+      "content-encoding": "zstd",
+    },
+    body: encoded,
+  });
+  let upstreamUrl = "";
+  let upstreamRequest: Request | undefined;
+  const response = await forwardNativeCodexRequest(request, "responses/compact", async input => {
+    upstreamUrl = input.url;
+    upstreamRequest = input;
+    return Response.json({ output: [] }, { status: 200 });
+  });
+
+  expect(upstreamUrl).toBe("https://chatgpt.com/backend-api/codex/responses/compact");
+  expect(upstreamRequest!.headers.get("authorization")).toBe("Bearer codex-oauth-token");
+  expect(Buffer.from(await upstreamRequest!.arrayBuffer())).toEqual(Buffer.from(originalBody));
+  expect(response.status).toBe(200);
+  expect(await response.json()).toEqual({ output: [] });
+});
+
 test("native passthrough fails closed without Codex bearer authentication", async () => {
   const request = new Request("http://127.0.0.1:17841/v1/responses", {
     method: "POST",

--- a/tests/prompt-contract.test.ts
+++ b/tests/prompt-contract.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test";
+import { compileChatGptWebPrompt } from "../src/adapters/chatgpt-web/prompt";
+import { CHATGPT_WEB_MODEL_ID } from "../src/adapters/chatgpt-web/model";
+import type { CodexParsedRequest } from "../src/types";
+
+function request(reasoning: "high" | "pro"): CodexParsedRequest {
+  return {
+    modelId: CHATGPT_WEB_MODEL_ID,
+    context: {
+      systemPrompt: ["preserve-system"],
+      messages: [
+        { role: "developer", content: "preserve-developer", timestamp: 1 },
+        { role: "user", content: "perform the task", timestamp: 2 },
+      ],
+    },
+    stream: true,
+    options: { reasoning },
+  };
+}
+
+test("tool-capable prompts resume the mandatory bind contract after the complete context envelope", () => {
+  const token = "turn_12345678901234567890123456789012";
+  const compiled = compileChatGptWebPrompt(
+    request("high"),
+    { localToolsEnabled: true, proAvailable: true },
+    token,
+  );
+  const envelopeEnd = compiled.text.indexOf("</codex_context_json>");
+  const resume = compiled.text.indexOf("<codex_transport_resume>", envelopeEnd);
+  const finalToken = compiled.text.lastIndexOf(token);
+
+  expect(envelopeEnd).toBeGreaterThan(0);
+  expect(resume).toBeGreaterThan(envelopeEnd);
+  expect(finalToken).toBeGreaterThan(resume);
+  expect(compiled.text.slice(resume)).toContain("first action now must be the actual Codex Native codex_bind_turn call");
+});
+
+test("read-only prompts resume without exposing a bind capability", () => {
+  const compiled = compileChatGptWebPrompt(
+    request("pro"),
+    { localToolsEnabled: true, proAvailable: true },
+  );
+
+  expect(compiled.text).toContain("The context envelope is complete. Execute the latest active user request now under the read-only transport contract above.");
+  expect(compiled.text).not.toContain("codex_bind_turn");
+  expect(compiled.text).not.toContain("turn_token");
+});

--- a/tests/runtime-layout.test.ts
+++ b/tests/runtime-layout.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, expect, test } from "bun:test";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { assertDurableRuntimeCommand, defaultConfig, loadConfig, loadConfigForSetup } from "../src/config";
+import { removeLegacyRuntimeArtifacts } from "../src/service";
+
+const roots: string[] = [];
+afterEach(() => {
+  delete process.env.CODEX_CHATGPT_WEB_HOME;
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+test("managed runtime commands reject every ephemeral path component", () => {
+  expect(() => assertDurableRuntimeCommand(["/private/tmp/codex-chatgpt-web"])).toThrow("ephemeral path");
+  expect(() => assertDurableRuntimeCommand([process.execPath, "/tmp/build/app/cli.js"])).toThrow("ephemeral path");
+  expect(() => assertDurableRuntimeCommand([process.execPath])).not.toThrow();
+});
+
+test("setup explicitly migrates v1 pro-only config to v2 browser-only", () => {
+  const root = join(tmpdir(), `codex-chatgpt-web-config-migration-${process.pid}-${Date.now()}`);
+  roots.push(root);
+  process.env.CODEX_CHATGPT_WEB_HOME = root;
+  mkdirSync(root, { recursive: true });
+  writeFileSync(join(root, "config.json"), `${JSON.stringify({
+    version: 1,
+    releaseVersion: "0.1.0",
+    mode: "pro-only",
+    host: "127.0.0.1",
+    port: 17841,
+    contextWindow: 256_000,
+    appName: "Codex Native",
+    chromeExecutablePath: "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    storageStatePath: join(root, "browser", "storage-state.json"),
+    brokerSocketPath: join(root, "runtime", "turn-broker.sock"),
+    headed: true,
+    proAvailable: true,
+    autoApproveToolCalls: false,
+    controlToken: "config-migration-control-token-0123456789abcdef",
+    runtimeCommand: [process.execPath],
+  })}\n`);
+
+  expect(() => loadConfig()).toThrow("rerun setup to migrate");
+  expect(loadConfigForSetup()).toMatchObject({ version: 2, mode: "browser-only" });
+});
+
+test("legacy temp-path wrapper and vendor are removed only after runtime ownership changes", () => {
+  const root = join(tmpdir(), `codex-chatgpt-web-legacy-runtime-${process.pid}-${Date.now()}`);
+  roots.push(root);
+  process.env.CODEX_CHATGPT_WEB_HOME = root;
+  const wrapper = join(root, "bin", "serve-with-playwright.sh");
+  const vendorFile = join(root, "vendor", "node_modules", "playwright-core", "package.json");
+  mkdirSync(join(root, "bin"), { recursive: true });
+  mkdirSync(join(root, "vendor", "node_modules", "playwright-core"), { recursive: true });
+  writeFileSync(wrapper, "#!/bin/sh\n");
+  writeFileSync(vendorFile, "{}\n");
+
+  const config = defaultConfig("browser-only");
+  config.runtimeCommand = [wrapper];
+  expect(() => removeLegacyRuntimeArtifacts(config)).toThrow("still references");
+  expect(existsSync(wrapper)).toBe(true);
+  config.runtimeCommand = [process.execPath];
+  removeLegacyRuntimeArtifacts(config);
+  expect(existsSync(wrapper)).toBe(false);
+  expect(existsSync(join(root, "vendor"))).toBe(false);
+});

--- a/tests/turn-broker-lifecycle.test.ts
+++ b/tests/turn-broker-lifecycle.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { TurnBroker } from "../src/adapters/chatgpt-web/turn-broker";
+
+test("turn broker creates its private runtime directory on a cold start", async () => {
+  const root = mkdtempSync("/tmp/cgw-broker-");
+  const socketPath = join(root, "runtime", "turn-broker.sock");
+  const broker = TurnBroker.forSocket(socketPath);
+  try {
+    await broker.register({
+      cwd: root,
+      roots: [root],
+      writableRoots: [root],
+      sandboxPolicy: { type: "dangerFullAccess" },
+      tools: [],
+    }, 10_000);
+    expect(existsSync(socketPath)).toBe(true);
+    expect(statSync(dirname(socketPath)).mode & 0o777).toBe(0o700);
+  } finally {
+    await broker.close();
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What changed

- expose one native `ChatGPT Web` model with Light, Medium, High, Extra High, and capability-gated Pro efforts
- run every browser turn in an isolated ChatGPT Temporary Chat; normal history chats are never created or deleted
- bridge non-Pro tool calls back into the active outer Codex harness through an expiring MCP turn capability
- keep Pro read-only while replaying the complete Codex context, prior tool evidence, compaction summaries, and images
- preserve native Codex routing for non-web models and restore the native context/compaction limits
- replace the ephemeral compiled binary layout with a versioned, relocatable runtime bundle and atomic installer
- harden login persistence, browser lifecycle, prompt integrity checks, environment provenance, service draining, diagnostics, and release smoke tests

## Why

The previous implementation exposed separate web model entries, depended on an ephemeral build path, and did not fully prove the current Codex environment or long-lived MCP tool loop. The new contract keeps model selection native and explicit while making the browser transport fail closed instead of silently changing models, context, tools, or chat isolation.

## User impact

Codex shows one `ChatGPT Web` model. In full mode, Light through Extra High can use the current Codex tool registry inside one ChatGPT response; Pro remains read-only and emits a visible warning. Browser-only mode needs no tunnel. Both modes preserve full context, images, task history, streaming, and compaction.

## Validation

- `bun run verify`: version sync, dependency audit, TypeScript, 56 tests, runtime build, third-party notices, relocatable smoke
- `bun run smoke:codex`: native catalog passthrough smoke
- `sh -n scripts/install.sh`
- live Temporary Chat E2E: bind → `pwd` → `apply_patch` → exact verification → cleanup
- live Pro E2E: exact `PRO_READ_ONLY_OK`, no MCP capability attached
- live image E2E: one native Codex image attachment recognized as `IMAGE_PIPELINE_OK`
- post-deploy `doctor`, proxy health, and tunnel readiness all green

`shellcheck` and `actionlint` were unavailable locally; the release workflow remains covered by GitHub Actions.
