### PR TITLE
Add Linux, Firefox, and ngrok support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
             asset: codex-chatgpt-web-darwin-arm64.tar.gz
           - runner: macos-15-intel
             asset: codex-chatgpt-web-darwin-amd64.tar.gz
+          - runner: ubuntu-latest
+            asset: codex-chatgpt-web-linux-amd64.tar.gz
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6
@@ -27,7 +29,8 @@ jobs:
       - run: bun run typecheck
       - run: bun test
       - run: bun run build
-      - run: codesign --verify --deep --strict dist/runtime/runtime/bun
+      - if: runner.os == 'macOS'
+        run: codesign --verify --deep --strict dist/runtime/runtime/bun
       - run: bun run smoke
       - run: tar -czf "${{ matrix.asset }}" -C dist/runtime .
       - uses: actions/upload-artifact@v4
@@ -62,7 +65,7 @@ jobs:
           cp LICENSES/Bun-1.3.11.md release-assets/Bun-1.3.11.md
           cp dist/THIRD_PARTY_NOTICES.txt release-assets/THIRD_PARTY_NOTICES.txt
           cd release-assets
-          sha256sum codex-chatgpt-web-darwin-*.tar.gz LICENSE NOTICE.md OpenCodex-MIT.txt Bun-1.3.11.md THIRD_PARTY_NOTICES.txt > checksums.txt
+          sha256sum codex-chatgpt-web-*.tar.gz LICENSE NOTICE.md OpenCodex-MIT.txt Bun-1.3.11.md THIRD_PARTY_NOTICES.txt > checksums.txt
       - name: Add installer
         run: cp scripts/install.sh release-assets/install.sh
       - name: Publish GitHub release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Core invariants:
 
 Before opening a pull request:
 
-1. Run `bun install --frozen-lockfile` and `bun run verify` on macOS.
+1. Run `bun install --frozen-lockfile` and `bun run verify` on macOS or Linux.
 2. Add a focused regression test for protocol, compaction, MCP, browser parsing, or installer changes.
 3. Do not commit cookies, browser state, tunnel ids, API keys, local absolute paths, or generated logs.
 4. Preserve fail-closed behavior. A UI selector failure must not pick another model or claim success.

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ codex-chatgpt-web setup --full \
 ```
 
 Attach the printed `/mcp` endpoint directly as the ChatGPT connector URL.
+The managed ngrok process does not inherit generic `HTTP_PROXY`/`HTTPS_PROXY` variables; configure
+a paid ngrok agent proxy explicitly in ngrok's own configuration when needed.
 
 Write/modify actions require a ChatGPT workspace and admin policy that permit them. OpenAI
 currently documents those actions for Business and Enterprise/Edu workspaces; personal Pro is

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <p align="center">
   <a href="https://github.com/miuuyy/codex-chatgpt-web/actions/workflows/ci.yml"><img src="https://github.com/miuuyy/codex-chatgpt-web/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT license"></a>
-  <img src="https://img.shields.io/badge/macOS-arm64%20%7C%20Intel-black?logo=apple" alt="macOS arm64 and Intel">
+  <img src="https://img.shields.io/badge/macOS%20%7C%20Linux-supported-black" alt="macOS and Linux">
   <img src="https://img.shields.io/badge/Free_AI-no_API_fees-10a37f" alt="Free AI with no API fees">
   <img src="https://img.shields.io/badge/Windows-coming_soon-0078d4?logo=windows11" alt="Windows support coming soon">
 </p>
@@ -25,7 +25,7 @@ Codex task.
 </p>
 
 ```text
-Codex task ──Responses + SSE──▶ codex-chatgpt-web ──controlled Chrome──▶ ChatGPT
+Codex task ──Responses + SSE──▶ codex-chatgpt-web ──controlled browser──▶ ChatGPT
      ▲                                │                                      │
      └──────── native UI, context, images, tracing, and tool lifecycle ──────┘
 ```
@@ -58,17 +58,24 @@ policies.
 
 ## Quick start
 
-Browser-only mode needs macOS, Google Chrome, and a ChatGPT account. It does not need an API key,
-tunnel, system Node/Bun installation, OpenCodex, or a Playwright browser download.
+Browser-only mode needs macOS or Linux, Chromium or Firefox, and a ChatGPT account. It does not
+need an API key, tunnel, system Node/Bun installation, or OpenCodex. Firefox setup downloads
+Playwright's compatible Firefox build.
 
 ```bash
 curl -fsSL https://github.com/miuuyy/codex-chatgpt-web/releases/latest/download/install.sh \
   | sh -s -- --browser-only --acknowledge-unofficial
 ```
 
-Sign in through the one Chrome window opened by setup, restart Codex once, and select a
+Sign in through the one browser window opened by setup, restart Codex once, and select a
 **ChatGPT Web — …** model. Pro appears only when it is available on the authenticated account.
-Normal use starts automatically after macOS login and does not require another terminal command.
+Normal use starts automatically after OS login and does not require another terminal command.
+
+Use Firefox with:
+
+```bash
+codex-chatgpt-web setup --browser-only --browser firefox --acknowledge-unofficial
+```
 
 ## Modes
 
@@ -87,9 +94,9 @@ approvals, sandboxing, and tool results remain owned by Codex.
 
 ## Full harness
 
-Full mode connects ChatGPT's tool calls back to the current Codex task through the official
-[OpenAI tunnel-client](https://github.com/openai/tunnel-client). The tunnel is outbound: it does
-not expose a public IP, open an inbound port, or require router forwarding.
+Full mode connects ChatGPT's tool calls back to the current Codex task through either the official
+[OpenAI tunnel-client](https://github.com/openai/tunnel-client) or ngrok. Both are outbound and do
+not require router forwarding. Ngrok exposes a token-gated MCP endpoint at the configured HTTPS URL.
 
 1. Create a tunnel in [Platform tunnel settings](https://platform.openai.com/settings/organization/tunnels).
 2. Create a runtime key with **Tunnels Read + Use** in [Platform API key settings](https://platform.openai.com/settings/organization/api-keys).
@@ -112,6 +119,18 @@ not expose a public IP, open an inbound port, or require router forwarding.
    in [ChatGPT connector settings](https://chatgpt.com/#settings/Connectors), scan its tools, set
    the intended action permissions, and restart Codex once.
 
+For ngrok, configure its authtoken first and use a stable endpoint:
+
+```bash
+ngrok config add-authtoken YOUR_TOKEN
+codex-chatgpt-web setup --full \
+  --tunnel-provider ngrok \
+  --ngrok-url https://your-static-domain.ngrok.app \
+  --acknowledge-unofficial
+```
+
+Attach the printed `/mcp` endpoint directly as the ChatGPT connector URL.
+
 Write/modify actions require a ChatGPT workspace and admin policy that permit them. OpenAI
 currently documents those actions for Business and Enterprise/Edu workspaces; personal Pro is
 limited to read/fetch MCP permissions. See
@@ -130,7 +149,7 @@ codex-chatgpt-web login                # refresh an expired ChatGPT session
 codex-chatgpt-web uninstall --yes
 ```
 
-Setup stores private state under `~/.codex-chatgpt-web`, installs versioned launchd services, and
+Setup stores private state under `~/.codex-chatgpt-web`, installs launchd or systemd user services, and
 journals the previous Codex route so uninstall can restore it. It refuses to replace a different
 route unless `--replace-codex-route` is explicit, and refuses to stop or update while a task is
 still active.
@@ -152,12 +171,12 @@ codex-chatgpt-web service cancel-turns
 - The Responses listener is loopback-only, but another process running as the same local user can
   reach it. Use a trusted single-user workstation.
 - Browser turns are serialized to protect one profile and prevent transcript reuse across tasks.
-- Managed background installation currently supports macOS only.
+- Managed background installation supports macOS launchd and Linux systemd user services.
 - Codex Desktop hardcodes Pro's wire effort as **Ultra** and always shows a **Standard** speed row.
   Those controls do not alter the fixed ChatGPT Web model. Renaming them would require patching the
   signed Codex app.
 - macOS may report that Bun was prevented from modifying apps when Playwright launches installed
-  Chrome. The bridge does not modify Chrome; leaving that App Management permission denied is
+  Chromium. The bridge does not modify the browser; leaving that App Management permission denied is
   expected.
 
 Read the complete [architecture](docs/architecture.md) and
@@ -172,7 +191,7 @@ bun run verify
 ```
 
 `verify` runs dependency auditing, strict TypeScript checks, harness/MCP/config tests, a
-relocatable runtime smoke test, and a real headless launch of system Chrome.
+relocatable runtime smoke test, and platform browser checks.
 
 - [Architecture](docs/architecture.md)
 - [Security model](docs/security-model.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,11 +7,11 @@ Codex app / CLI
 codex-chatgpt-web daemon
   ├─ official /models passthrough + fixed ChatGPT Web models
   ├─ native Responses passthrough or ChatGPT Responses/SSE bridge
-  ├─ ChatGPT browser worker (one Chrome process, one turn at a time)
+  ├─ ChatGPT browser worker (one Chromium or Firefox process, one turn at a time)
   ├─ capability broker (full mode only)
-  └─ stdio MCP server
+  └─ MCP server (stdio or Streamable HTTP)
             ▲
-            │ outbound OpenAI Tunnel
+            │ outbound OpenAI Tunnel or ngrok
             ▼
       ChatGPT custom connector
 ```
@@ -31,14 +31,14 @@ codex-chatgpt-web daemon
 
 - Exposes the same fixed models; Instant through Extra High are tool-capable, while Pro remains
   read-only.
-- ChatGPT uses a custom MCP connector backed by `openai/tunnel-client`.
+- ChatGPT uses a custom MCP connector backed by `openai/tunnel-client` or a stable ngrok endpoint.
 - Every connector call is bound to one outer Codex turn capability.
 - Tool calls and results remain in the same ChatGPT response while Codex executes them locally.
 
 ## Browser lifecycle
 
-Playwright CLI is a development/debugging tool and is not part of the runtime. The daemon owns one
-long-lived Chrome process. A Codex turn gets a fresh Temporary Chat page; the preceding page is
+The daemon owns one long-lived Chromium or Firefox process. Firefox uses Playwright's compatible
+managed browser build. A Codex turn gets a fresh Temporary Chat page; the preceding page is
 closed. This prevents transcript leakage without creating a new Chrome window per tool call.
 
 Contexts through 40,000 serialized characters remain an inline JSON envelope. Larger contexts
@@ -58,13 +58,14 @@ rows becomes native Codex commentary.
 
 The release artifact is a versioned runtime bundle containing a pinned Bun executable and the
 bundled application. It contains the Responses bridge, Playwright client code, MCP server, setup,
-doctor, and launchd management; it uses the user's installed Google Chrome and does not download a
-second browser. Full mode separately downloads the official pinned `openai/tunnel-client` release
-and verifies it against that release's published SHA-256 manifest.
+doctor, and launchd/systemd management. Chromium uses the user's configured executable; Firefox is
+installed by Playwright during setup. OpenAI full mode separately downloads the official pinned
+`openai/tunnel-client` release and verifies it against that release's published SHA-256 manifest.
 
-Setup creates a user launchd service for the Responses proxy. Full mode also creates a separate
-launchd service that runs `tunnel-client` directly from its generated profile. Both use `RunAtLoad`
-and `KeepAlive`; no shell, terminal, tmux session, or manual post-login command owns production
+Setup creates a launchd service on macOS or a systemd user service on Linux for the Responses proxy.
+Full mode creates a second managed service. It runs `tunnel-client` directly, or runs an ngrok
+process beside a loopback Streamable HTTP MCP server. No shell, terminal, tmux session, or manual
+post-login command owns production
 lifecycle. Setup keeps Codex's built-in `openai` provider and switches only `openai_base_url` after
 required services report healthy and ready. The daemon forwards the authenticated official model
 catalog and appends only the routed models owned by the `chatgpt-web/` namespace; no static catalog

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -2,8 +2,8 @@
 
 ## Trust boundaries
 
-The user trusts the local Codex app, this loopback daemon, the configured Chrome profile, the
-selected ChatGPT workspace, OpenAI's tunnel service, and the exact MCP connector they created.
+The user trusts the local Codex app, this loopback daemon, the configured browser profile, the
+selected ChatGPT workspace, the selected tunnel provider, and the exact MCP connector they created.
 Repository contents, tool output, websites, and prompt text are untrusted data.
 
 ## Full-mode capability flow
@@ -42,6 +42,10 @@ The runtime key needs only Tunnels Read + Use. It is accepted through a hidden p
 from a file, stored with user-only permissions, referenced by file, and never placed in a command
 argument or generated profile. Rotate it after suspected exposure.
 
+Ngrok mode uses ngrok's own user configuration and never copies its authtoken into application
+state. Its public MCP endpoint has no second shared secret; possession of the short-lived random
+turn token is the capability boundary. Use a dedicated stable ngrok URL and do not publish it.
+
 ### Same-user local process
 
 The Responses endpoint is loopback-only, but it has no independent bearer secret because the
@@ -74,9 +78,9 @@ response; the bridge does not fabricate or install a Codex history checkpoint.
 ## Network exposure
 
 - Responses and health listeners bind to `127.0.0.1` only.
-- Full mode uses OpenAI's outbound HTTPS Secure MCP Tunnel; it opens no public listener or inbound
-  firewall rule.
-- Chrome connects to ChatGPT and user-authorized attachment URLs only through its normal browser
+- Full mode uses either OpenAI's outbound HTTPS Secure MCP Tunnel or an outbound ngrok connection.
+  Ngrok publishes the configured HTTPS MCP URL but opens no local inbound firewall rule.
+- The browser connects to ChatGPT and user-authorized attachment URLs only through its normal browser
   networking.
 
 ## Non-goals

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,18 +7,23 @@ BIN_DIR="${CODEX_CHATGPT_WEB_BIN_DIR:-$HOME/.local/bin}"
 LIB_DIR="${CODEX_CHATGPT_WEB_LIB_DIR:-$HOME/.local/lib/codex-chatgpt-web}"
 DOC_DIR="${CODEX_CHATGPT_WEB_DOC_DIR:-$HOME/.local/share/doc/codex-chatgpt-web}"
 
-if [ "$(uname -s)" != "Darwin" ]; then
-  echo "codex-chatgpt-web 0.1 supports macOS only" >&2
+case "$(uname -s)" in
+  Darwin) OS="darwin" ;;
+  Linux) OS="linux" ;;
+  *) echo "Unsupported operating system: $(uname -s)" >&2; exit 1 ;;
+esac
+
+case "$(uname -m)" in
+  arm64|aarch64) ARCH="arm64" ;;
+  x86_64) ARCH="amd64" ;;
+  *) echo "Unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+if [ "$OS" = "linux" ] && [ "$ARCH" = "arm64" ]; then
+  echo "Linux arm64 release assets are not published yet" >&2
   exit 1
 fi
 
-case "$(uname -m)" in
-  arm64) ARCH="arm64" ;;
-  x86_64) ARCH="amd64" ;;
-  *) echo "Unsupported macOS architecture: $(uname -m)" >&2; exit 1 ;;
-esac
-
-ASSET="codex-chatgpt-web-darwin-$ARCH.tar.gz"
+ASSET="codex-chatgpt-web-$OS-$ARCH.tar.gz"
 BASE_URL="https://github.com/$REPOSITORY/releases/download/v$VERSION"
 TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/codex-chatgpt-web.XXXXXX")"
 STAGE_DIR="$LIB_DIR/.stage-$VERSION-$$"
@@ -30,7 +35,11 @@ curl -fsSL "$BASE_URL/$ASSET" -o "$TEMP_DIR/$ASSET"
 curl -fsSL "$BASE_URL/checksums.txt" -o "$TEMP_DIR/checksums.txt"
 
 EXPECTED="$(awk -v asset="$ASSET" '$2 == asset { print $1 }' "$TEMP_DIR/checksums.txt")"
-ACTUAL="$(shasum -a 256 "$TEMP_DIR/$ASSET" | awk '{ print $1 }')"
+if command -v sha256sum >/dev/null 2>&1; then
+  ACTUAL="$(sha256sum "$TEMP_DIR/$ASSET" | awk '{ print $1 }')"
+else
+  ACTUAL="$(shasum -a 256 "$TEMP_DIR/$ASSET" | awk '{ print $1 }')"
+fi
 if [ -z "$EXPECTED" ] || [ "$ACTUAL" != "$EXPECTED" ]; then
   echo "SHA-256 verification failed for $ASSET" >&2
   exit 1
@@ -39,7 +48,11 @@ fi
 for DOC in LICENSE NOTICE.md OpenCodex-MIT.txt Bun-1.3.11.md THIRD_PARTY_NOTICES.txt; do
   curl -fsSL "$BASE_URL/$DOC" -o "$TEMP_DIR/$DOC"
   DOC_EXPECTED="$(awk -v asset="$DOC" '$2 == asset { print $1 }' "$TEMP_DIR/checksums.txt")"
-  DOC_ACTUAL="$(shasum -a 256 "$TEMP_DIR/$DOC" | awk '{ print $1 }')"
+  if command -v sha256sum >/dev/null 2>&1; then
+    DOC_ACTUAL="$(sha256sum "$TEMP_DIR/$DOC" | awk '{ print $1 }')"
+  else
+    DOC_ACTUAL="$(shasum -a 256 "$TEMP_DIR/$DOC" | awk '{ print $1 }')"
+  fi
   if [ -z "$DOC_EXPECTED" ] || [ "$DOC_ACTUAL" != "$DOC_EXPECTED" ]; then
     echo "SHA-256 verification failed for $DOC" >&2
     exit 1

--- a/scripts/smoke-release.ts
+++ b/scripts/smoke-release.ts
@@ -1,6 +1,7 @@
-import { cpSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
+import { fetchLoopback } from "../src/loopback-http";
 
 const sourceBundle = resolve(process.argv[2] ?? "dist/runtime");
 const sourceRoot = resolve(import.meta.dir, "..");
@@ -13,6 +14,9 @@ renameSync(firstLocation, runtimeRoot);
 const launcher = join(runtimeRoot, "bin", "codex-chatgpt-web");
 const cliBundle = readFileSync(join(runtimeRoot, "app", "cli.js"), "utf8");
 const launcherText = readFileSync(launcher, "utf8");
+if (!existsSync(join(runtimeRoot, "app", "node_modules", "playwright-core", "cli.js"))) {
+  throw new Error("Relocatable runtime is missing the Playwright browser installer");
+}
 for (const forbidden of [sourceRoot, dirname(sourceBundle), "/private/tmp/codex-chatgpt-web-verify", "/tmp/codex-chatgpt-web-verify"]) {
   if (cliBundle.includes(forbidden) || launcherText.includes(forbidden)) {
     throw new Error(`Runtime artifact embeds an ephemeral build path: ${forbidden}`);
@@ -63,7 +67,7 @@ try {
   let health: Response | undefined;
   while (Date.now() < deadline) {
     try {
-      health = await fetch(`http://127.0.0.1:${port}/healthz`);
+      health = await fetchLoopback(`http://127.0.0.1:${port}/healthz`);
       if (health.ok) break;
     } catch {}
     await Bun.sleep(50);
@@ -74,30 +78,30 @@ try {
     throw new Error(`unexpected health payload: ${JSON.stringify(payload)}`);
   }
 
-  const unauthenticatedModels = await fetch(`http://127.0.0.1:${port}/v1/models`);
+  const unauthenticatedModels = await fetchLoopback(`http://127.0.0.1:${port}/v1/models`);
   const unauthenticatedModelsBody = await unauthenticatedModels.json() as { error?: { message?: string } };
   if (unauthenticatedModels.status !== 502
     || !unauthenticatedModelsBody.error?.message?.includes("incoming Bearer authorization")) {
     throw new Error(`native model passthrough did not fail closed without Codex auth: ${JSON.stringify(unauthenticatedModelsBody)}`);
   }
-  const websocketNegotiation = await fetch(`http://127.0.0.1:${port}/v1/responses`);
+  const websocketNegotiation = await fetchLoopback(`http://127.0.0.1:${port}/v1/responses`);
   if (websocketNegotiation.status !== 426) {
     throw new Error(`Responses WebSocket negotiation did not select Codex HTTP/SSE fallback: HTTP ${websocketNegotiation.status}`);
   }
-  const invalid = await fetch(`http://127.0.0.1:${port}/v1/responses`, {
+  const invalid = await fetchLoopback(`http://127.0.0.1:${port}/v1/responses`, {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ model: "chatgpt-web/not-enabled", input: "test", stream: false }),
   });
   if (invalid.status !== 400) throw new Error(`unsupported model did not fail closed: HTTP ${invalid.status}`);
 
-  const unauthorizedDrain = await fetch(`http://127.0.0.1:${port}/admin/drain`, {
+  const unauthorizedDrain = await fetchLoopback(`http://127.0.0.1:${port}/admin/drain`, {
     method: "POST",
     headers: { authorization: "Bearer wrong-release-smoke-token" },
   });
   if (unauthorizedDrain.status !== 401) throw new Error(`lifecycle control accepted an invalid token: HTTP ${unauthorizedDrain.status}`);
 
-  const drain = await fetch(`http://127.0.0.1:${port}/admin/drain`, {
+  const drain = await fetchLoopback(`http://127.0.0.1:${port}/admin/drain`, {
     method: "POST",
     headers: { authorization: `Bearer ${config.controlToken}` },
   });
@@ -106,7 +110,7 @@ try {
     || drainPayload.active_http_turns !== 0 || drainPayload.active_browser_turns !== 0) {
     throw new Error(`daemon did not acknowledge an idle authenticated drain: ${JSON.stringify(drainPayload)}`);
   }
-  const rejectedWhileDraining = await fetch(`http://127.0.0.1:${port}/v1/responses`, {
+  const rejectedWhileDraining = await fetchLoopback(`http://127.0.0.1:${port}/v1/responses`, {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ model: "chatgpt-web/high", reasoning: { effort: "high" }, input: "test", stream: false }),
@@ -114,7 +118,7 @@ try {
   if (rejectedWhileDraining.status !== 503) {
     throw new Error(`daemon accepted a new turn while draining: HTTP ${rejectedWhileDraining.status}`);
   }
-  const resume = await fetch(`http://127.0.0.1:${port}/admin/resume`, {
+  const resume = await fetchLoopback(`http://127.0.0.1:${port}/admin/resume`, {
     method: "POST",
     headers: { authorization: `Bearer ${config.controlToken}` },
   });

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -1,8 +1,9 @@
 import { existsSync } from "node:fs";
 import { join, resolve } from "node:path";
-import { chromium, type Browser, type BrowserContext, type Locator, type Page } from "playwright-core";
+import type { Browser, BrowserContext, Locator, Page } from "playwright-core";
 import { atomicWriteFile, expandUserPath, getConfigDir } from "../../config";
 import type { CodexProviderConfig } from "../../types";
+import { browserName, browserType, defaultBrowserExecutable, resolvedBrowserExecutable, type BrowserEngine } from "../../browser-engine";
 import { parseDataUrl } from "../image";
 import { ChatGptMarkdownStream } from "./markdown";
 import { resolveChatGptWebModelMode, type ChatGptWebCapabilities, type ChatGptWebModelMode } from "./model";
@@ -47,7 +48,8 @@ export interface BrowserTurn {
 interface ResolvedBrowserConfig {
   appName: string;
   storageStatePath: string;
-  chromeExecutablePath: string;
+  browserEngine: BrowserEngine;
+  browserExecutablePath: string;
   turnTimeoutMs: number;
   headed: boolean;
   autoApproveToolCalls: boolean;
@@ -237,10 +239,14 @@ export function redactChatGptUiDiagnostic(value: string): string {
 
 function resolveBrowserConfig(provider: CodexProviderConfig): ResolvedBrowserConfig {
   const configured = provider.chatgptWeb ?? {};
+  const browserEngine = configured.browserEngine ?? "chromium";
+  const configuredPath = configured.browserExecutablePath?.trim() || configured.chromeExecutablePath?.trim()
+    || defaultBrowserExecutable(browserEngine);
   return {
     appName: configured.appName?.trim() || "Codex Native",
     storageStatePath: resolve(expandUserPath(configured.storageStatePath?.trim() || join(getConfigDir(), "browser", "storage-state.json"))),
-    chromeExecutablePath: resolve(expandUserPath(configured.chromeExecutablePath?.trim() || "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome")),
+    browserEngine,
+    browserExecutablePath: resolve(expandUserPath(configuredPath || resolvedBrowserExecutable({ browserEngine }))),
     turnTimeoutMs: configured.turnTimeoutMs ?? DEFAULT_CHATGPT_TURN_TIMEOUT_MS,
     headed: configured.headed !== false,
     autoApproveToolCalls: configured.autoApproveToolCalls === true,
@@ -351,11 +357,11 @@ export class ChatGptBrowserWorker {
     if (!existsSync(this.config.storageStatePath) || !existsSync(loginVerificationMarkerPath(this.config.storageStatePath))) {
       throw new Error(`ChatGPT web login state is missing: ${this.config.storageStatePath}`);
     }
-    if (!existsSync(this.config.chromeExecutablePath)) {
-      throw new Error(`Configured Chrome executable does not exist: ${this.config.chromeExecutablePath}`);
+    if (!existsSync(this.config.browserExecutablePath)) {
+      throw new Error(`Configured ${browserName(this.config.browserEngine)} executable does not exist: ${this.config.browserExecutablePath}`);
     }
-    this.browser = await chromium.launch({
-      executablePath: this.config.chromeExecutablePath,
+    this.browser = await browserType(this.config.browserEngine).launch({
+      executablePath: this.config.browserExecutablePath,
       headless: !this.config.headed,
     });
     this.context = await this.browser.newContext({ storageState: this.config.storageStatePath });

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -29,6 +29,11 @@ const browserStageTimeouts = {
   send: 20_000,
 } as const;
 
+export function chatGptComposerTextMatchesPrompt(observed: string, prompt: string): boolean {
+  const canonical = (text: string): string => text.replace(/\r\n?/g, "\n").replaceAll("\n", " ");
+  return canonical(observed) === canonical(prompt);
+}
+
 export interface BrowserTurn {
   traceId: string;
   modelId: string;
@@ -454,7 +459,7 @@ export class ChatGptBrowserWorker {
     let observed = "";
     while (Date.now() < deadline) {
       observed = await this.attachedPromptText(page);
-      if (observed === prompt) return;
+      if (chatGptComposerTextMatchesPrompt(observed, prompt)) return;
       await new Promise(resolveSleep => setTimeout(resolveSleep, 50));
     }
     let commonPrefix = 0;

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -30,7 +30,7 @@ const browserStageTimeouts = {
 } as const;
 
 export function chatGptComposerTextMatchesPrompt(observed: string, prompt: string): boolean {
-  const canonical = (text: string): string => text.replace(/\r\n?/g, "\n").replaceAll("\n", " ");
+  const canonical = (text: string): string => text.replaceAll("\n", " ");
   return canonical(observed) === canonical(prompt);
 }
 

--- a/src/adapters/chatgpt-web/environment.ts
+++ b/src/adapters/chatgpt-web/environment.ts
@@ -78,9 +78,12 @@ function environmentBeforeUser(input: unknown[], userIndex: number, expectedTurn
 
 function sandboxTypeFromEnvironment(text: string): ChatGptSandboxPolicy["type"] | undefined {
   const unrestricted = /<permission_profile\s+type=["']disabled["'][^>]*>[\s\S]*?<file_system\s+type=["']unrestricted["'][^>]*\/?\s*>/i.test(text)
-    || /<sandbox_mode>danger-full-access<\/sandbox_mode>/i.test(text);
-  const workspaceWrite = /<sandbox_mode>workspace-write<\/sandbox_mode>/i.test(text);
-  const readOnly = /<sandbox_mode>read-only<\/sandbox_mode>/i.test(text);
+    || /<sandbox_mode>danger-full-access<\/sandbox_mode>/i.test(text)
+    || /`sandbox_mode`\s+is\s+`danger-full-access`/i.test(text);
+  const workspaceWrite = /<sandbox_mode>workspace-write<\/sandbox_mode>/i.test(text)
+    || /`sandbox_mode`\s+is\s+`workspace-write`/i.test(text);
+  const readOnly = /<sandbox_mode>read-only<\/sandbox_mode>/i.test(text)
+    || /`sandbox_mode`\s+is\s+`read-only`/i.test(text);
   if (Number(unrestricted) + Number(workspaceWrite) + Number(readOnly) !== 1) return undefined;
   return unrestricted ? "dangerFullAccess" : workspaceWrite ? "workspaceWrite" : "readOnly";
 }
@@ -194,12 +197,11 @@ function rawEnvironmentText(parsed: CodexParsedRequest): string | undefined {
 
 function trustedEnvironmentText(parsed: CodexParsedRequest): string {
   const raw = rawEnvironmentText(parsed);
-  if (raw) return raw;
   const system = parsed.context.systemPrompt ?? [];
   const developer = parsed.context.messages
     .filter(message => message.role === "developer")
     .map(message => contentText(message.content));
-  return [...system, ...developer].join("\n");
+  return [raw, ...system, ...developer].filter((value): value is string => typeof value === "string").join("\n");
 }
 
 function decodeXmlText(value: string): string {

--- a/src/adapters/chatgpt-web/mcp-http.ts
+++ b/src/adapters/chatgpt-web/mcp-http.ts
@@ -1,9 +1,27 @@
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import { timingSafeEqual } from "node:crypto";
 import { createChatGptMcpServer } from "./mcp-server";
+
+function tokenMatches(actual: string | undefined, expected: string): boolean {
+  if (actual === undefined) return false;
+  const actualBytes = Buffer.from(actual);
+  const expectedBytes = Buffer.from(expected);
+  return actualBytes.length === expectedBytes.length && timingSafeEqual(actualBytes, expectedBytes);
+}
+
+function requestAccessToken(request: Request, url: URL): string | undefined {
+  const authorization = request.headers.get("authorization");
+  if (authorization !== null) {
+    const match = /^Bearer ([A-Za-z0-9_-]+)$/.exec(authorization);
+    return match?.[1];
+  }
+  return url.searchParams.get("access_token") ?? undefined;
+}
 
 export function startChatGptMcpHttpServer(options: {
   brokerSocketPath: string;
   port: number;
+  accessToken: string;
 }): ReturnType<typeof Bun.serve> {
   return Bun.serve({
     hostname: "127.0.0.1",
@@ -12,6 +30,16 @@ export function startChatGptMcpHttpServer(options: {
       const url = new URL(request.url);
       if (url.pathname === "/healthz") return Response.json({ status: "ok", service: "codex-chatgpt-web-mcp" });
       if (url.pathname !== "/mcp") return new Response("Not found", { status: 404 });
+      if (!tokenMatches(requestAccessToken(request, url), options.accessToken)) {
+        return Response.json({
+          jsonrpc: "2.0",
+          error: { code: -32001, message: "Unauthorized." },
+          id: null,
+        }, {
+          status: 401,
+          headers: { "www-authenticate": "Bearer" },
+        });
+      }
       if (request.method !== "POST") {
         return Response.json({
           jsonrpc: "2.0",

--- a/src/adapters/chatgpt-web/mcp-http.ts
+++ b/src/adapters/chatgpt-web/mcp-http.ts
@@ -1,0 +1,48 @@
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import { createChatGptMcpServer } from "./mcp-server";
+
+export function startChatGptMcpHttpServer(options: {
+  brokerSocketPath: string;
+  port: number;
+}): ReturnType<typeof Bun.serve> {
+  return Bun.serve({
+    hostname: "127.0.0.1",
+    port: options.port,
+    async fetch(request) {
+      const url = new URL(request.url);
+      if (url.pathname === "/healthz") return Response.json({ status: "ok", service: "codex-chatgpt-web-mcp" });
+      if (url.pathname !== "/mcp") return new Response("Not found", { status: 404 });
+      if (request.method !== "POST") {
+        return Response.json({
+          jsonrpc: "2.0",
+          error: { code: -32000, message: "Method not allowed." },
+          id: null,
+        }, { status: 405 });
+      }
+
+      const server = createChatGptMcpServer({ brokerSocketPath: options.brokerSocketPath });
+      const transport = new WebStandardStreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,
+        enableJsonResponse: true,
+      });
+      try {
+        await server.connect(transport);
+        const response = await transport.handleRequest(request);
+        const body = await response.arrayBuffer();
+        await server.close();
+        return new Response(body, {
+          status: response.status,
+          statusText: response.statusText,
+          headers: response.headers,
+        });
+      } catch (error) {
+        await server.close().catch(() => {});
+        return Response.json({
+          jsonrpc: "2.0",
+          error: { code: -32603, message: error instanceof Error ? error.message : "Internal server error" },
+          id: null,
+        }, { status: 500 });
+      }
+    },
+  });
+}

--- a/src/adapters/chatgpt-web/mcp-server.ts
+++ b/src/adapters/chatgpt-web/mcp-server.ts
@@ -121,7 +121,7 @@ function execGatewayProgram(
   ].join("\n");
 }
 
-export async function runChatGptMcpServer(options: { brokerSocketPath: string }): Promise<void> {
+export function createChatGptMcpServer(options: { brokerSocketPath: string }): McpServer {
   const server = new McpServer({ name: "codex-native", version: "3.0.0" });
 
   const environment = async (bindingId: string): Promise<ChatGptTurnEnvironment & { expiresAt: number }> => {
@@ -377,5 +377,9 @@ export async function runChatGptMcpServer(options: { brokerSocketPath: string })
     },
   );
 
-  await server.connect(new StdioServerTransport());
+  return server;
+}
+
+export async function runChatGptMcpServer(options: { brokerSocketPath: string }): Promise<void> {
+  await createChatGptMcpServer(options).connect(new StdioServerTransport());
 }

--- a/src/adapters/chatgpt-web/prompt.ts
+++ b/src/adapters/chatgpt-web/prompt.ts
@@ -121,6 +121,7 @@ export function compileChatGptWebPrompt(
       `After emitting ${CHATGPT_INTERNAL_COMPACTION_MARKER}, call codex_bind_turn again with the same turn_token before any other action; claiming the same active turn again is intentional and idempotent.`,
       "Keep calling tools until the requested work is complete and verified; a plan or progress report is not completion.",
       "Use codex_apply_patch for targeted edits, codex_exec for commands, and codex_write_stdin for sessions returned by codex_exec.",
+      "Do not use nested local-agent workspace connectors such as CodexPro or Yahee open_workspace and handoff tools for the current workspace; they recurse into another connector instead of accessing the local Codex runtime. Use codex_exec and codex_apply_patch directly.",
       "Use codex_tool_inventory and codex_tool_call for any other tool advertised by the current Codex harness, including configured MCP/apps.",
       "Codex Native synchronously bridges each plugin action into the same outer Codex turn; wait for its real result before continuing.",
       "Never serialize a proposed tool call as assistant text. Make the actual MCP call and use its real result.",

--- a/src/browser-engine.ts
+++ b/src/browser-engine.ts
@@ -1,0 +1,49 @@
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium, firefox } from "playwright-core";
+import { runChecked } from "./process";
+
+export type BrowserEngine = "chromium" | "firefox";
+
+export function browserName(engine: BrowserEngine): string {
+  return engine === "firefox" ? "Firefox" : "Chromium";
+}
+
+export function browserType(engine: BrowserEngine): typeof chromium | typeof firefox {
+  return engine === "firefox" ? firefox : chromium;
+}
+
+export function defaultBrowserExecutable(engine: BrowserEngine): string | undefined {
+  if (engine === "firefox") return undefined;
+  if (process.platform === "darwin") return "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+  if (process.platform === "win32") {
+    return join(process.env.PROGRAMFILES || "C:\\Program Files", "Google", "Chrome", "Application", "chrome.exe");
+  }
+  return "/usr/bin/google-chrome";
+}
+
+export function resolvedBrowserExecutable(config: {
+  browserEngine: BrowserEngine;
+  browserExecutablePath?: string;
+}): string {
+  return config.browserExecutablePath || browserType(config.browserEngine).executablePath();
+}
+
+export function ensureBrowserExecutable(config: {
+  browserEngine: BrowserEngine;
+  browserExecutablePath?: string;
+}): string {
+  let executable = resolvedBrowserExecutable(config);
+  if (existsSync(executable)) return executable;
+  if (config.browserEngine !== "firefox" || config.browserExecutablePath) {
+    throw new Error(`${browserName(config.browserEngine)} was not found at ${executable}. Pass --browser-path with its executable path.`);
+  }
+
+  const packageEntry = fileURLToPath(import.meta.resolve("playwright-core"));
+  const cli = join(dirname(packageEntry), "cli.js");
+  runChecked(process.execPath, [cli, "install", "firefox"], { stdio: "inherit" });
+  executable = resolvedBrowserExecutable(config);
+  if (!existsSync(executable)) throw new Error(`Playwright did not install Firefox at ${executable}`);
+  return executable;
+}

--- a/src/browser-login.ts
+++ b/src/browser-login.ts
@@ -91,13 +91,14 @@ export async function loginToChatGpt(
   options: { timeoutMs?: number } = {},
 ): Promise<BrowserLoginResult> {
   const executable = ensureBrowserExecutable(config);
+  const loginExecutable = normalLoginBrowserExecutable(config.browserEngine, executable);
   const name = browserName(config.browserEngine);
   const profileDir = join(dirname(config.storageStatePath), "login-profile");
   mkdirSync(profileDir, { recursive: true, mode: 0o700 });
   process.stdout.write(
     `A normal ${name} window is open. Sign in to ChatGPT, confirm that the composer is visible, then quit this dedicated ${name} instance completely.\n`,
   );
-  const loginBrowser = spawn(executable, browserLoginArguments(config.browserEngine, profileDir), { env: process.env, stdio: "ignore" });
+  const loginBrowser = spawn(loginExecutable, browserLoginArguments(config.browserEngine, profileDir), { env: process.env, stdio: "ignore" });
   const loginExit = await new Promise<number>((resolveExit, rejectExit) => {
     loginBrowser.once("error", rejectExit);
     loginBrowser.once("exit", (code, signal) => {
@@ -141,6 +142,16 @@ export async function loginToChatGpt(
     await context.close();
     if (browserLoginStateExists(config)) rmSync(profileDir, { recursive: true, force: true });
   }
+}
+
+export function normalLoginBrowserExecutable(
+  engine: BrowserEngine,
+  automationExecutable: string,
+  platform = process.platform,
+  linuxFirefoxPath = "/usr/bin/firefox",
+): string {
+  if (engine === "firefox" && platform === "linux" && existsSync(linuxFirefoxPath)) return linuxFirefoxPath;
+  return automationExecutable;
 }
 
 export function browserLoginArguments(engine: BrowserEngine, profileDir: string): string[] {

--- a/src/browser-login.ts
+++ b/src/browser-login.ts
@@ -1,9 +1,10 @@
 import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { chromium, type BrowserContextOptions } from "playwright-core";
+import type { BrowserContextOptions } from "playwright-core";
 import type { AppConfig } from "./config";
 import { atomicWriteFile } from "./config";
+import { browserName, browserType, ensureBrowserExecutable, type BrowserEngine } from "./browser-engine";
 import {
   assertAuthenticatedChatGptPage,
   assertTemporaryChatPage,
@@ -42,11 +43,14 @@ async function inspectStoredState(
   config: AppConfig,
   storageState: NonNullable<BrowserContextOptions["storageState"]>,
 ): Promise<{ proAvailable: boolean; url: string }> {
-  const verifierBrowser = await chromium.launch({
-    executablePath: config.chromeExecutablePath,
+  const engine = browserType(config.browserEngine);
+  const verifierBrowser = await engine.launch({
+    executablePath: ensureBrowserExecutable(config),
     headless: false,
-    ignoreDefaultArgs: ["--password-store=basic", "--use-mock-keychain"],
-    args: ["--no-first-run", "--no-default-browser-check"],
+    ...(config.browserEngine === "chromium" ? {
+      ignoreDefaultArgs: ["--password-store=basic", "--use-mock-keychain"],
+      args: ["--no-first-run", "--no-default-browser-check"],
+    } : {}),
   });
   try {
     const verifierContext = await verifierBrowser.newContext({ storageState });
@@ -86,36 +90,30 @@ export async function loginToChatGpt(
   config: AppConfig,
   options: { timeoutMs?: number } = {},
 ): Promise<BrowserLoginResult> {
-  if (!existsSync(config.chromeExecutablePath)) {
-    throw new Error(`Google Chrome was not found at ${config.chromeExecutablePath}. Pass --chrome with its executable path.`);
-  }
+  const executable = ensureBrowserExecutable(config);
+  const name = browserName(config.browserEngine);
   const profileDir = join(dirname(config.storageStatePath), "login-profile");
   mkdirSync(profileDir, { recursive: true, mode: 0o700 });
   process.stdout.write(
-    "A normal Chrome window is open. Sign in to ChatGPT, confirm that the composer is visible, then quit this dedicated Chrome instance completely.\n",
+    `A normal ${name} window is open. Sign in to ChatGPT, confirm that the composer is visible, then quit this dedicated ${name} instance completely.\n`,
   );
-  const loginBrowser = spawn(config.chromeExecutablePath, [
-    `--user-data-dir=${profileDir}`,
-    "--new-window",
-    "--disable-background-mode",
-    "--no-first-run",
-    "--no-default-browser-check",
-    CHATGPT_TEMPORARY_CHAT_URL,
-  ], { env: process.env, stdio: "ignore" });
+  const loginBrowser = spawn(executable, browserLoginArguments(config.browserEngine, profileDir), { env: process.env, stdio: "ignore" });
   const loginExit = await new Promise<number>((resolveExit, rejectExit) => {
     loginBrowser.once("error", rejectExit);
     loginBrowser.once("exit", (code, signal) => {
-      if (signal) rejectExit(new Error(`Normal Chrome login window exited from signal ${signal}`));
+      if (signal) rejectExit(new Error(`Normal ${name} login window exited from signal ${signal}`));
       else resolveExit(code ?? 1);
     });
   });
-  if (loginExit !== 0) throw new Error(`Normal Chrome login window exited with status ${loginExit}`);
+  if (loginExit !== 0) throw new Error(`Normal ${name} login window exited with status ${loginExit}`);
 
-  const context = await chromium.launchPersistentContext(profileDir, {
-    executablePath: config.chromeExecutablePath,
+  const context = await browserType(config.browserEngine).launchPersistentContext(profileDir, {
+    executablePath: executable,
     headless: false,
-    ignoreDefaultArgs: ["--password-store=basic", "--use-mock-keychain"],
-    args: ["--no-first-run", "--no-default-browser-check"],
+    ...(config.browserEngine === "chromium" ? {
+      ignoreDefaultArgs: ["--password-store=basic", "--use-mock-keychain"],
+      args: ["--no-first-run", "--no-default-browser-check"],
+    } : {}),
   });
   try {
     const page = context.pages()[0] ?? await context.newPage();
@@ -145,6 +143,19 @@ export async function loginToChatGpt(
   }
 }
 
+export function browserLoginArguments(engine: BrowserEngine, profileDir: string): string[] {
+  return engine === "firefox"
+    ? ["-no-remote", "-profile", profileDir, "-new-window", CHATGPT_TEMPORARY_CHAT_URL]
+    : [
+        `--user-data-dir=${profileDir}`,
+        "--new-window",
+        "--disable-background-mode",
+        "--no-first-run",
+        "--no-default-browser-check",
+        CHATGPT_TEMPORARY_CHAT_URL,
+      ];
+}
+
 export function browserLoginStateExists(config: AppConfig): boolean {
   if (!existsSync(config.storageStatePath)) return false;
   const markerPath = loginVerificationMarkerPath(config.storageStatePath);
@@ -158,11 +169,10 @@ export function browserLoginStateExists(config: AppConfig): boolean {
 }
 
 export async function checkBrowserEngine(config: AppConfig): Promise<void> {
-  if (!existsSync(config.chromeExecutablePath)) throw new Error(`Google Chrome was not found at ${config.chromeExecutablePath}`);
-  const browser = await chromium.launch({
-    executablePath: config.chromeExecutablePath,
+  const browser = await browserType(config.browserEngine).launch({
+    executablePath: ensureBrowserExecutable(config),
     headless: true,
-    args: ["--no-first-run", "--no-default-browser-check"],
+    ...(config.browserEngine === "chromium" ? { args: ["--no-first-run", "--no-default-browser-check"] } : {}),
   });
   try {
     const page = await browser.newPage();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -47,6 +47,7 @@ Setup options:
   --tunnel-provider PROVIDER   openai or ngrok (default: openai)
   --ngrok-path PATH            ngrok executable
   --ngrok-url URL              Stable HTTPS ngrok endpoint
+  --rotate-mcp-token           Replace the MCP connector access token
   --replace-codex-route        Reversibly replace an existing openai_base_url
   --restart-service            Explicitly restart this project's daemon after an update
   --login                      Refresh the stored ChatGPT login even if one exists
@@ -143,6 +144,7 @@ async function setupCommand(args: string[]): Promise<void> {
   if (ngrokPath) options.ngrokPath = ngrokPath;
   if (ngrokUrl) options.ngrokUrl = ngrokUrl;
   if (appName) options.appName = appName;
+  options.rotateMcpAccessToken = takeFlag(args, "--rotate-mcp-token");
   if (tunnelId) options.tunnelId = tunnelId;
   if (runtimeKeyFile) options.runtimeKeyFile = runtimeKeyFile;
   options.forceLogin = takeFlag(args, "--login");
@@ -331,7 +333,13 @@ async function main(): Promise<void> {
     if (!binaryPath || !brokerSocketPath || !url || !Number.isInteger(port)) {
       throw new Error("ngrok-tunnel requires --ngrok, --broker-socket, --port, and --url");
     }
-    await runNgrokRuntime({ binaryPath, brokerSocketPath, port, url });
+    await runNgrokRuntime({
+      binaryPath,
+      brokerSocketPath,
+      port,
+      url,
+      accessToken: loadConfig().mcpAccessToken,
+    });
   }
   else if (command === "service") await serviceCommand(args);
   else if (command === "tunnel") await tunnelCommand(args);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,7 @@ import { existingFullSetupCredentials, setup, type SetupOptions } from "./setup"
 import { installRuntimeKeyBytes, managedRuntimeKeyPath, stopTunnel, tunnelStatus, waitForTunnelReady } from "./tunnel";
 import { getTunnelServiceStatus, restartTunnelService, startTunnelService, stopTunnelService, uninstallTunnelService } from "./tunnel-service";
 import { VERSION } from "./version";
+import { runNgrokRuntime } from "./ngrok-runtime";
 
 const HELP = `codex-chatgpt-web ${VERSION}
 
@@ -38,9 +39,14 @@ Setup options:
   --full                       Fixed Instant–Extra High tool models plus read-only Pro
   --port NUMBER                Loopback Responses port (default: 17841)
   --chrome PATH                Google Chrome executable
+  --browser ENGINE             chromium or firefox (default: chromium)
+  --browser-path PATH          Explicit browser executable
   --app-name NAME              ChatGPT connector name (default: Codex Native)
   --tunnel-id ID               Existing OpenAI tunnel id (full mode)
   --runtime-key-file PATH      File containing a Tunnels Read+Use runtime key
+  --tunnel-provider PROVIDER   openai or ngrok (default: openai)
+  --ngrok-path PATH            ngrok executable
+  --ngrok-url URL              Stable HTTPS ngrok endpoint
   --replace-codex-route        Reversibly replace an existing openai_base_url
   --restart-service            Explicitly restart this project's daemon after an update
   --login                      Refresh the stored ChatGPT login even if one exists
@@ -117,7 +123,25 @@ async function setupCommand(args: string[]): Promise<void> {
   const tunnelId = takeOption(args, "--tunnel-id");
   const runtimeKeyFile = takeOption(args, "--runtime-key-file");
   const chrome = takeOption(args, "--chrome");
-  if (chrome) options.chromeExecutablePath = chrome;
+  const browser = takeOption(args, "--browser");
+  const browserPath = takeOption(args, "--browser-path");
+  const tunnelProvider = takeOption(args, "--tunnel-provider");
+  const ngrokPath = takeOption(args, "--ngrok-path");
+  const ngrokUrl = takeOption(args, "--ngrok-url");
+  if (browser && browser !== "chromium" && browser !== "firefox") throw new Error("--browser must be chromium or firefox");
+  if (tunnelProvider && tunnelProvider !== "openai" && tunnelProvider !== "ngrok") {
+    throw new Error("--tunnel-provider must be openai or ngrok");
+  }
+  if (chrome && (browser || browserPath)) throw new Error("--chrome cannot be combined with --browser or --browser-path");
+  if (chrome) {
+    options.browserEngine = "chromium";
+    options.browserExecutablePath = chrome;
+  }
+  if (browser) options.browserEngine = browser as "chromium" | "firefox";
+  if (browserPath) options.browserExecutablePath = browserPath;
+  if (tunnelProvider) options.tunnelProvider = tunnelProvider as "openai" | "ngrok";
+  if (ngrokPath) options.ngrokPath = ngrokPath;
+  if (ngrokUrl) options.ngrokUrl = ngrokUrl;
   if (appName) options.appName = appName;
   if (tunnelId) options.tunnelId = tunnelId;
   if (runtimeKeyFile) options.runtimeKeyFile = runtimeKeyFile;
@@ -144,7 +168,8 @@ async function setupCommand(args: string[]): Promise<void> {
     && !reusableCredentials.runtimeKey
     && !existsSync(managedRuntimeKeyPath());
 
-  if (full && (needsTunnelId || needsRuntimeKey) && stdin.isTTY) {
+  const selectedTunnelProvider = options.tunnelProvider ?? existing?.tunnel?.provider ?? "openai";
+  if (full && selectedTunnelProvider === "openai" && (needsTunnelId || needsRuntimeKey) && stdin.isTTY) {
     stdout.write("Full mode needs an OpenAI tunnel and a runtime key with Tunnels Read + Use.\n");
     stdout.write("Tunnels: https://platform.openai.com/settings/organization/tunnels\n");
     stdout.write("Runtime keys: https://platform.openai.com/settings/organization/api-keys\n");
@@ -159,6 +184,7 @@ async function setupCommand(args: string[]): Promise<void> {
   stdout.write(`Config: ${result.configPath}\n`);
   if (result.connectorSetupRequired) {
     stdout.write("One account-level step remains: attach the tunnel to the ChatGPT connector named in config.\n");
+    if (result.connectorEndpoint) stdout.write(`Connector endpoint: ${result.connectorEndpoint}\n`);
     stdout.write("Open: https://chatgpt.com/#settings/Connectors\n");
   }
   stdout.write("Restart the Codex app once so its native model catalog refreshes through the installed route.\n");
@@ -247,16 +273,17 @@ async function uninstallCommand(args: string[]): Promise<void> {
     throw new Error("Uninstall cancelled");
   }
   const config = existsSync(getConfigPath()) ? loadConfig() : undefined;
-  if (!config && process.platform === "darwin" && getServiceStatus().installed) {
+  const managedPlatform = process.platform === "darwin" || process.platform === "linux";
+  if (!config && managedPlatform && getServiceStatus().installed) {
     throw new Error("Service exists but configuration is missing; refusing an unverifiable uninstall");
   }
-  if (config && process.platform === "darwin") await assertServiceIdle(config);
+  if (config && managedPlatform) await assertServiceIdle(config);
   uninstallCodexIntegration();
   if (config?.mode === "full") {
-    if (process.platform === "darwin") await uninstallTunnelService();
+    if (managedPlatform) await uninstallTunnelService();
     stopTunnel(config);
   }
-  if (config && process.platform === "darwin") await uninstallService(config);
+  if (config && managedPlatform) await uninstallService(config);
   if (!keepData) rmSync(getConfigDir(), { recursive: true, force: true });
   stdout.write(keepData ? "Uninstalled; private application data was preserved.\n" : "Uninstalled and removed private application data.\n");
 }
@@ -285,8 +312,9 @@ async function main(): Promise<void> {
     const action = args.shift();
     assertNoArgs(args);
     if (action !== "check") throw new Error("Browser command must be: browser check");
-    await checkBrowserEngine(loadConfig());
-    stdout.write("Playwright can launch the configured Chrome executable.\n");
+    const config = loadConfig();
+    await checkBrowserEngine(config);
+    stdout.write(`Playwright can launch the configured ${config.browserEngine} browser.\n`);
   } else if (command === "serve") {
     assertNoArgs(args);
     const config = loadConfig();
@@ -294,6 +322,17 @@ async function main(): Promise<void> {
     stdout.write(`codex-chatgpt-web ${VERSION} listening on http://${config.host}:${server.port}/v1 (${config.mode})\n`);
     await new Promise<void>(() => {});
   } else if (command === "mcp") await runChatGptMcpMain(args);
+  else if (command === "ngrok-tunnel") {
+    const binaryPath = takeOption(args, "--ngrok");
+    const brokerSocketPath = takeOption(args, "--broker-socket");
+    const port = Number(takeOption(args, "--port"));
+    const url = takeOption(args, "--url");
+    assertNoArgs(args);
+    if (!binaryPath || !brokerSocketPath || !url || !Number.isInteger(port)) {
+      throw new Error("ngrok-tunnel requires --ngrok, --broker-socket, --port, and --url");
+    }
+    await runNgrokRuntime({ binaryPath, brokerSocketPath, port, url });
+  }
   else if (command === "service") await serviceCommand(args);
   else if (command === "tunnel") await tunnelCommand(args);
   else if (command === "open") await openCommand(args);

--- a/src/config.ts
+++ b/src/config.ts
@@ -52,6 +52,7 @@ export interface AppConfig {
   proAvailable: boolean;
   autoApproveToolCalls: boolean;
   controlToken: string;
+  mcpAccessToken: string;
   runtimeCommand: string[];
   acknowledgedUnofficialAt?: string;
   tunnel?: TunnelConfig;
@@ -108,6 +109,7 @@ export function defaultConfig(mode: RuntimeMode = "browser-only"): AppConfig {
     proAvailable: false,
     autoApproveToolCalls: false,
     controlToken: randomBytes(32).toString("base64url"),
+    mcpAccessToken: randomBytes(32).toString("base64url"),
     runtimeCommand: currentRuntimeCommand(),
   };
 }
@@ -165,6 +167,9 @@ export function loadConfigForSetup(): AppConfig {
     raw.version = 2;
     raw.mode = "browser-only";
   }
+  if (raw.version === 2 && typeof raw.mcpAccessToken !== "string") {
+    raw.mcpAccessToken = randomBytes(32).toString("base64url");
+  }
   return parseConfig(raw, path);
 }
 
@@ -190,12 +195,13 @@ function parseConfig(value: unknown, path: string): AppConfig {
   if (parsed.host !== "127.0.0.1") throw new Error("The Responses proxy must bind to 127.0.0.1");
   if (!Number.isInteger(parsed.port) || parsed.port! < 1 || parsed.port! > 65_535) throw new Error(`Invalid port in ${path}`);
   const requiredStrings: Array<keyof AppConfig> = [
-    "appName", "storageStatePath", "brokerSocketPath", "controlToken",
+    "appName", "storageStatePath", "brokerSocketPath", "controlToken", "mcpAccessToken",
   ];
   for (const key of requiredStrings) {
     if (typeof parsed[key] !== "string" || !(parsed[key] as string).trim()) throw new Error(`Missing ${key} in ${path}`);
   }
   if (!/^[A-Za-z0-9_-]{40,}$/.test(parsed.controlToken!)) throw new Error(`Invalid controlToken in ${path}`);
+  if (!/^[A-Za-z0-9_-]{40,}$/.test(parsed.mcpAccessToken!)) throw new Error(`Invalid mcpAccessToken in ${path}`);
   if (parsed.mode === "full" && !parsed.tunnel) throw new Error("Full mode requires tunnel configuration");
   if (parsed.tunnel && !(parsed.tunnel as { provider?: string }).provider) {
     (parsed.tunnel as { provider: string }).provider = "openai";

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,16 +5,35 @@ import { basename, dirname, isAbsolute, join, resolve, sep } from "node:path";
 import { tmpdir } from "node:os";
 import type { CodexProviderConfig } from "./types";
 import { VERSION } from "./version";
+import { defaultBrowserExecutable, type BrowserEngine } from "./browser-engine";
 
 export type RuntimeMode = "browser-only" | "full";
 
-export interface TunnelConfig {
+export interface OpenAiTunnelConfig {
+  provider: "openai";
   binaryPath: string;
   tunnelId: string;
   runtimeKeyFile: string;
   profileDir: string;
   profileName: string;
   alias: string;
+}
+
+export interface NgrokTunnelConfig {
+  provider: "ngrok";
+  binaryPath: string;
+  url: string;
+  port: number;
+}
+
+export type TunnelConfig = OpenAiTunnelConfig | NgrokTunnelConfig;
+
+export function isOpenAiTunnel(tunnel: TunnelConfig): tunnel is OpenAiTunnelConfig {
+  return tunnel.provider === "openai";
+}
+
+export function isNgrokTunnel(tunnel: TunnelConfig): tunnel is NgrokTunnelConfig {
+  return tunnel.provider === "ngrok";
 }
 
 export interface AppConfig {
@@ -25,7 +44,8 @@ export interface AppConfig {
   port: number;
   contextWindow: number;
   appName: string;
-  chromeExecutablePath: string;
+  browserEngine: BrowserEngine;
+  browserExecutablePath?: string;
   storageStatePath: string;
   brokerSocketPath: string;
   headed: boolean;
@@ -80,7 +100,8 @@ export function defaultConfig(mode: RuntimeMode = "browser-only"): AppConfig {
     port: 17841,
     contextWindow: 256_000,
     appName: "Codex Native",
-    chromeExecutablePath: defaultChromeExecutable(),
+    browserEngine: "chromium",
+    browserExecutablePath: defaultBrowserExecutable("chromium"),
     storageStatePath: join(home, "browser", "storage-state.json"),
     brokerSocketPath: join(home, "runtime", "turn-broker.sock"),
     headed: true,
@@ -130,16 +151,6 @@ export function assertDurableRuntimeCommand(command: string[]): void {
   if (!existsSync(executable)) throw new Error(`Runtime executable does not exist: ${executable}`);
 }
 
-function defaultChromeExecutable(): string {
-  if (process.platform === "darwin") {
-    return "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
-  }
-  if (process.platform === "win32") {
-    return join(process.env.PROGRAMFILES || "C:\\Program Files", "Google", "Chrome", "Application", "chrome.exe");
-  }
-  return "/usr/bin/google-chrome";
-}
-
 export function loadConfig(): AppConfig {
   const path = getConfigPath();
   if (!existsSync(path)) throw new Error(`Configuration is missing: ${path}. Run codex-chatgpt-web setup first.`);
@@ -159,20 +170,39 @@ export function loadConfigForSetup(): AppConfig {
 
 function parseConfig(value: unknown, path: string): AppConfig {
   if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`Invalid configuration object in ${path}`);
-  const parsed = value as Partial<AppConfig>;
+  const parsed = value as Partial<AppConfig> & { chromeExecutablePath?: unknown };
+  if (parsed.browserEngine === undefined) parsed.browserEngine = "chromium";
+  if (parsed.browserExecutablePath === undefined && typeof parsed.chromeExecutablePath === "string") {
+    parsed.browserExecutablePath = parsed.chromeExecutablePath;
+  }
+  delete parsed.chromeExecutablePath;
   if (parsed.version !== 2) throw new Error(`Unsupported configuration version in ${path}; rerun setup to migrate it`);
   if (typeof parsed.releaseVersion !== "string" || !parsed.releaseVersion.trim()) throw new Error(`Missing releaseVersion in ${path}`);
   if (parsed.mode !== "browser-only" && parsed.mode !== "full") throw new Error(`Invalid runtime mode in ${path}`);
+  if (parsed.browserEngine !== "chromium" && parsed.browserEngine !== "firefox") throw new Error(`Invalid browserEngine in ${path}`);
+  if (parsed.browserExecutablePath !== undefined
+    && (typeof parsed.browserExecutablePath !== "string" || !parsed.browserExecutablePath.trim())) {
+    throw new Error(`Invalid browserExecutablePath in ${path}`);
+  }
+  if (parsed.browserEngine === "chromium" && !parsed.browserExecutablePath) {
+    throw new Error(`Missing browserExecutablePath in ${path}`);
+  }
   if (parsed.host !== "127.0.0.1") throw new Error("The Responses proxy must bind to 127.0.0.1");
   if (!Number.isInteger(parsed.port) || parsed.port! < 1 || parsed.port! > 65_535) throw new Error(`Invalid port in ${path}`);
   const requiredStrings: Array<keyof AppConfig> = [
-    "appName", "chromeExecutablePath", "storageStatePath", "brokerSocketPath", "controlToken",
+    "appName", "storageStatePath", "brokerSocketPath", "controlToken",
   ];
   for (const key of requiredStrings) {
     if (typeof parsed[key] !== "string" || !(parsed[key] as string).trim()) throw new Error(`Missing ${key} in ${path}`);
   }
   if (!/^[A-Za-z0-9_-]{40,}$/.test(parsed.controlToken!)) throw new Error(`Invalid controlToken in ${path}`);
   if (parsed.mode === "full" && !parsed.tunnel) throw new Error("Full mode requires tunnel configuration");
+  if (parsed.tunnel && !(parsed.tunnel as { provider?: string }).provider) {
+    (parsed.tunnel as { provider: string }).provider = "openai";
+  }
+  if (parsed.tunnel && parsed.tunnel.provider !== "openai" && parsed.tunnel.provider !== "ngrok") {
+    throw new Error(`Invalid tunnel provider in ${path}`);
+  }
   if (!Array.isArray(parsed.runtimeCommand) || parsed.runtimeCommand.length === 0
     || parsed.runtimeCommand.some(part => typeof part !== "string" || !part.trim())) {
     throw new Error(`Invalid runtimeCommand in ${path}`);
@@ -205,7 +235,8 @@ export function providerConfig(config: AppConfig): CodexProviderConfig {
     chatgptWeb: {
       appName: config.appName,
       storageStatePath: config.storageStatePath,
-      chromeExecutablePath: config.chromeExecutablePath,
+      browserEngine: config.browserEngine,
+      browserExecutablePath: config.browserExecutablePath,
       brokerSocketPath: config.brokerSocketPath,
       threadEnvironmentStatePath: join(getConfigDir(), "runtime", "thread-environments.json"),
       headed: config.headed,

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -6,6 +6,9 @@ import { browserLoginStateExists, loginVerificationMarkerPath } from "./browser-
 import { getServiceStatus } from "./service";
 import { tunnelStatus } from "./tunnel";
 import { getTunnelServiceStatus } from "./tunnel-service";
+import { browserName, resolvedBrowserExecutable } from "./browser-engine";
+import { isNgrokTunnel } from "./config";
+import { fetchLoopback } from "./loopback-http";
 
 export type CheckStatus = "ok" | "warning" | "error";
 
@@ -31,7 +34,7 @@ async function proxyCheck(config: AppConfig): Promise<DoctorCheck> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 2_000);
   try {
-    const response = await fetch(`http://${config.host}:${config.port}/healthz`, { signal: controller.signal });
+    const response = await fetchLoopback(`http://${config.host}:${config.port}/healthz`, { signal: controller.signal });
     if (!response.ok) return { id: "proxy", status: "error", message: `Responses proxy returned HTTP ${response.status}` };
     const body = await response.json() as Record<string, unknown>;
     if (body.service !== "codex-chatgpt-web" || body.status !== "ok") {
@@ -63,10 +66,12 @@ export async function runDoctor(): Promise<DoctorReport> {
     return { ok: false, checks };
   }
 
-  if (!existsSync(config.chromeExecutablePath)) {
-    checks.push({ id: "chrome", status: "error", message: `Chrome executable is missing: ${config.chromeExecutablePath}` });
+  const name = browserName(config.browserEngine);
+  const browserPath = resolvedBrowserExecutable(config);
+  if (!existsSync(browserPath)) {
+    checks.push({ id: "browser", status: "error", message: `${name} executable is missing: ${browserPath}` });
   } else {
-    checks.push({ id: "chrome", status: "ok", message: `Chrome executable found: ${config.chromeExecutablePath}` });
+    checks.push({ id: "browser", status: "ok", message: `${name} browser is configured: ${browserPath}` });
   }
   if (!browserLoginStateExists(config)) {
     checks.push({ id: "login", status: "error", message: "ChatGPT login state is missing or unverified; run `codex-chatgpt-web login`" });
@@ -91,30 +96,30 @@ export async function runDoctor(): Promise<DoctorReport> {
   if (!service.supported) {
     checks.push({ id: "service", status: "warning", message: "Managed service is unavailable on this OS; keep `serve` running manually" });
   } else if (!service.installed || !service.loaded) {
-    checks.push({ id: "service", status: "error", message: "macOS background service is not installed and loaded" });
+    checks.push({ id: "service", status: "error", message: "Managed background service is not installed and loaded" });
   } else {
-    checks.push({ id: "service", status: "ok", message: "macOS background service is loaded" });
+    checks.push({ id: "service", status: "ok", message: "Managed background service is loaded" });
   }
   checks.push(await proxyCheck(config));
 
   if (config.mode === "full") {
     const settings = config.tunnel!;
     if (!existsSync(settings.binaryPath)) {
-      checks.push({ id: "tunnel-binary", status: "error", message: `tunnel-client is missing: ${settings.binaryPath}` });
+      checks.push({ id: "tunnel-binary", status: "error", message: `${isNgrokTunnel(settings) ? "ngrok" : "tunnel-client"} is missing: ${settings.binaryPath}` });
     } else {
-      checks.push({ id: "tunnel-binary", status: "ok", message: "Pinned openai/tunnel-client binary is installed" });
+      checks.push({ id: "tunnel-binary", status: "ok", message: isNgrokTunnel(settings) ? "ngrok binary is installed" : "Pinned openai/tunnel-client binary is installed" });
     }
-    if (!existsSync(settings.runtimeKeyFile)) {
+    if (!isNgrokTunnel(settings) && !existsSync(settings.runtimeKeyFile)) {
       checks.push({ id: "tunnel-key", status: "error", message: "Tunnel runtime key file is missing" });
-    } else if (!secureFile(settings.runtimeKeyFile)) {
+    } else if (!isNgrokTunnel(settings) && !secureFile(settings.runtimeKeyFile)) {
       checks.push({ id: "tunnel-key", status: "error", message: "Tunnel runtime key file has unsafe permissions" });
-    } else {
+    } else if (!isNgrokTunnel(settings)) {
       checks.push({ id: "tunnel-key", status: "ok", message: "Tunnel runtime key is stored privately" });
     }
     const tunnelService = getTunnelServiceStatus();
     checks.push(tunnelService.installed && tunnelService.loaded && tunnelService.running
-      ? { id: "tunnel-service", status: "ok", message: "macOS tunnel service is installed, loaded, and running" }
-      : { id: "tunnel-service", status: "error", message: "macOS tunnel service is not fully running", detail: JSON.stringify(tunnelService) });
+      ? { id: "tunnel-service", status: "ok", message: "Managed tunnel service is installed, loaded, and running" }
+      : { id: "tunnel-service", status: "error", message: "Managed tunnel service is not fully running", detail: JSON.stringify(tunnelService) });
     const runtime = tunnelStatus(config);
     checks.push(runtime.ok
       ? { id: "tunnel-runtime", status: "ok", message: "Tunnel runtime reports healthy and ready" }

--- a/src/loopback-http.ts
+++ b/src/loopback-http.ts
@@ -1,0 +1,9 @@
+export async function fetchLoopback(url: string, init: RequestInit = {}): Promise<Response> {
+  const host = new URL(url).hostname;
+  if (host !== "127.0.0.1" && host !== "[::1]") throw new Error(`Not a loopback URL: ${url}`);
+  for (const key of ["NO_PROXY", "no_proxy"]) {
+    const entries = (process.env[key] ?? "").split(",").map(entry => entry.trim()).filter(Boolean);
+    if (!entries.includes(host)) process.env[key] = [...entries, host].join(",");
+  }
+  return await fetch(url, init);
+}

--- a/src/model-catalog.ts
+++ b/src/model-catalog.ts
@@ -49,7 +49,7 @@ export function buildChatGptWebModel(
     input_modalities: ["text", "image"],
     visibility: "list",
     supported_in_api: false,
-    prefer_websockets: false,
+    prefer_websockets: true,
     tool_mode: config.mode === "full" && !route.requiresPro ? template.tool_mode : null,
     upgrade: null,
     default_reasoning_level: route.codexEffort,

--- a/src/model-catalog.ts
+++ b/src/model-catalog.ts
@@ -49,6 +49,7 @@ export function buildChatGptWebModel(
     input_modalities: ["text", "image"],
     visibility: "list",
     supported_in_api: false,
+    prefer_websockets: false,
     tool_mode: config.mode === "full" && !route.requiresPro ? template.tool_mode : null,
     upgrade: null,
     default_reasoning_level: route.codexEffort,

--- a/src/ngrok-runtime.ts
+++ b/src/ngrok-runtime.ts
@@ -12,6 +12,12 @@ export function ngrokStartedUrl(line: string): string | undefined {
   }
 }
 
+export function ngrokEnvironment(environment: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const next = { ...environment };
+  for (const key of ["HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"]) delete next[key];
+  return next;
+}
+
 export async function runNgrokRuntime(options: {
   binaryPath: string;
   brokerSocketPath: string;
@@ -34,11 +40,16 @@ export async function runNgrokRuntime(options: {
     "--log-format",
     "json",
   ], {
+    env: ngrokEnvironment(),
     stdout: "pipe",
     stderr: "inherit",
   });
 
-  const stopChild = () => child.kill("SIGTERM");
+  let stopping = false;
+  const stopChild = () => {
+    stopping = true;
+    child.kill("SIGTERM");
+  };
   process.on("SIGINT", stopChild);
   process.on("SIGTERM", stopChild);
   let buffered = "";
@@ -69,7 +80,7 @@ export async function runNgrokRuntime(options: {
 
   try {
     const [, exitCode] = await Promise.all([pumpLogs(), child.exited]);
-    if (exitCode !== 0) throw new Error(`ngrok exited with status ${exitCode}`);
+    if (exitCode !== 0 && !stopping) throw new Error(`ngrok exited with status ${exitCode}`);
   } finally {
     process.off("SIGINT", stopChild);
     process.off("SIGTERM", stopChild);

--- a/src/ngrok-runtime.ts
+++ b/src/ngrok-runtime.ts
@@ -1,0 +1,79 @@
+import { rmSync } from "node:fs";
+import { atomicWriteFile } from "./config";
+import { startChatGptMcpHttpServer } from "./adapters/chatgpt-web/mcp-http";
+import { ngrokStatusPath } from "./tunnel";
+
+export function ngrokStartedUrl(line: string): string | undefined {
+  try {
+    const event = JSON.parse(line) as Record<string, unknown>;
+    return event.msg === "started tunnel" && typeof event.url === "string" ? event.url : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function runNgrokRuntime(options: {
+  binaryPath: string;
+  brokerSocketPath: string;
+  port: number;
+  url: string;
+}): Promise<void> {
+  rmSync(ngrokStatusPath(), { force: true });
+  const server = startChatGptMcpHttpServer({
+    brokerSocketPath: options.brokerSocketPath,
+    port: options.port,
+  });
+  const child = Bun.spawn([
+    options.binaryPath,
+    "http",
+    `http://127.0.0.1:${options.port}`,
+    "--url",
+    options.url,
+    "--log",
+    "stdout",
+    "--log-format",
+    "json",
+  ], {
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+
+  const stopChild = () => child.kill("SIGTERM");
+  process.on("SIGINT", stopChild);
+  process.on("SIGTERM", stopChild);
+  let buffered = "";
+  const pumpLogs = async () => {
+    const reader = child.stdout.getReader();
+    const decoder = new TextDecoder();
+    while (true) {
+      const result = await reader.read();
+      if (result.done) break;
+      process.stdout.write(result.value);
+      buffered += decoder.decode(result.value, { stream: true });
+      const lines = buffered.split("\n");
+      buffered = lines.pop() ?? "";
+      for (const line of lines) {
+        const endpoint = ngrokStartedUrl(line);
+        if (endpoint && new URL(endpoint).origin === new URL(options.url).origin) {
+          atomicWriteFile(ngrokStatusPath(), `${JSON.stringify({
+            version: 1,
+            ready: true,
+            url: options.url,
+            endpoint,
+            startedAt: new Date().toISOString(),
+          })}\n`);
+        }
+      }
+    }
+  };
+
+  try {
+    const [, exitCode] = await Promise.all([pumpLogs(), child.exited]);
+    if (exitCode !== 0) throw new Error(`ngrok exited with status ${exitCode}`);
+  } finally {
+    process.off("SIGINT", stopChild);
+    process.off("SIGTERM", stopChild);
+    server.stop(true);
+    rmSync(ngrokStatusPath(), { force: true });
+  }
+}

--- a/src/ngrok-runtime.ts
+++ b/src/ngrok-runtime.ts
@@ -23,11 +23,13 @@ export async function runNgrokRuntime(options: {
   brokerSocketPath: string;
   port: number;
   url: string;
+  accessToken: string;
 }): Promise<void> {
   rmSync(ngrokStatusPath(), { force: true });
   const server = startChatGptMcpHttpServer({
     brokerSocketPath: options.brokerSocketPath,
     port: options.port,
+    accessToken: options.accessToken,
   });
   const child = Bun.spawn([
     options.binaryPath,

--- a/src/responses/state.ts
+++ b/src/responses/state.ts
@@ -218,7 +218,7 @@ export function previousResponseReplayPrefixLength(body: unknown): number {
 export function rememberResponseState(
   requestBody: unknown,
   response: { id?: unknown; output?: unknown; status?: unknown; incomplete_details?: unknown },
-  opts?: { force?: boolean },
+  opts?: { force?: boolean; persist?: boolean },
 ): void {
   if (!requestBody || typeof requestBody !== "object" || Array.isArray(requestBody)) return;
   const request = requestBody as Record<string, unknown>;
@@ -240,7 +240,7 @@ export function rememberResponseState(
     items: [...inputItems(request.input), ...response.output],
   });
   pruneResponses();
-  schedulePersist();
+  if (opts?.persist !== false) schedulePersist();
 }
 
 /** Memory-only reset (simulates a process restart: the snapshot file survives). */

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,6 +21,158 @@ import { expandPreviousResponseInput, flushResponseState, rememberResponseState 
 import { namespacedToolName, type AdapterEvent, type CodexParsedRequest } from "./types";
 import { VERSION } from "./version";
 
+interface ResponsesWebSocketData {
+  headers: [string, string][];
+  chain: Promise<void>;
+  abort?: AbortController;
+  closed: boolean;
+}
+
+interface ResponsesWebSocket {
+  data: ResponsesWebSocketData;
+  send(data: string): unknown;
+}
+
+function sendWebSocketError(
+  socket: ResponsesWebSocket,
+  message: string,
+  code = "server_error",
+  status = 500,
+): void {
+  try {
+    socket.send(JSON.stringify({
+      type: "error",
+      status,
+      error: { type: code, code, message },
+    }));
+  } catch {
+    // The peer may have disconnected while the turn was failing.
+  }
+}
+
+function forwardSseEvent(socket: ResponsesWebSocket, block: string): void {
+  const data = block
+    .split(/\r?\n/)
+    .filter(line => line.startsWith("data:"))
+    .map(line => line.slice(5).replace(/^ /, ""))
+    .join("\n");
+  if (data && data !== "[DONE]") socket.send(data);
+}
+
+async function forwardResponseToWebSocket(socket: ResponsesWebSocket, response: Response): Promise<void> {
+  if (!response.ok) {
+    let message = `Responses request failed with HTTP ${response.status}`;
+    let code = "server_error";
+    try {
+      const body = await response.json() as { error?: { message?: unknown; type?: unknown } };
+      if (typeof body.error?.message === "string") message = body.error.message;
+      if (typeof body.error?.type === "string") code = body.error.type;
+    } catch {
+      // Keep the status-derived fallback for non-JSON errors.
+    }
+    sendWebSocketError(socket, message, code, response.status);
+    return;
+  }
+  if (!response.body) {
+    sendWebSocketError(socket, "Responses request returned no event stream");
+    return;
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffered = "";
+  while (true) {
+    const chunk = await reader.read();
+    if (chunk.done) {
+      buffered += decoder.decode();
+      break;
+    }
+    buffered += decoder.decode(chunk.value, { stream: true });
+    while (true) {
+      const boundary = /\r?\n\r?\n/.exec(buffered);
+      if (!boundary || boundary.index === undefined) break;
+      forwardSseEvent(socket, buffered.slice(0, boundary.index));
+      buffered = buffered.slice(boundary.index + boundary[0].length);
+    }
+  }
+  if (buffered.trim()) forwardSseEvent(socket, buffered);
+}
+
+async function handleResponsesWebSocketMessage(
+  socket: ResponsesWebSocket,
+  message: string | Uint8Array,
+  config: AppConfig,
+  draining: () => boolean,
+): Promise<void> {
+  if (socket.data.closed) return;
+  let envelope: Record<string, unknown>;
+  try {
+    const parsed = JSON.parse(typeof message === "string" ? message : new TextDecoder().decode(message));
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error("message must be an object");
+    envelope = parsed as Record<string, unknown>;
+  } catch (error) {
+    sendWebSocketError(
+      socket,
+      error instanceof Error ? `Invalid WebSocket message: ${error.message}` : "Invalid WebSocket message",
+      "invalid_request_error",
+      400,
+    );
+    return;
+  }
+  if (envelope.type !== "response.create") {
+    sendWebSocketError(socket, "WebSocket messages must use type response.create", "invalid_request_error", 400);
+    return;
+  }
+  if (draining()) {
+    sendWebSocketError(socket, "codex-chatgpt-web is draining for a requested service operation", "server_error", 503);
+    return;
+  }
+
+  const generate = envelope.generate;
+  delete envelope.type;
+  delete envelope.generate;
+  envelope.stream = true;
+
+  if (generate === false) {
+    if (typeof envelope.model !== "string" || !envelope.model) {
+      sendWebSocketError(socket, "Responses prewarm requires a model", "invalid_request_error", 400);
+      return;
+    }
+    try {
+      parseRequest(envelope);
+      if (isChatGptWebModelSlug(envelope.model)) requireChatGptWebModelRoute(envelope.model, config.proAvailable);
+    } catch (error) {
+      sendWebSocketError(
+        socket,
+        error instanceof Error ? error.message : String(error),
+        "invalid_request_error",
+        400,
+      );
+      return;
+    }
+    const response = buildResponseJSON([], envelope.model);
+    rememberResponseState(envelope, response, { force: true, persist: false });
+    socket.send(JSON.stringify({ type: "response.completed", sequence_number: 0, response }));
+    return;
+  }
+
+  const abort = new AbortController();
+  socket.data.abort = abort;
+  try {
+    const headers = new Headers(socket.data.headers);
+    headers.set("content-type", "application/json");
+    const request = new Request("http://127.0.0.1/v1/responses", {
+      method: "POST",
+      headers,
+      body: JSON.stringify(envelope),
+      signal: abort.signal,
+    });
+    await forwardResponseToWebSocket(socket, await responseRequest(request, config));
+  } finally {
+    if (socket.data.abort === abort) socket.data.abort = undefined;
+  }
+}
+
 export class HttpTurnCounter {
   private active = 0;
 
@@ -274,11 +426,11 @@ export function startServer(config: AppConfig): ReturnType<typeof Bun.serve> {
     const actual = Buffer.from(header);
     return actual.length === expected.length && timingSafeEqual(actual, expected);
   };
-  const server = Bun.serve({
+  const server = Bun.serve<ResponsesWebSocketData>({
     hostname: config.host,
     port: config.port,
     idleTimeout: 0,
-    fetch(req) {
+    fetch(req, bunServer) {
       const url = new URL(req.url);
       if (req.method === "GET" && url.pathname === "/healthz") {
         return Response.json({
@@ -307,6 +459,19 @@ export function startServer(config: AppConfig): ReturnType<typeof Bun.serve> {
         return modelsRequest(req, config, undefined, readCodexModelContextOverride);
       }
       if (req.method === "GET" && url.pathname === "/v1/responses") {
+        if (req.headers.get("upgrade")?.toLowerCase() === "websocket") {
+          if (draining) return formatErrorResponse(503, "server_error", "codex-chatgpt-web is draining for a requested service operation");
+          if (bunServer.upgrade(req, {
+            data: {
+              headers: Array.from(req.headers.entries()).filter(([name]) =>
+                name !== "connection" && name !== "upgrade" && !name.startsWith("sec-websocket-")
+              ),
+              chain: Promise.resolve(),
+              closed: false,
+            },
+          })) return;
+          return new Response("WebSocket upgrade failed", { status: 500 });
+        }
         return new Response("Responses WebSocket transport is not enabled on this local route", {
           status: 426,
           headers: { "content-type": "text/plain; charset=utf-8" },
@@ -321,6 +486,21 @@ export function startServer(config: AppConfig): ReturnType<typeof Bun.serve> {
         return httpTurns.track(() => compactRequest(req, config));
       }
       return new Response("Not found", { status: 404 });
+    },
+    websocket: {
+      message(socket, message) {
+        socket.data.chain = socket.data.chain
+          .then(() => {
+            if (!socket.data.closed) return handleResponsesWebSocketMessage(socket, message, config, () => draining);
+          })
+          .catch(error => {
+            sendWebSocketError(socket, error instanceof Error ? error.message : String(error));
+          });
+      },
+      close(socket) {
+        socket.data.closed = true;
+        socket.data.abort?.abort();
+      },
     },
   });
   const shutdown = () => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -56,7 +56,30 @@ function forwardSseEvent(socket: ResponsesWebSocket, block: string): void {
     .filter(line => line.startsWith("data:"))
     .map(line => line.slice(5).replace(/^ /, ""))
     .join("\n");
-  if (data && data !== "[DONE]") socket.send(data);
+  if (!data || data === "[DONE]") return;
+  try {
+    const event = JSON.parse(data) as {
+      type?: unknown;
+      response?: { error?: { code?: unknown; type?: unknown; message?: unknown } };
+    };
+    if (event.type === "response.failed") {
+      const error = event.response?.error;
+      const status = typeof error?.code === "number" && error.code >= 400 && error.code <= 599
+        ? error.code
+        : 500;
+      const code = typeof error?.type === "string"
+        ? error.type
+        : typeof error?.code === "string"
+          ? error.code
+          : "server_error";
+      const message = typeof error?.message === "string" ? error.message : "Responses request failed";
+      sendWebSocketError(socket, message, code, status);
+      return;
+    }
+  } catch {
+    // The Codex client will ignore an unknown non-JSON event just as it does for HTTP SSE.
+  }
+  socket.send(data);
 }
 
 async function forwardResponseToWebSocket(socket: ResponsesWebSocket, response: Response): Promise<void> {

--- a/src/service.ts
+++ b/src/service.ts
@@ -4,8 +4,10 @@ import { dirname, join } from "node:path";
 import type { AppConfig } from "./config";
 import { assertDurableRuntimeCommand, atomicWriteFile, getConfigDir } from "./config";
 import { runCommand, runChecked } from "./process";
+import { fetchLoopback } from "./loopback-http";
 
 const LABEL = "io.github.codex-chatgpt-web.daemon";
+const SYSTEMD_UNIT = "codex-chatgpt-web.service";
 
 export interface ServiceStatus {
   supported: boolean;
@@ -34,6 +36,14 @@ function launchDomain(): string {
 
 function serviceTarget(): string {
   return `${launchDomain()}/${LABEL}`;
+}
+
+function unitPath(): string {
+  return join(homedir(), ".config", "systemd", "user", SYSTEMD_UNIT);
+}
+
+function systemdArg(value: string): string {
+  return `"${value.replaceAll("\\", "\\\\").replaceAll('"', '\\"').replaceAll("%", "%%")}"`;
 }
 
 async function bootstrapService(path: string, timeoutMs = 20_000): Promise<void> {
@@ -91,13 +101,50 @@ ${args.map(arg => `    <string>${xml(arg)}</string>`).join("\n")}
 `;
 }
 
-function assertMacOs(): void {
-  if (process.platform !== "darwin") {
-    throw new Error("Version 0.1 supports managed background services on macOS only; run `codex-chatgpt-web serve` manually on this platform.");
+function systemdUnit(config: AppConfig): string {
+  const args = [...config.runtimeCommand, "serve"];
+  return `[Unit]
+Description=Codex ChatGPT Web daemon
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=${args.map(systemdArg).join(" ")}
+Environment=${systemdArg(`CODEX_CHATGPT_WEB_HOME=${getConfigDir()}`)}
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=default.target
+`;
+}
+
+export function serviceDefinition(config: AppConfig, platform: NodeJS.Platform = process.platform): string {
+  return platform === "linux" ? systemdUnit(config) : plist(config);
+}
+
+function assertManagedPlatform(): void {
+  if (process.platform !== "darwin" && process.platform !== "linux") {
+    throw new Error("Managed background services are supported on macOS and Linux");
   }
 }
 
 export function getServiceStatus(): ServiceStatus {
+  if (process.platform === "linux") {
+    try {
+      const result = runCommand("systemctl", ["--user", "is-active", "--quiet", SYSTEMD_UNIT]);
+      return {
+        supported: true,
+        installed: existsSync(unitPath()),
+        loaded: result.status === 0,
+        label: SYSTEMD_UNIT,
+        definitionPath: unitPath(),
+      };
+    } catch {
+      return { supported: false, installed: false, loaded: false, label: SYSTEMD_UNIT };
+    }
+  }
   if (process.platform !== "darwin") return { supported: false, installed: false, loaded: false, label: LABEL };
   const path = plistPath();
   const result = runCommand("launchctl", ["print", serviceTarget()]);
@@ -111,8 +158,17 @@ export function getServiceStatus(): ServiceStatus {
 }
 
 export function installService(config: AppConfig): ServiceStatus {
-  assertMacOs();
+  assertManagedPlatform();
   assertDurableRuntimeCommand(config.runtimeCommand);
+  if (process.platform === "linux") {
+    const path = unitPath();
+    mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+    const next = systemdUnit(config);
+    if (!existsSync(path) || readFileSync(path, "utf8") !== next) atomicWriteFile(path, next);
+    runChecked("systemctl", ["--user", "daemon-reload"]);
+    runChecked("systemctl", ["--user", "enable", "--now", SYSTEMD_UNIT]);
+    return getServiceStatus();
+  }
   const path = plistPath();
   mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
   mkdirSync(join(getConfigDir(), "logs"), { recursive: true, mode: 0o700 });
@@ -124,7 +180,13 @@ export function installService(config: AppConfig): ServiceStatus {
 }
 
 export function startService(): ServiceStatus {
-  assertMacOs();
+  assertManagedPlatform();
+  if (process.platform === "linux") {
+    if (!existsSync(unitPath())) throw new Error(`Service is not installed: ${unitPath()}`);
+    runChecked("systemctl", ["--user", "daemon-reload"]);
+    runChecked("systemctl", ["--user", "enable", "--now", SYSTEMD_UNIT]);
+    return getServiceStatus();
+  }
   const path = plistPath();
   if (!existsSync(path)) throw new Error(`Service is not installed: ${path}`);
   const status = getServiceStatus();
@@ -140,7 +202,7 @@ async function control(config: AppConfig, action: "drain" | "resume" | "cancel-b
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 5_000);
   try {
-    const response = await fetch(`http://${config.host}:${config.port}/admin/${action}`, {
+    const response = await fetchLoopback(`http://${config.host}:${config.port}/admin/${action}`, {
       method: "POST",
       headers: { authorization: `Bearer ${config.controlToken}` },
       signal: controller.signal,
@@ -208,9 +270,18 @@ export async function assertServiceIdle(config: AppConfig): Promise<void> {
 }
 
 export async function restartService(config: AppConfig): Promise<ServiceStatus> {
-  assertMacOs();
+  assertManagedPlatform();
   if (!getServiceStatus().loaded) return startService();
   const lease = await acquireDrain(config);
+  if (process.platform === "linux") {
+    try {
+      runChecked("systemctl", ["--user", "restart", SYSTEMD_UNIT]);
+    } catch (error) {
+      await lease.release().catch(() => {});
+      throw error;
+    }
+    return getServiceStatus();
+  }
   try {
     runChecked("launchctl", ["bootout", serviceTarget()]);
     await waitForServiceUnloaded();
@@ -233,12 +304,15 @@ export function removeLegacyRuntimeArtifacts(config: AppConfig): void {
 }
 
 export async function stopService(config: AppConfig): Promise<ServiceStatus> {
-  assertMacOs();
+  assertManagedPlatform();
   if (getServiceStatus().loaded) {
     const lease = await acquireDrain(config);
     try {
-      runChecked("launchctl", ["bootout", serviceTarget()]);
-      await waitForServiceUnloaded();
+      if (process.platform === "linux") runChecked("systemctl", ["--user", "stop", SYSTEMD_UNIT]);
+      else {
+        runChecked("launchctl", ["bootout", serviceTarget()]);
+        await waitForServiceUnloaded();
+      }
     } catch (error) {
       await lease.release().catch(() => {});
       throw error;
@@ -248,17 +322,24 @@ export async function stopService(config: AppConfig): Promise<ServiceStatus> {
 }
 
 export async function uninstallService(config: AppConfig): Promise<ServiceStatus> {
-  assertMacOs();
+  assertManagedPlatform();
   if (getServiceStatus().loaded) {
     const lease = await acquireDrain(config);
     try {
-      runChecked("launchctl", ["bootout", serviceTarget()]);
-      await waitForServiceUnloaded();
+      if (process.platform === "linux") runChecked("systemctl", ["--user", "disable", "--now", SYSTEMD_UNIT]);
+      else {
+        runChecked("launchctl", ["bootout", serviceTarget()]);
+        await waitForServiceUnloaded();
+      }
     } catch (error) {
       await lease.release().catch(() => {});
       throw error;
     }
   }
-  rmSync(plistPath(), { force: true });
+  if (process.platform === "linux") {
+    runCommand("systemctl", ["--user", "disable", SYSTEMD_UNIT]);
+    rmSync(unitPath(), { force: true });
+    runChecked("systemctl", ["--user", "daemon-reload"]);
+  } else rmSync(plistPath(), { force: true });
   return getServiceStatus();
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -103,10 +103,13 @@ ${args.map(arg => `    <string>${xml(arg)}</string>`).join("\n")}
 
 function systemdUnit(config: AppConfig): string {
   const args = [...config.runtimeCommand, "serve"];
+  const graphicalSession = config.headed
+    ? "After=network-online.target graphical-session.target\nWants=network-online.target\nPartOf=graphical-session.target"
+    : "After=network-online.target\nWants=network-online.target";
+  const installTarget = config.headed ? "graphical-session.target" : "default.target";
   return `[Unit]
 Description=Codex ChatGPT Web daemon
-After=network-online.target
-Wants=network-online.target
+${graphicalSession}
 
 [Service]
 Type=simple
@@ -116,7 +119,7 @@ Restart=always
 RestartSec=10
 
 [Install]
-WantedBy=default.target
+WantedBy=${installTarget}
 `;
 }
 
@@ -166,7 +169,7 @@ export function installService(config: AppConfig): ServiceStatus {
     const next = systemdUnit(config);
     if (!existsSync(path) || readFileSync(path, "utf8") !== next) atomicWriteFile(path, next);
     runChecked("systemctl", ["--user", "daemon-reload"]);
-    runChecked("systemctl", ["--user", "enable", "--now", SYSTEMD_UNIT]);
+    runChecked("systemctl", ["--user", "reenable", "--now", SYSTEMD_UNIT]);
     return getServiceStatus();
   }
   const path = plistPath();

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -2,7 +2,8 @@ import { existsSync } from "node:fs";
 import { randomBytes } from "node:crypto";
 import { createServer } from "node:net";
 import type { AppConfig, RuntimeMode } from "./config";
-import { currentRuntimeCommand, defaultConfig, getConfigPath, loadConfigForSetup, saveConfig } from "./config";
+import { currentRuntimeCommand, defaultConfig, getConfigPath, isNgrokTunnel, isOpenAiTunnel, loadConfigForSetup, saveConfig } from "./config";
+import { defaultBrowserExecutable, ensureBrowserExecutable, type BrowserEngine } from "./browser-engine";
 import {
   browserLoginStateExists,
   inspectBrowserLoginCapabilities,
@@ -11,14 +12,16 @@ import {
 } from "./browser-login";
 import { installCodexIntegration } from "./codex-integration";
 import { assertServiceIdle, getServiceStatus, installService, removeLegacyRuntimeArtifacts, restartService } from "./service";
-import { connectTunnel, createTunnelConfig, installRuntimeKey, installRuntimeKeyBytes, installTunnelClient, managedRuntimeKeyPath, stopTunnel, waitForTunnelReady } from "./tunnel";
+import { connectTunnel, createNgrokTunnelConfig, createTunnelConfig, installRuntimeKey, installRuntimeKeyBytes, installTunnelClient, managedRuntimeKeyPath, ngrokConnectorUrl, stopTunnel, waitForTunnelReady } from "./tunnel";
 import { getTunnelServiceStatus, installTunnelService, restartTunnelService, stopTunnelService, tunnelServiceDefinitionMatches, uninstallTunnelService } from "./tunnel-service";
 import { VERSION } from "./version";
+import { fetchLoopback } from "./loopback-http";
 
 export interface SetupOptions {
   mode: RuntimeMode;
   port?: number;
-  chromeExecutablePath?: string;
+  browserEngine?: BrowserEngine;
+  browserExecutablePath?: string;
   appName?: string;
   forceLogin?: boolean;
   autoApproveToolCalls?: boolean;
@@ -28,6 +31,9 @@ export interface SetupOptions {
   tunnelId?: string;
   runtimeKeyFile?: string;
   runtimeKeyValue?: string;
+  tunnelProvider?: "openai" | "ngrok";
+  ngrokPath?: string;
+  ngrokUrl?: string;
 }
 
 export interface SetupResult {
@@ -38,6 +44,7 @@ export interface SetupResult {
   tunnelReady: boolean | null;
   codexRestartRequired: true;
   connectorSetupRequired: boolean;
+  connectorEndpoint?: string;
 }
 
 export interface ExistingFullSetupCredentials {
@@ -46,7 +53,7 @@ export interface ExistingFullSetupCredentials {
 }
 
 export function existingFullSetupCredentials(existing: AppConfig | undefined): ExistingFullSetupCredentials {
-  const tunnel = existing?.mode === "full" ? existing.tunnel : undefined;
+  const tunnel = existing?.mode === "full" && existing.tunnel && isOpenAiTunnel(existing.tunnel) ? existing.tunnel : undefined;
   return {
     tunnelId: Boolean(tunnel?.tunnelId),
     runtimeKey: Boolean(tunnel?.runtimeKeyFile && existsSync(tunnel.runtimeKeyFile)),
@@ -66,7 +73,8 @@ function meaningfulRuntimeChange(before: AppConfig, after: AppConfig): boolean {
     port: before.port,
     contextWindow: before.contextWindow,
     appName: before.appName,
-    chromeExecutablePath: before.chromeExecutablePath,
+    browserEngine: before.browserEngine,
+    browserExecutablePath: before.browserExecutablePath,
     storageStatePath: before.storageStatePath,
     brokerSocketPath: before.brokerSocketPath,
     headed: before.headed,
@@ -82,7 +90,8 @@ function meaningfulRuntimeChange(before: AppConfig, after: AppConfig): boolean {
     port: after.port,
     contextWindow: after.contextWindow,
     appName: after.appName,
-    chromeExecutablePath: after.chromeExecutablePath,
+    browserEngine: after.browserEngine,
+    browserExecutablePath: after.browserExecutablePath,
     storageStatePath: after.storageStatePath,
     brokerSocketPath: after.brokerSocketPath,
     headed: after.headed,
@@ -115,7 +124,7 @@ async function waitForProxy(config: AppConfig, timeoutMs = 10_000): Promise<void
   let lastError = "not reachable";
   while (Date.now() < deadline) {
     try {
-      const response = await fetch(`http://${config.host}:${config.port}/healthz`);
+      const response = await fetchLoopback(`http://${config.host}:${config.port}/healthz`);
       if (response.ok) {
         const body = await response.json() as Record<string, unknown>;
         if (body.service === "codex-chatgpt-web" && body.mode === config.mode && body.version === config.releaseVersion) return;
@@ -140,7 +149,11 @@ function baseConfig(existing: AppConfig | undefined, options: SetupOptions): App
     if (!Number.isInteger(options.port) || options.port < 1 || options.port > 65_535) throw new Error("--port must be an integer from 1 to 65535");
     config.port = options.port;
   }
-  if (options.chromeExecutablePath) config.chromeExecutablePath = options.chromeExecutablePath;
+  if (options.browserEngine && options.browserEngine !== config.browserEngine) {
+    config.browserEngine = options.browserEngine;
+    config.browserExecutablePath = defaultBrowserExecutable(options.browserEngine);
+  }
+  if (options.browserExecutablePath) config.browserExecutablePath = options.browserExecutablePath;
   if (options.appName) config.appName = options.appName;
   if (options.autoApproveToolCalls !== undefined) config.autoApproveToolCalls = options.autoApproveToolCalls;
   if (options.acknowledgedUnofficial) config.acknowledgedUnofficialAt = new Date().toISOString();
@@ -156,11 +169,26 @@ async function configureTunnel(config: AppConfig, existing: AppConfig | undefine
     return;
   }
   const existingTunnel = existing?.mode === "full" ? existing.tunnel : undefined;
-  const tunnelId = options.tunnelId ?? existingTunnel?.tunnelId;
+  const provider = options.tunnelProvider ?? existingTunnel?.provider ?? "openai";
+  if (provider === "ngrok") {
+    const previous = existingTunnel && isNgrokTunnel(existingTunnel) ? existingTunnel : undefined;
+    const binaryPath = options.ngrokPath ?? previous?.binaryPath ?? Bun.which("ngrok");
+    if (!binaryPath || !existsSync(binaryPath)) throw new Error("Ngrok was not found. Install it or pass --ngrok-path.");
+    const url = options.ngrokUrl ?? previous?.url;
+    if (!url) throw new Error("Ngrok full mode requires a stable --ngrok-url, for example https://example.ngrok.app");
+    config.tunnel = createNgrokTunnelConfig({
+      binaryPath,
+      url,
+      port: previous?.port ?? config.port + 1,
+    });
+    return;
+  }
+  const previous = existingTunnel && isOpenAiTunnel(existingTunnel) ? existingTunnel : undefined;
+  const tunnelId = options.tunnelId ?? previous?.tunnelId;
   if (!tunnelId) {
     throw new Error("Full mode requires --tunnel-id. Create it at https://platform.openai.com/settings/organization/tunnels");
   }
-  let runtimeKeyFile = existingTunnel?.runtimeKeyFile;
+  let runtimeKeyFile = previous?.runtimeKeyFile;
   if (!runtimeKeyFile && existsSync(managedRuntimeKeyPath())) runtimeKeyFile = managedRuntimeKeyPath();
   if (options.runtimeKeyFile) runtimeKeyFile = installRuntimeKey(options.runtimeKeyFile);
   if (options.runtimeKeyValue) runtimeKeyFile = installRuntimeKeyBytes(options.runtimeKeyValue);
@@ -172,17 +200,18 @@ async function configureTunnel(config: AppConfig, existing: AppConfig | undefine
     binaryPath: installedBinary,
     tunnelId,
     runtimeKeyFile,
-    profileName: existingTunnel?.profileName,
-    alias: existingTunnel?.alias,
+    profileName: previous?.profileName,
+    alias: previous?.alias,
   });
 }
 
 export async function setup(options: SetupOptions): Promise<SetupResult> {
-  if (process.platform !== "darwin") {
-    throw new Error("The 0.1 release installer currently supports macOS only; no untested service fallback is installed.");
+  if (process.platform !== "darwin" && process.platform !== "linux") {
+    throw new Error("Managed setup currently supports macOS and Linux.");
   }
   const existing = loadExistingConfig();
   const config = baseConfig(existing, options);
+  ensureBrowserExecutable(config);
   const refreshTunnelWorker = tunnelWorkerRuntimeChanged(existing, config);
   if (existing && options.restartService) config.controlToken = randomBytes(32).toString("base64url");
   const beforeService = getServiceStatus();
@@ -243,17 +272,26 @@ export async function setup(options: SetupOptions): Promise<SetupResult> {
     stopTunnel(existing);
   }
   if (config.mode === "full") {
-    const profilePath = `${config.tunnel!.profileDir}/${config.tunnel!.profileName}.yaml`;
     const tunnelService = getTunnelServiceStatus();
     const needsOwnershipMigration = !tunnelService.installed || !tunnelService.loaded || !tunnelServiceDefinitionMatches(config);
-    const needsProfile = !existsSync(profilePath);
-    if (needsOwnershipMigration || needsProfile) {
+    if (isOpenAiTunnel(config.tunnel!)) {
+      const profilePath = `${config.tunnel.profileDir}/${config.tunnel.profileName}.yaml`;
+      const needsProfile = !existsSync(profilePath);
+      if (needsOwnershipMigration || needsProfile) {
+        await assertServiceIdle(config);
+        if (tunnelService.loaded) await stopTunnelService();
+        connectTunnel(config);
+        const bootstrapStatus = await waitForTunnelReady(config);
+        if (!bootstrapStatus.ok) throw new Error(`Temporary tunnel bootstrap did not become healthy and ready: ${bootstrapStatus.detail}`);
+        stopTunnel(config);
+        installTunnelService(config);
+      } else if (refreshTunnelWorker) {
+        await assertServiceIdle(config);
+        await restartTunnelService();
+      }
+    } else if (needsOwnershipMigration) {
       await assertServiceIdle(config);
       if (tunnelService.loaded) await stopTunnelService();
-      connectTunnel(config);
-      const bootstrapStatus = await waitForTunnelReady(config);
-      if (!bootstrapStatus.ok) throw new Error(`Temporary tunnel bootstrap did not become healthy and ready: ${bootstrapStatus.detail}`);
-      stopTunnel(config);
       installTunnelService(config);
     } else if (refreshTunnelWorker) {
       await assertServiceIdle(config);
@@ -275,5 +313,8 @@ export async function setup(options: SetupOptions): Promise<SetupResult> {
     tunnelReady,
     codexRestartRequired: true,
     connectorSetupRequired: config.mode === "full",
+    ...(config.mode === "full" && config.tunnel && isNgrokTunnel(config.tunnel)
+      ? { connectorEndpoint: ngrokConnectorUrl(config.tunnel) }
+      : {}),
   };
 }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -34,6 +34,7 @@ export interface SetupOptions {
   tunnelProvider?: "openai" | "ngrok";
   ngrokPath?: string;
   ngrokUrl?: string;
+  rotateMcpAccessToken?: boolean;
 }
 
 export interface SetupResult {
@@ -81,6 +82,7 @@ function meaningfulRuntimeChange(before: AppConfig, after: AppConfig): boolean {
     proAvailable: before.proAvailable,
     autoApproveToolCalls: before.autoApproveToolCalls,
     controlToken: before.controlToken,
+    mcpAccessToken: before.mcpAccessToken,
     runtimeCommand: before.runtimeCommand,
     tunnel: before.tunnel,
   }) !== JSON.stringify({
@@ -98,6 +100,7 @@ function meaningfulRuntimeChange(before: AppConfig, after: AppConfig): boolean {
     proAvailable: after.proAvailable,
     autoApproveToolCalls: after.autoApproveToolCalls,
     controlToken: after.controlToken,
+    mcpAccessToken: after.mcpAccessToken,
     runtimeCommand: after.runtimeCommand,
     tunnel: after.tunnel,
   });
@@ -107,7 +110,8 @@ export function tunnelWorkerRuntimeChanged(before: AppConfig | undefined, after:
   if (!before || before.mode !== "full" || after.mode !== "full") return false;
   return before.releaseVersion !== after.releaseVersion
     || JSON.stringify(before.runtimeCommand) !== JSON.stringify(after.runtimeCommand)
-    || before.brokerSocketPath !== after.brokerSocketPath;
+    || before.brokerSocketPath !== after.brokerSocketPath
+    || before.mcpAccessToken !== after.mcpAccessToken;
 }
 
 async function assertPortAvailable(host: string, port: number): Promise<void> {
@@ -155,6 +159,7 @@ function baseConfig(existing: AppConfig | undefined, options: SetupOptions): App
   }
   if (options.browserExecutablePath) config.browserExecutablePath = options.browserExecutablePath;
   if (options.appName) config.appName = options.appName;
+  if (options.rotateMcpAccessToken) config.mcpAccessToken = randomBytes(32).toString("base64url");
   if (options.autoApproveToolCalls !== undefined) config.autoApproveToolCalls = options.autoApproveToolCalls;
   if (options.acknowledgedUnofficial) config.acknowledgedUnofficialAt = new Date().toISOString();
   if (!config.acknowledgedUnofficialAt) {
@@ -314,7 +319,7 @@ export async function setup(options: SetupOptions): Promise<SetupResult> {
     codexRestartRequired: true,
     connectorSetupRequired: config.mode === "full",
     ...(config.mode === "full" && config.tunnel && isNgrokTunnel(config.tunnel)
-      ? { connectorEndpoint: ngrokConnectorUrl(config.tunnel) }
+      ? { connectorEndpoint: ngrokConnectorUrl(config.tunnel, config.mcpAccessToken) }
       : {}),
   };
 }

--- a/src/tunnel-service.ts
+++ b/src/tunnel-service.ts
@@ -2,10 +2,11 @@ import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { homedir, userInfo } from "node:os";
 import { dirname, join } from "node:path";
 import type { AppConfig } from "./config";
-import { atomicWriteFile, getConfigDir } from "./config";
+import { atomicWriteFile, getConfigDir, isNgrokTunnel, isOpenAiTunnel } from "./config";
 import { runCommand, runChecked } from "./process";
 
 const LABEL = "io.github.codex-chatgpt-web.tunnel";
+const SYSTEMD_UNIT = "codex-chatgpt-web-tunnel.service";
 
 export interface TunnelServiceStatus {
   supported: boolean;
@@ -37,21 +38,43 @@ function serviceTarget(): string {
   return `${launchDomain()}/${LABEL}`;
 }
 
+function unitPath(): string {
+  return join(homedir(), ".config", "systemd", "user", SYSTEMD_UNIT);
+}
+
+function systemdArg(value: string): string {
+  return `"${value.replaceAll("\\", "\\\\").replaceAll('"', '\\"').replaceAll("%", "%%")}"`;
+}
+
 function settings(config: AppConfig) {
   if (config.mode !== "full" || !config.tunnel) throw new Error("Tunnel service requires full mode");
   return config.tunnel;
 }
 
-function assertMacOs(): void {
-  if (process.platform !== "darwin") {
-    throw new Error("Managed tunnel service installation is currently supported on macOS only");
+function assertManagedPlatform(): void {
+  if (process.platform !== "darwin" && process.platform !== "linux") {
+    throw new Error("Managed tunnel services are supported on macOS and Linux");
   }
 }
 
-export function tunnelServiceDefinition(config: AppConfig): string {
+function serviceArguments(config: AppConfig): string[] {
   const tunnel = settings(config);
+  if (isNgrokTunnel(tunnel)) {
+    return [
+      ...config.runtimeCommand,
+      "ngrok-tunnel",
+      "--ngrok", tunnel.binaryPath,
+      "--broker-socket", config.brokerSocketPath,
+      "--port", String(tunnel.port),
+      "--url", tunnel.url,
+    ];
+  }
+  return [tunnel.binaryPath, "run", "--profile-dir", tunnel.profileDir, "--profile", tunnel.profileName];
+}
+
+function launchdDefinition(config: AppConfig): string {
   const logDir = join(getConfigDir(), "logs");
-  const args = [tunnel.binaryPath, "run", "--profile-dir", tunnel.profileDir, "--profile", tunnel.profileName];
+  const args = serviceArguments(config);
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -84,7 +107,44 @@ ${args.map(arg => `    <string>${xml(arg)}</string>`).join("\n")}
 `;
 }
 
+function systemdDefinition(config: AppConfig): string {
+  return `[Unit]
+Description=Codex ChatGPT Web tunnel
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=${serviceArguments(config).map(systemdArg).join(" ")}
+Environment=${systemdArg(`CODEX_CHATGPT_WEB_HOME=${getConfigDir()}`)}
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=default.target
+`;
+}
+
+export function tunnelServiceDefinition(config: AppConfig, platform: NodeJS.Platform = process.platform): string {
+  return platform === "linux" ? systemdDefinition(config) : launchdDefinition(config);
+}
+
 export function getTunnelServiceStatus(): TunnelServiceStatus {
+  if (process.platform === "linux") {
+    try {
+      const result = runCommand("systemctl", ["--user", "is-active", "--quiet", SYSTEMD_UNIT]);
+      return {
+        supported: true,
+        installed: existsSync(unitPath()),
+        loaded: result.status === 0,
+        running: result.status === 0,
+        label: SYSTEMD_UNIT,
+        definitionPath: unitPath(),
+      };
+    } catch {
+      return { supported: false, installed: false, loaded: false, running: false, label: SYSTEMD_UNIT };
+    }
+  }
   if (process.platform !== "darwin") {
     return { supported: false, installed: false, loaded: false, running: false, label: LABEL };
   }
@@ -101,32 +161,42 @@ export function getTunnelServiceStatus(): TunnelServiceStatus {
 }
 
 export function tunnelServiceDefinitionMatches(config: AppConfig): boolean {
-  const path = plistPath();
+  const path = process.platform === "linux" ? unitPath() : plistPath();
   return existsSync(path) && readFileSync(path, "utf8") === tunnelServiceDefinition(config);
 }
 
 export function installTunnelService(config: AppConfig): TunnelServiceStatus {
-  assertMacOs();
+  assertManagedPlatform();
   const tunnel = settings(config);
-  const profile = join(tunnel.profileDir, `${tunnel.profileName}.yaml`);
   if (!existsSync(tunnel.binaryPath)) throw new Error(`Tunnel client is missing: ${tunnel.binaryPath}`);
-  if (!existsSync(profile)) throw new Error(`Tunnel profile is missing: ${profile}`);
+  if (isOpenAiTunnel(tunnel)) {
+    const profile = join(tunnel.profileDir, `${tunnel.profileName}.yaml`);
+    if (!existsSync(profile)) throw new Error(`Tunnel profile is missing: ${profile}`);
+  }
   const current = getTunnelServiceStatus();
   const next = tunnelServiceDefinition(config);
-  if (current.loaded && (!current.installed || readFileSync(plistPath(), "utf8") !== next)) {
+  const path = process.platform === "linux" ? unitPath() : plistPath();
+  if (current.loaded && (!current.installed || readFileSync(path, "utf8") !== next)) {
     throw new Error("Refusing to replace a loaded tunnel service definition; stop it before installing the update");
   }
-  mkdirSync(dirname(plistPath()), { recursive: true, mode: 0o700 });
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
   mkdirSync(join(getConfigDir(), "logs"), { recursive: true, mode: 0o700 });
-  if (!current.installed || readFileSync(plistPath(), "utf8") !== next) atomicWriteFile(plistPath(), next);
-  if (!current.loaded) runChecked("launchctl", ["bootstrap", launchDomain(), plistPath()]);
+  if (!current.installed || readFileSync(path, "utf8") !== next) atomicWriteFile(path, next);
+  if (process.platform === "linux") {
+    runChecked("systemctl", ["--user", "daemon-reload"]);
+    if (!current.loaded) runChecked("systemctl", ["--user", "enable", "--now", SYSTEMD_UNIT]);
+  } else if (!current.loaded) runChecked("launchctl", ["bootstrap", launchDomain(), plistPath()]);
   return getTunnelServiceStatus();
 }
 
 export function startTunnelService(): TunnelServiceStatus {
-  assertMacOs();
-  if (!existsSync(plistPath())) throw new Error("Tunnel service is not installed; rerun full setup");
-  if (!getTunnelServiceStatus().loaded) runChecked("launchctl", ["bootstrap", launchDomain(), plistPath()]);
+  assertManagedPlatform();
+  const path = process.platform === "linux" ? unitPath() : plistPath();
+  if (!existsSync(path)) throw new Error("Tunnel service is not installed; rerun full setup");
+  if (process.platform === "linux") {
+    runChecked("systemctl", ["--user", "daemon-reload"]);
+    if (!getTunnelServiceStatus().loaded) runChecked("systemctl", ["--user", "enable", "--now", SYSTEMD_UNIT]);
+  } else if (!getTunnelServiceStatus().loaded) runChecked("launchctl", ["bootstrap", launchDomain(), plistPath()]);
   return getTunnelServiceStatus();
 }
 
@@ -139,10 +209,13 @@ async function waitForTunnelServiceUnloaded(timeoutMs = 20_000): Promise<void> {
 }
 
 export async function stopTunnelService(): Promise<TunnelServiceStatus> {
-  assertMacOs();
+  assertManagedPlatform();
   if (getTunnelServiceStatus().loaded) {
-    runChecked("launchctl", ["bootout", serviceTarget()]);
-    await waitForTunnelServiceUnloaded();
+    if (process.platform === "linux") runChecked("systemctl", ["--user", "stop", SYSTEMD_UNIT]);
+    else {
+      runChecked("launchctl", ["bootout", serviceTarget()]);
+      await waitForTunnelServiceUnloaded();
+    }
   }
   return getTunnelServiceStatus();
 }
@@ -153,8 +226,12 @@ export async function restartTunnelService(): Promise<TunnelServiceStatus> {
 }
 
 export async function uninstallTunnelService(): Promise<TunnelServiceStatus> {
-  assertMacOs();
+  assertManagedPlatform();
   await stopTunnelService();
-  rmSync(plistPath(), { force: true });
+  if (process.platform === "linux") {
+    runCommand("systemctl", ["--user", "disable", SYSTEMD_UNIT]);
+    rmSync(unitPath(), { force: true });
+    runChecked("systemctl", ["--user", "daemon-reload"]);
+  } else rmSync(plistPath(), { force: true });
   return getTunnelServiceStatus();
 }

--- a/src/tunnel.ts
+++ b/src/tunnel.ts
@@ -165,8 +165,10 @@ export function createNgrokTunnelConfig(options: {
   };
 }
 
-export function ngrokConnectorUrl(config: NgrokTunnelConfig): string {
-  return `${config.url}/mcp`;
+export function ngrokConnectorUrl(config: NgrokTunnelConfig, accessToken?: string): string {
+  const endpoint = new URL(`${config.url.replace(/\/$/, "")}/mcp`);
+  if (accessToken) endpoint.searchParams.set("access_token", accessToken);
+  return endpoint.toString();
 }
 
 export function ngrokStatusPath(): string {
@@ -273,7 +275,7 @@ export function tunnelStatus(config: AppConfig): TunnelRuntimeStatus {
         healthy: ready,
         ready,
         state: ready ? "ready" : "starting",
-        detail: ready ? `endpoint=${ngrokConnectorUrl(config.tunnel)}` : "ngrok endpoint has not reported ready",
+        detail: ready ? `endpoint=${ngrokConnectorUrl(config.tunnel)} (authentication required)` : "ngrok endpoint has not reported ready",
       };
     } catch {
       return {

--- a/src/tunnel.ts
+++ b/src/tunnel.ts
@@ -2,8 +2,8 @@ import { createHash } from "node:crypto";
 import { chmodSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { unzipSync } from "fflate";
-import type { AppConfig, TunnelConfig } from "./config";
-import { atomicWriteFile, getConfigDir } from "./config";
+import type { AppConfig, NgrokTunnelConfig, OpenAiTunnelConfig } from "./config";
+import { atomicWriteFile, getConfigDir, isNgrokTunnel, isOpenAiTunnel } from "./config";
 import { runCommand, runChecked } from "./process";
 import { getTunnelServiceStatus } from "./tunnel-service";
 
@@ -126,7 +126,7 @@ export function createTunnelConfig(options: {
   runtimeKeyFile: string;
   profileName?: string;
   alias?: string;
-}): TunnelConfig {
+}): OpenAiTunnelConfig {
   if (!/^tunnel_[a-f0-9]{32}$/.test(options.tunnelId)) throw new Error("--tunnel-id must be tunnel_ followed by 32 lowercase hexadecimal characters");
   const profileName = options.profileName ?? "codex-chatgpt-web";
   const alias = options.alias ?? "codex-chatgpt-web";
@@ -134,6 +134,7 @@ export function createTunnelConfig(options: {
     throw new Error("Tunnel profile and alias may contain only letters, digits, dot, underscore, and dash");
   }
   return {
+    provider: "openai",
     binaryPath: options.binaryPath,
     tunnelId: options.tunnelId,
     runtimeKeyFile: options.runtimeKeyFile,
@@ -141,6 +142,35 @@ export function createTunnelConfig(options: {
     profileName,
     alias,
   };
+}
+
+export function createNgrokTunnelConfig(options: {
+  binaryPath: string;
+  url: string;
+  port: number;
+}): NgrokTunnelConfig {
+  const parsed = new URL(options.url);
+  if (parsed.protocol !== "https:" || parsed.username || parsed.password || parsed.search || parsed.hash
+    || (parsed.pathname !== "/" && parsed.pathname !== "")) {
+    throw new Error("--ngrok-url must be an HTTPS origin without credentials, path, query, or fragment");
+  }
+  if (!Number.isInteger(options.port) || options.port < 1 || options.port > 65_535) {
+    throw new Error("Ngrok MCP port must be an integer from 1 to 65535");
+  }
+  return {
+    provider: "ngrok",
+    binaryPath: options.binaryPath,
+    url: parsed.origin,
+    port: options.port,
+  };
+}
+
+export function ngrokConnectorUrl(config: NgrokTunnelConfig): string {
+  return `${config.url}/mcp`;
+}
+
+export function ngrokStatusPath(): string {
+  return join(getConfigDir(), "runtime", "ngrok-status.json");
 }
 
 function shellQuote(value: string): string {
@@ -152,8 +182,10 @@ export function mcpCommand(config: AppConfig): string {
   return [...config.runtimeCommand, "mcp", "--broker-socket", config.brokerSocketPath].map(shellQuote).join(" ");
 }
 
-function tunnel(config: AppConfig): TunnelConfig {
-  if (config.mode !== "full" || !config.tunnel) throw new Error("Tunnel commands require full mode");
+function tunnel(config: AppConfig): OpenAiTunnelConfig {
+  if (config.mode !== "full" || !config.tunnel || !isOpenAiTunnel(config.tunnel)) {
+    throw new Error("This command requires the OpenAI tunnel provider");
+  }
   return config.tunnel;
 }
 
@@ -174,6 +206,7 @@ export function connectTunnel(config: AppConfig): void {
 }
 
 export function stopTunnel(config: AppConfig): void {
+  if (config.mode === "full" && config.tunnel && isNgrokTunnel(config.tunnel)) return;
   const settings = tunnel(config);
   const result = runCommand(settings.binaryPath, ["runtimes", "stop", settings.alias, "--json"]);
   if (result.status !== 0 && !/not found|not running|unknown alias/i.test(`${result.stdout}\n${result.stderr}`)) {
@@ -225,7 +258,34 @@ export function parseTunnelStatus(output: string, exitStatus = 0): TunnelRuntime
 }
 
 export function tunnelStatus(config: AppConfig): TunnelRuntimeStatus {
-  const settings = tunnel(config);
+  if (config.mode !== "full" || !config.tunnel) throw new Error("Tunnel commands require full mode");
+  if (isNgrokTunnel(config.tunnel)) {
+    const service = getTunnelServiceStatus();
+    if (!existsSync(config.tunnel.binaryPath)) {
+      return { ok: false, processRunning: false, healthy: false, ready: false, detail: `Missing ${config.tunnel.binaryPath}` };
+    }
+    try {
+      const marker = JSON.parse(readFileSync(ngrokStatusPath(), "utf8")) as Record<string, unknown>;
+      const ready = service.running && marker.ready === true && marker.url === config.tunnel.url;
+      return {
+        ok: ready,
+        processRunning: service.running,
+        healthy: ready,
+        ready,
+        state: ready ? "ready" : "starting",
+        detail: ready ? `endpoint=${ngrokConnectorUrl(config.tunnel)}` : "ngrok endpoint has not reported ready",
+      };
+    } catch {
+      return {
+        ok: false,
+        processRunning: service.running,
+        healthy: false,
+        ready: false,
+        detail: service.running ? "ngrok endpoint is starting" : "ngrok service is not running",
+      };
+    }
+  }
+  const settings = config.tunnel;
   if (!existsSync(settings.binaryPath)) {
     return { ok: false, processRunning: false, healthy: false, ready: false, detail: `Missing ${settings.binaryPath}` };
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -300,7 +300,11 @@ export interface CodexProviderConfig {
     appName?: string;
     /** Playwright storage-state file created by the explicit browser login. */
     storageStatePath?: string;
-    /** System Chrome executable. The runtime never downloads a browser. */
+    /** Browser engine used by Playwright. */
+    browserEngine?: "chromium" | "firefox";
+    /** Explicit browser executable. Firefox defaults to Playwright's managed build. */
+    browserExecutablePath?: string;
+    /** Legacy Chromium executable setting. */
     chromeExecutablePath?: string;
     /** Unix socket bridging the turn-bound MCP capability into outer Codex tools. */
     brokerSocketPath?: string;

--- a/tests/browser-login.test.ts
+++ b/tests/browser-login.test.ts
@@ -2,7 +2,13 @@ import { expect, test } from "bun:test";
 import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { browserLoginArguments, browserLoginStateExists, loginToChatGpt, loginVerificationMarkerPath } from "../src/browser-login";
+import {
+  browserLoginArguments,
+  browserLoginStateExists,
+  loginToChatGpt,
+  loginVerificationMarkerPath,
+  normalLoginBrowserExecutable,
+} from "../src/browser-login";
 import { CHATGPT_TEMPORARY_CHAT_URL } from "../src/chatgpt-session";
 import { defaultConfig } from "../src/config";
 
@@ -43,6 +49,18 @@ test("Firefox login uses a dedicated profile without Chromium flags", () => {
     "-new-window",
     CHATGPT_TEMPORARY_CHAT_URL,
   ]);
+});
+
+test("Linux Firefox login uses the system browser instead of the automation build", () => {
+  const root = mkdtempSync(join(tmpdir(), "codex-chatgpt-web-system-firefox-"));
+  try {
+    const systemFirefox = join(root, "firefox");
+    writeFileSync(systemFirefox, "");
+    expect(normalLoginBrowserExecutable("firefox", "/playwright/firefox", "linux", systemFirefox)).toBe(systemFirefox);
+    expect(normalLoginBrowserExecutable("chromium", "/playwright/chromium", "linux", systemFirefox)).toBe("/playwright/chromium");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("a storage-state file is not trusted without a verification marker", () => {

--- a/tests/browser-login.test.ts
+++ b/tests/browser-login.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test";
 import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { browserLoginStateExists, loginToChatGpt, loginVerificationMarkerPath } from "../src/browser-login";
+import { browserLoginArguments, browserLoginStateExists, loginToChatGpt, loginVerificationMarkerPath } from "../src/browser-login";
 import { CHATGPT_TEMPORARY_CHAT_URL } from "../src/chatgpt-session";
 import { defaultConfig } from "../src/config";
 
@@ -16,7 +16,7 @@ test("login starts with normal Chrome and captures state in a headed Keychain-aw
   process.env.CODEX_LOGIN_ARG_LOG = argsLog;
   try {
     const config = defaultConfig("browser-only");
-    config.chromeExecutablePath = executable;
+    config.browserExecutablePath = executable;
     config.storageStatePath = join(root, "browser", "storage-state.json");
     await loginToChatGpt(config, { timeoutMs: 100 }).catch(() => {});
 
@@ -32,6 +32,17 @@ test("login starts with normal Chrome and captures state in a headed Keychain-aw
     else process.env.CODEX_LOGIN_ARG_LOG = previousLog;
     rmSync(root, { recursive: true, force: true });
   }
+});
+
+test("Firefox login uses a dedicated profile without Chromium flags", () => {
+  const args = browserLoginArguments("firefox", "/tmp/firefox-profile");
+  expect(args).toEqual([
+    "-no-remote",
+    "-profile",
+    "/tmp/firefox-profile",
+    "-new-window",
+    CHATGPT_TEMPORARY_CHAT_URL,
+  ]);
 });
 
 test("a storage-state file is not trusted without a verification marker", () => {

--- a/tests/chatgpt-web-harness.test.ts
+++ b/tests/chatgpt-web-harness.test.ts
@@ -34,6 +34,9 @@ const tools: CodexTool[] = [
   { name: "write_stdin", description: "Continue command", parameters: { type: "object" } },
   { name: "apply_patch", description: "Patch files", parameters: {}, freeform: true },
   { name: "view_image", description: "View image", parameters: { type: "object" } },
+  { name: "get_goal", description: "Read the current persistent goal", parameters: { type: "object" } },
+  { name: "create_goal", description: "Create a persistent goal", parameters: { type: "object" } },
+  { name: "update_goal", description: "Update the current persistent goal", parameters: { type: "object" } },
   { name: "search_openai_docs", namespace: "mcp__openaiDeveloperDocs", description: "Search docs", parameters: { type: "object" } },
 ];
 
@@ -300,6 +303,7 @@ describe("ChatGPT outer-native harness v3", () => {
 
     expect(compiled.text).toContain("d".repeat(70_000));
     expect(compiled.text).toContain("<codex_context_json>");
+    expect(compiled.text).toContain("Do not use nested local-agent workspace connectors");
     expect(files.map(file => file.name)).toEqual(["codex-input-image-1.png"]);
     expect(files[0]!.mimeType).toBe("image/png");
   });
@@ -787,7 +791,7 @@ describe("ChatGPT outer-native harness v3", () => {
     const broker = TurnBroker.forSocket(socketPath);
     const gatewayOnlyEnvironment = extractChatGptTurnEnvironment(parsed(environmentXml));
     gatewayOnlyEnvironment.tools = gatewayOnlyEnvironment.tools.filter(tool => (
-      tool.name === "exec" || tool.name === "search_openai_docs"
+      ["exec", "search_openai_docs", "get_goal", "create_goal", "update_goal"].includes(tool.name)
     ));
     const token = await broker.register(gatewayOnlyEnvironment, 60_000);
     const transport = new StdioClientTransport({
@@ -823,6 +827,10 @@ describe("ChatGPT outer-native harness v3", () => {
       const discovered = (inventory.structuredContent as { tools: Array<{ wire_name: string }> }).tools;
       expect(discovered.map(tool => tool.wire_name)).toEqual(["mcp__openaiDeveloperDocs__search_openai_docs"]);
 
+      const goalInventory = await call("codex_tool_inventory", { binding_id: bindingId, query: "goal" });
+      const goalTools = (goalInventory.structuredContent as { tools: Array<{ wire_name: string }> }).tools;
+      expect(goalTools.map(tool => tool.wire_name)).toEqual(["get_goal", "create_goal", "update_goal"]);
+
       const execPromise = call("codex_exec", { binding_id: bindingId, cmd: "pwd", workdir: tempRoot });
       const [execRequest] = await broker.nextToolBatch(token);
       expect(execRequest).toMatchObject({ wireName: "exec", freeform: true });
@@ -848,6 +856,17 @@ describe("ChatGPT outer-native harness v3", () => {
       expect(docsRequest?.input).toContain('tools["mcp__openaiDeveloperDocs__search_openai_docs"]({"query":"Responses API"})');
       broker.completeTool(token, docsRequest!.callId, toolResult({ hits: 3 }));
       expect((await docsPromise).structuredContent).toEqual({ hits: 3 });
+
+      const goalPromise = call("codex_tool_call", {
+        binding_id: bindingId,
+        wire_name: "get_goal",
+        arguments: {},
+      });
+      const [goalRequest] = await broker.nextToolBatch(token);
+      expect(goalRequest).toMatchObject({ wireName: "exec", freeform: true });
+      expect(goalRequest?.input).toContain('tools["get_goal"]({})');
+      broker.completeTool(token, goalRequest!.callId, toolResult({ status: "active" }));
+      expect((await goalPromise).structuredContent).toEqual({ status: "active" });
     } finally {
       await client.close().catch(() => {});
       broker.revoke(token);

--- a/tests/chatgpt-web-harness.test.ts
+++ b/tests/chatgpt-web-harness.test.ts
@@ -105,6 +105,8 @@ describe("ChatGPT outer-native harness v3", () => {
     expect(chatGptComposerTextMatchesPrompt("first second", "first\nsecond")).toBe(true);
     expect(chatGptComposerTextMatchesPrompt("first  second", "first\n\nsecond")).toBe(true);
     expect(chatGptComposerTextMatchesPrompt("first changed", "first\nsecond")).toBe(false);
+    expect(chatGptComposerTextMatchesPrompt("first second", "first\r\nsecond")).toBe(false);
+    expect(chatGptComposerTextMatchesPrompt("first second", "first\rsecond")).toBe(false);
   });
 
   test("extracts authoritative environment, tool registry, and turn identity from the Codex wire envelope", () => {

--- a/tests/chatgpt-web-harness.test.ts
+++ b/tests/chatgpt-web-harness.test.ts
@@ -5,7 +5,13 @@ import { mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { buildResponseJSON } from "../src/bridge";
-import { ChatGptCompletionTracker, chatGptImageFilePayloads, chatGptPromptFilePayloads, chatGptTurnIsComplete } from "../src/adapters/chatgpt-web/browser-worker";
+import {
+  ChatGptCompletionTracker,
+  chatGptComposerTextMatchesPrompt,
+  chatGptImageFilePayloads,
+  chatGptPromptFilePayloads,
+  chatGptTurnIsComplete,
+} from "../src/adapters/chatgpt-web/browser-worker";
 import { ChatGptBrowserWorker, type BrowserTurn } from "../src/adapters/chatgpt-web/browser-worker";
 import { extractChatGptTurnEnvironment, extractChatGptTurnIdentity } from "../src/adapters/chatgpt-web/environment";
 import { createChatGptWebAdapter } from "../src/adapters/chatgpt-web/index";
@@ -94,6 +100,13 @@ function toolResult(value: Record<string, unknown>): BrokerToolResult {
 }
 
 describe("ChatGPT outer-native harness v3", () => {
+  test("accepts only the composer's newline-to-space canonicalization", () => {
+    expect(chatGptComposerTextMatchesPrompt("first\nsecond", "first\nsecond")).toBe(true);
+    expect(chatGptComposerTextMatchesPrompt("first second", "first\nsecond")).toBe(true);
+    expect(chatGptComposerTextMatchesPrompt("first  second", "first\n\nsecond")).toBe(true);
+    expect(chatGptComposerTextMatchesPrompt("first changed", "first\nsecond")).toBe(false);
+  });
+
   test("extracts authoritative environment, tool registry, and turn identity from the Codex wire envelope", () => {
     const request = rawWireRequest(environmentXml);
     expect(extractChatGptTurnEnvironment(request)).toEqual({

--- a/tests/environment.test.ts
+++ b/tests/environment.test.ts
@@ -80,6 +80,33 @@ describe("trusted current Codex environment envelope", () => {
     expect(() => extractChatGptTurnEnvironment(currentWire({ includeIds: false })))
       .toThrow("missing cwd");
   });
+
+  test("accepts the Codex 0.145 split permissions instructions", () => {
+    const parsed = currentWire({ sandbox: "read-only", includeIds: false });
+    parsed.context.messages.unshift(
+      {
+        role: "developer",
+        content: "<permissions instructions>\nFilesystem sandboxing defines which files can be read or written. `sandbox_mode` is `read-only`: The sandbox only permits reading files.\n</permissions instructions>",
+        timestamp: 0,
+      },
+      {
+        role: "developer",
+        content: `<environment_context>
+  <cwd>${root}</cwd>
+  <filesystem><workspace_roots><root>${root}</root></workspace_roots><permission_profile type="managed"><file_system type="restricted"><entry access="read"><special>:root</special></entry></file_system></permission_profile></filesystem>
+</environment_context>`,
+        timestamp: 0,
+      },
+    );
+
+    expect(extractChatGptTurnEnvironment(parsed)).toEqual({
+      cwd: root,
+      roots: [root],
+      writableRoots: [],
+      sandboxPolicy: { type: "readOnly", networkAccess: false },
+      tools: [],
+    });
+  });
 });
 
 describe("trusted Codex task environment continuity", () => {

--- a/tests/mcp-http.test.ts
+++ b/tests/mcp-http.test.ts
@@ -1,32 +1,48 @@
 import { expect, test } from "bun:test";
 import { startChatGptMcpHttpServer } from "../src/adapters/chatgpt-web/mcp-http";
 
-test("stateless Streamable HTTP MCP initializes over loopback", async () => {
+const accessToken = "mcp-access-token-0123456789abcdef0123456789";
+const initializeRequest = {
+  method: "POST",
+  headers: {
+    "content-type": "application/json",
+    accept: "application/json, text/event-stream",
+  },
+  body: JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: "2025-06-18",
+      capabilities: {},
+      clientInfo: { name: "test", version: "1" },
+    },
+  }),
+};
+
+test("stateless Streamable HTTP MCP requires its access token", async () => {
   const server = startChatGptMcpHttpServer({
     brokerSocketPath: "/tmp/codex-chatgpt-web-unused-broker.sock",
     port: 0,
+    accessToken,
   });
   try {
-    const response = await fetch(`http://localhost:${server.port}/mcp`, {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        accept: "application/json, text/event-stream",
-      },
-      body: JSON.stringify({
-        jsonrpc: "2.0",
-        id: 1,
-        method: "initialize",
-        params: {
-          protocolVersion: "2025-06-18",
-          capabilities: {},
-          clientInfo: { name: "test", version: "1" },
-        },
-      }),
-    });
+    const unauthorized = await fetch(`http://localhost:${server.port}/mcp`, initializeRequest);
+    expect(unauthorized.status).toBe(401);
+
+    const response = await fetch(
+      `http://localhost:${server.port}/mcp?access_token=${encodeURIComponent(accessToken)}`,
+      initializeRequest,
+    );
     const payload = await response.json() as { result?: { serverInfo?: { name?: string } } };
     expect(response.status).toBe(200);
     expect(payload.result?.serverInfo?.name).toBe("codex-native");
+
+    const bearerResponse = await fetch(`http://localhost:${server.port}/mcp`, {
+      ...initializeRequest,
+      headers: { ...initializeRequest.headers, authorization: `Bearer ${accessToken}` },
+    });
+    expect(bearerResponse.status).toBe(200);
   } finally {
     server.stop(true);
   }

--- a/tests/mcp-http.test.ts
+++ b/tests/mcp-http.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test";
+import { startChatGptMcpHttpServer } from "../src/adapters/chatgpt-web/mcp-http";
+
+test("stateless Streamable HTTP MCP initializes over loopback", async () => {
+  const server = startChatGptMcpHttpServer({
+    brokerSocketPath: "/tmp/codex-chatgpt-web-unused-broker.sock",
+    port: 0,
+  });
+  try {
+    const response = await fetch(`http://localhost:${server.port}/mcp`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: { name: "test", version: "1" },
+        },
+      }),
+    });
+    const payload = await response.json() as { result?: { serverInfo?: { name?: string } } };
+    expect(response.status).toBe(200);
+    expect(payload.result?.serverInfo?.name).toBe("codex-native");
+  } finally {
+    server.stop(true);
+  }
+});

--- a/tests/model-catalog.test.ts
+++ b/tests/model-catalog.test.ts
@@ -55,6 +55,7 @@ describe("native /models augmentation", () => {
       expect(model).toMatchObject({
         slug: route.slug,
         display_name: route.displayName,
+        prefer_websockets: false,
         tool_mode: route.requiresPro ? null : "code_mode_only",
         default_reasoning_level: route.codexEffort,
         supported_reasoning_levels: [{ effort: route.codexEffort, description: route.displayName }],

--- a/tests/model-catalog.test.ts
+++ b/tests/model-catalog.test.ts
@@ -55,7 +55,7 @@ describe("native /models augmentation", () => {
       expect(model).toMatchObject({
         slug: route.slug,
         display_name: route.displayName,
-        prefer_websockets: false,
+        prefer_websockets: true,
         tool_mode: route.requiresPro ? null : "code_mode_only",
         default_reasoning_level: route.codexEffort,
         supported_reasoning_levels: [{ effort: route.codexEffort, description: route.displayName }],

--- a/tests/ngrok-runtime.test.ts
+++ b/tests/ngrok-runtime.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "bun:test";
+import { ngrokStartedUrl } from "../src/ngrok-runtime";
+
+test("ngrok readiness accepts only a structured started-tunnel event", () => {
+  expect(ngrokStartedUrl(JSON.stringify({
+    msg: "started tunnel",
+    url: "https://codex.example.ngrok.app",
+  }))).toBe("https://codex.example.ngrok.app");
+  expect(ngrokStartedUrl(JSON.stringify({ msg: "starting tunnel", url: "https://wrong.example" }))).toBeUndefined();
+  expect(ngrokStartedUrl("not json")).toBeUndefined();
+});

--- a/tests/ngrok-runtime.test.ts
+++ b/tests/ngrok-runtime.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { ngrokStartedUrl } from "../src/ngrok-runtime";
+import { ngrokEnvironment, ngrokStartedUrl } from "../src/ngrok-runtime";
 
 test("ngrok readiness accepts only a structured started-tunnel event", () => {
   expect(ngrokStartedUrl(JSON.stringify({
@@ -8,4 +8,14 @@ test("ngrok readiness accepts only a structured started-tunnel event", () => {
   }))).toBe("https://codex.example.ngrok.app");
   expect(ngrokStartedUrl(JSON.stringify({ msg: "starting tunnel", url: "https://wrong.example" }))).toBeUndefined();
   expect(ngrokStartedUrl("not json")).toBeUndefined();
+});
+
+test("ngrok does not inherit generic HTTP proxy variables", () => {
+  expect(ngrokEnvironment({
+    HTTP_PROXY: "http://proxy.example",
+    HTTPS_PROXY: "http://proxy.example",
+    http_proxy: "http://proxy.example",
+    https_proxy: "http://proxy.example",
+    NGROK_AUTHTOKEN: "preserved",
+  })).toEqual({ NGROK_AUTHTOKEN: "preserved" });
 });

--- a/tests/runtime-layout.test.ts
+++ b/tests/runtime-layout.test.ts
@@ -42,6 +42,10 @@ test("setup explicitly migrates v1 pro-only config to v2 browser-only", () => {
 
   expect(() => loadConfig()).toThrow("rerun setup to migrate");
   expect(loadConfigForSetup()).toMatchObject({ version: 2, mode: "browser-only" });
+  expect(loadConfigForSetup()).toMatchObject({
+    browserEngine: "chromium",
+    browserExecutablePath: "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+  });
 });
 
 test("legacy temp-path wrapper and vendor are removed only after runtime ownership changes", () => {

--- a/tests/runtime-layout.test.ts
+++ b/tests/runtime-layout.test.ts
@@ -41,8 +41,10 @@ test("setup explicitly migrates v1 pro-only config to v2 browser-only", () => {
   })}\n`);
 
   expect(() => loadConfig()).toThrow("rerun setup to migrate");
-  expect(loadConfigForSetup()).toMatchObject({ version: 2, mode: "browser-only" });
-  expect(loadConfigForSetup()).toMatchObject({
+  const migrated = loadConfigForSetup();
+  expect(migrated).toMatchObject({ version: 2, mode: "browser-only" });
+  expect(migrated.mcpAccessToken).toMatch(/^[A-Za-z0-9_-]{40,}$/);
+  expect(migrated).toMatchObject({
     browserEngine: "chromium",
     browserExecutablePath: "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
   });

--- a/tests/server-lifecycle.test.ts
+++ b/tests/server-lifecycle.test.ts
@@ -45,14 +45,14 @@ test("authenticated lifecycle control cancels orphaned browser turns", async () 
   }));
 
   try {
-    const unauthorized = await fetch(`http://127.0.0.1:${server.port}/admin/cancel-browser-turns`, {
+    const unauthorized = await fetch(`http://localhost:${server.port}/admin/cancel-browser-turns`, {
       method: "POST",
       headers: { authorization: "Bearer invalid" },
     });
     expect(unauthorized.status).toBe(401);
     expect(chatGptTurnSessions.activeCount()).toBe(1);
 
-    const response = await fetch(`http://127.0.0.1:${server.port}/admin/cancel-browser-turns`, {
+    const response = await fetch(`http://localhost:${server.port}/admin/cancel-browser-turns`, {
       method: "POST",
       headers: { authorization: `Bearer ${config.controlToken}` },
     });

--- a/tests/server-websocket.test.ts
+++ b/tests/server-websocket.test.ts
@@ -21,6 +21,23 @@ function nextJson(socket: WebSocket): Promise<Record<string, unknown>> {
   });
 }
 
+function nextJsonOfType(socket: WebSocket, type: string): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const onMessage = (event: MessageEvent) => {
+      try {
+        const payload = JSON.parse(String(event.data)) as Record<string, unknown>;
+        if (payload.type !== type) return;
+        socket.removeEventListener("message", onMessage);
+        resolve(payload);
+      } catch (error) {
+        socket.removeEventListener("message", onMessage);
+        reject(error);
+      }
+    };
+    socket.addEventListener("message", onMessage);
+  });
+}
+
 test("Responses WebSocket accepts reusable response.create prewarms", async () => {
   const config = { ...defaultConfig("browser-only"), port: 0 };
   const server = startServer(config);
@@ -74,6 +91,23 @@ test("Responses WebSocket accepts reusable response.create prewarms", async () =
     const second = await secondMessage;
     expect(second.type).toBe("response.completed");
     expect((second.response as { id: string }).id).not.toBe(firstId);
+
+    const failedMessage = nextJsonOfType(socket, "error");
+    socket.send(JSON.stringify({
+      type: "response.create",
+      model: "chatgpt-web/high",
+      instructions: "",
+      input: [{ role: "user", content: [{ type: "input_text", text: "missing trusted environment" }] }],
+      tools: [],
+      tool_choice: "auto",
+      parallel_tool_calls: true,
+      store: false,
+      stream: true,
+    }));
+    expect(await failedMessage).toMatchObject({
+      type: "error",
+      status: 500,
+    });
   } finally {
     socket.close();
     await server.stop(true);

--- a/tests/server-websocket.test.ts
+++ b/tests/server-websocket.test.ts
@@ -1,0 +1,81 @@
+import { expect, test } from "bun:test";
+import { defaultConfig } from "../src/config";
+import { startServer } from "../src/server";
+
+function opened(socket: WebSocket): Promise<void> {
+  return new Promise((resolve, reject) => {
+    socket.addEventListener("open", () => resolve(), { once: true });
+    socket.addEventListener("error", () => reject(new Error("WebSocket connection failed")), { once: true });
+  });
+}
+
+function nextJson(socket: WebSocket): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    socket.addEventListener("message", event => {
+      try {
+        resolve(JSON.parse(String(event.data)) as Record<string, unknown>);
+      } catch (error) {
+        reject(error);
+      }
+    }, { once: true });
+  });
+}
+
+test("Responses WebSocket accepts reusable response.create prewarms", async () => {
+  const config = { ...defaultConfig("browser-only"), port: 0 };
+  const server = startServer(config);
+  const socket = new WebSocket(`ws://127.0.0.1:${server.port}/v1/responses`);
+
+  try {
+    await opened(socket);
+
+    const invalidMessage = nextJson(socket);
+    socket.send(JSON.stringify({
+      type: "response.create",
+      generate: false,
+      model: "chatgpt-web/not-enabled",
+      input: [],
+      stream: true,
+    }));
+    expect(await invalidMessage).toMatchObject({
+      type: "error",
+      status: 400,
+      error: { type: "invalid_request_error" },
+    });
+
+    const firstMessage = nextJson(socket);
+    socket.send(JSON.stringify({
+      type: "response.create",
+      generate: false,
+      model: "chatgpt-web/high",
+      input: [],
+      stream: true,
+    }));
+    const first = await firstMessage;
+    expect(first.type).toBe("response.completed");
+    expect(first.sequence_number).toBe(0);
+    expect(first.response).toMatchObject({
+      object: "response",
+      status: "completed",
+      model: "chatgpt-web/high",
+      output: [],
+    });
+
+    const firstId = (first.response as { id: string }).id;
+    const secondMessage = nextJson(socket);
+    socket.send(JSON.stringify({
+      type: "response.create",
+      generate: false,
+      previous_response_id: firstId,
+      model: "chatgpt-web/high",
+      input: [],
+      stream: true,
+    }));
+    const second = await secondMessage;
+    expect(second.type).toBe("response.completed");
+    expect((second.response as { id: string }).id).not.toBe(firstId);
+  } finally {
+    socket.close();
+    await server.stop(true);
+  }
+});

--- a/tests/service-lifecycle.test.ts
+++ b/tests/service-lifecycle.test.ts
@@ -4,11 +4,21 @@ import { serviceDefinition } from "../src/service";
 import { defaultConfig } from "../src/config";
 
 describe("service drain lifecycle", () => {
-  test("defines a restartable systemd user service without a shell", () => {
+  test("starts a headed systemd service with the graphical session", () => {
     const definition = serviceDefinition(defaultConfig("browser-only"), "linux");
-    expect(definition).toContain("WantedBy=default.target");
+    expect(definition).toContain("After=network-online.target graphical-session.target");
+    expect(definition).toContain("PartOf=graphical-session.target");
+    expect(definition).toContain("WantedBy=graphical-session.target");
     expect(definition).toContain("Restart=always");
     expect(definition).not.toContain("/bin/sh");
+  });
+
+  test("starts a headless systemd service with the default user target", () => {
+    const config = defaultConfig("browser-only");
+    config.headed = false;
+    const definition = serviceDefinition(config, "linux");
+    expect(definition).not.toContain("graphical-session.target");
+    expect(definition).toContain("WantedBy=default.target");
   });
 
   test("compensates when a drain may have reached the daemon before the client times out", async () => {

--- a/tests/service-lifecycle.test.ts
+++ b/tests/service-lifecycle.test.ts
@@ -1,7 +1,16 @@
 import { describe, expect, test } from "bun:test";
 import { negotiateDrain } from "../src/service";
+import { serviceDefinition } from "../src/service";
+import { defaultConfig } from "../src/config";
 
 describe("service drain lifecycle", () => {
+  test("defines a restartable systemd user service without a shell", () => {
+    const definition = serviceDefinition(defaultConfig("browser-only"), "linux");
+    expect(definition).toContain("WantedBy=default.target");
+    expect(definition).toContain("Restart=always");
+    expect(definition).not.toContain("/bin/sh");
+  });
+
   test("compensates when a drain may have reached the daemon before the client times out", async () => {
     const actions: string[] = [];
     let acceptingTurns = true;

--- a/tests/tunnel-service.test.ts
+++ b/tests/tunnel-service.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { defaultConfig } from "../src/config";
-import { createTunnelConfig } from "../src/tunnel";
+import { createNgrokTunnelConfig, createTunnelConfig } from "../src/tunnel";
 import { tunnelServiceDefinition } from "../src/tunnel-service";
 import { existingFullSetupCredentials, tunnelWorkerRuntimeChanged } from "../src/setup";
 
@@ -32,7 +32,7 @@ describe("tunnel launchd ownership", () => {
       tunnelId: "tunnel_0123456789abcdef0123456789abcdef",
     });
 
-    const definition = tunnelServiceDefinition(config);
+    const definition = tunnelServiceDefinition(config, "darwin");
     expect(definition).toContain("<string>run</string>");
     expect(definition).toContain(`<string>${config.tunnel.profileDir}</string>`);
     expect(definition).toContain("<key>RunAtLoad</key>\n  <true/>");
@@ -41,6 +41,20 @@ describe("tunnel launchd ownership", () => {
     expect(definition).not.toContain("/bin/sh");
     expect(definition).not.toContain(config.tunnel.tunnelId);
     expect(definition).not.toContain(key);
+  });
+
+  test("runs ngrok and the HTTP MCP bridge under systemd", () => {
+    const config = defaultConfig("full");
+    config.tunnel = createNgrokTunnelConfig({
+      binaryPath: "/usr/local/bin/ngrok",
+      url: "https://codex.example.ngrok.app",
+      port: 17842,
+    });
+    const definition = tunnelServiceDefinition(config, "linux");
+    expect(definition).toContain("ngrok-tunnel");
+    expect(definition).toContain("https://codex.example.ngrok.app");
+    expect(definition).toContain("Restart=always");
+    expect(definition).not.toContain("/bin/sh");
   });
 
   test("restarts the long-lived MCP worker when the installed release changes", () => {

--- a/tests/tunnel.test.ts
+++ b/tests/tunnel.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { parseTunnelStatus } from "../src/tunnel";
+import { ngrokConnectorUrl, parseTunnelStatus } from "../src/tunnel";
 
 describe("tunnel status boundary", () => {
   test("requires the managed runtime process, health, and readiness together", () => {
@@ -31,5 +31,18 @@ describe("tunnel status boundary", () => {
     );
     expect(result.detail).toBe("failed [tunnel-id] with [redacted-key]");
     expect(result.detail).not.toContain("0123456789abcdef");
+  });
+
+  test("adds MCP access tokens only to connector setup URLs", () => {
+    const config = {
+      provider: "ngrok" as const,
+      binaryPath: "/usr/bin/ngrok",
+      url: "https://example.ngrok.app",
+      port: 17842,
+    };
+    expect(ngrokConnectorUrl(config)).toBe("https://example.ngrok.app/mcp");
+    expect(ngrokConnectorUrl(config, "secret-token")).toBe(
+      "https://example.ngrok.app/mcp?access_token=secret-token",
+    );
   });
 });


### PR DESCRIPTION
## Summary

- add Linux x64 installation and `systemd --user` managed services while preserving macOS/launchd support
- add Firefox support with Playwright-managed browser installation and profile handling
- add ngrok as a tunnel provider alongside the existing OpenAI tunnel client
- add stateless Streamable HTTP MCP transport at `/mcp` and a `/healthz` endpoint
- harden loopback/proxy behavior for Linux and ngrok
- update documentation, release packaging, and focused tests

## Validation

- `bun run verify`: 94 tests passed; typecheck, audit, build, licenses, and relocatable runtime smoke passed
- `sh -n scripts/install.sh`
- `git diff --check`
- Playwright Firefox launched headlessly on Linux
- Linux daemon lifecycle passed under `systemd --user`
- ngrok full-harness runtime passed under `systemd --user`
- public health and MCP initialization passed at `https://baggie-pectin-trophy.ngrok-free.dev/mcp`

## Notes

- Linux release installation currently supports x64 because the release workflow publishes an x64 Linux asset
- this remains an unofficial ChatGPT web automation integration and requires interactive browser login during final setup