### PR TITLE
Fix packaged prompt submission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,14 @@ jobs:
       - name: Verify embedded macOS runtime signature
         if: runner.os == 'macOS'
         run: codesign --verify --deep --strict launcher/build/runtime/runtime/bun
+      - name: Verify packaged macOS application signature
+        if: runner.os == 'macOS'
+        run: |
+          archive="$(find launcher/artifacts -maxdepth 1 -name '*-mac-*.zip' -print -quit)"
+          test -n "$archive"
+          stage="$(mktemp -d)"
+          ditto -x -k "$archive" "$stage"
+          codesign --verify --deep --strict --verbose=2 "$stage/Codex Web GPT.app"
       - name: Archive runtime
         if: runner.os != 'Windows'
         run: tar -czf "${{ matrix.runtime_asset }}" -C launcher/build/runtime .

--- a/launcher/electron/browser-host.cjs
+++ b/launcher/electron/browser-host.cjs
@@ -600,6 +600,9 @@ class BrowserHost {
     this.view.webContents.insertText(SMOKE_TEXT);
     await this.waitForComposerText(SMOKE_TEXT);
     await this.waitForSmokeSendButton();
+    if (!await this.focusSmokeSendButton()) {
+      throw new Error("ChatGPT send button could not receive focus for the smoke test");
+    }
     await this.pressTrustedBrowserKey("Enter");
     const submitted = await this.waitForSmokeSubmissionAccepted(beforeUserCount);
     this.logger.info("smoke.submitted", submitted);
@@ -757,6 +760,16 @@ class BrowserHost {
     );
   }
 
+  async focusSmokeSendButton() {
+    return await this.evaluateBrowserPage(`(() => {
+      /* smoke-send-button-focus */
+      const button = ${visibleElementScript('[data-testid="send-button"]')};
+      if (!button || button.disabled || button.getAttribute('aria-disabled') === 'true') return false;
+      button.focus({ preventScroll: true });
+      return document.activeElement === button;
+    })()`);
+  }
+
   async readSmokeSubmissionState(beforeUserCount) {
     return await this.evaluateBrowserPage(`(() => {
       /* smoke-submission-read */
@@ -787,7 +800,7 @@ class BrowserHost {
       await sleep(pollMs);
     } while (Date.now() < deadline);
     throw new Error(
-      `ChatGPT did not accept the smoke-test message after trusted Enter`
+      `ChatGPT did not accept the smoke-test message after activating the send button`
       + ` (userTurnsBefore=${beforeUserCount}; userTurnsNow=${state?.userTurnCount ?? "unknown"};`
       + ` stopVisible=${state?.stopVisible === true})`,
     );

--- a/launcher/package.json
+++ b/launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-web-gpt-launcher",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "description": "Desktop control center for Codex ChatGPT Web",
   "author": "miuuyy",

--- a/launcher/scripts/package.cjs
+++ b/launcher/scripts/package.cjs
@@ -27,15 +27,21 @@ if (target !== nativeTarget) {
 
 const env = { ...process.env };
 if (!env.CSC_LINK && !env.CSC_NAME) env.CSC_IDENTITY_AUTO_DISCOVERY = "false";
+const builderArgs = [
+  electronBuilderCli,
+  target,
+  "--publish",
+  "never",
+];
+if (target === "--mac" && !env.CSC_LINK && !env.CSC_NAME) {
+  builderArgs.push("--config.mac.identity=-");
+}
 
 const staging = fs.mkdtempSync(path.join(os.tmpdir(), "codex-web-gpt-package-"));
 const artifactsDirectory = path.join(root, "artifacts");
 try {
   const result = spawnSync(executable, [
-    electronBuilderCli,
-    target,
-    "--publish",
-    "never",
+    ...builderArgs,
     `--config.directories.output=${staging}`,
   ], {
     cwd: root,

--- a/launcher/tests/browser-host.test.cjs
+++ b/launcher/tests/browser-host.test.cjs
@@ -402,7 +402,7 @@ test("effort selection waits for an already-open menu to hydrate instead of clos
   ]);
 });
 
-test("smoke submission uses trusted Enter and waits for an accepted user turn", async () => {
+test("smoke submission focuses the send button before trusted Enter and waits for an accepted user turn", async () => {
   const keys = [];
   let sendReads = 0;
   let submissionReads = 0;
@@ -417,6 +417,7 @@ test("smoke submission uses trusted Enter and waits for an accepted user turn", 
           ? { ready: false, reason: "disabled" }
           : { ready: true, point: { x: 300, y: 220 } };
       }
+      if (expression.includes("smoke-send-button-focus")) return true;
       assert.match(expression, /smoke-submission-read/);
       submissionReads += 1;
       return {
@@ -429,6 +430,7 @@ test("smoke submission uses trusted Enter and waits for an accepted user turn", 
   };
 
   await BrowserHost.prototype.waitForSmokeSendButton.call(fixture, 100, 1);
+  assert.equal(await BrowserHost.prototype.focusSmokeSendButton.call(fixture), true);
   await BrowserHost.prototype.pressTrustedBrowserKey.call({
     view: fixture.view,
     dispatchTrustedKey: async input => keys.push(input),

--- a/launcher/tests/packaging-contract.test.cjs
+++ b/launcher/tests/packaging-contract.test.cjs
@@ -43,6 +43,8 @@ test("release installers resolve checksummed native launcher assets", () => {
   assert.match(packager, /-linux-x86_64\(\?=\\\.\).*?-linux-x64/);
   assert.match(packager, /process\.execPath/);
   assert.match(packager, /electron-builder\/out\/cli\/cli\.js/);
+  assert.match(packager, /target === "--mac" && !env\.CSC_LINK && !env\.CSC_NAME/);
+  assert.match(packager, /--config\.mac\.identity=-/);
   assert.doesNotMatch(packager, /electron-builder\.cmd/);
   assert.match(shellInstaller, /shell_quote\(\)/);
   assert.match(shellInstaller, /exec %s "\$@"/);
@@ -65,6 +67,8 @@ test("CI packages and smoke-launches on macOS, Windows, and Linux", () => {
   }
   assert.match(release, /launcher\/build\/runtime/);
   assert.match(release, /bun run app:smoke/);
+  assert.match(release, /codesign --verify --deep --strict --verbose=2/);
+  assert.match(release, /Codex Web GPT\.app/);
   assert.doesNotMatch(release, /gh release create[\s\S]*?--draft/);
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-chatgpt-web",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "description": "A focused local Responses bridge that runs Codex tasks through a user-authenticated ChatGPT web session.",
   "repository": {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,7 +2,7 @@
 set -eu
 
 REPOSITORY="${CODEX_CHATGPT_WEB_REPOSITORY:-miuuyy/codex-chatgpt-web}"
-VERSION="${CODEX_CHATGPT_WEB_VERSION:-1.0.0}"
+VERSION="${CODEX_CHATGPT_WEB_VERSION:-1.0.1}"
 BIN_DIR="${CODEX_CHATGPT_WEB_BIN_DIR:-$HOME/.local/bin}"
 LIB_DIR="${CODEX_CHATGPT_WEB_LIB_DIR:-$HOME/.local/lib/codex-chatgpt-web}"
 DOC_DIR="${CODEX_CHATGPT_WEB_DOC_DIR:-$HOME/.local/share/doc/codex-chatgpt-web}"

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -884,7 +884,15 @@ export class ChatGptBrowserWorker {
       const userTurns = page.locator(CHATGPT_USER_TURN_SELECTOR);
       const initialUserTurnCount = await userTurns.count();
       await this.runStage(turn.traceId, "send", browserStageTimeouts.send, async () => {
-        await page.getByTestId("send-button").dispatchEvent("click");
+        const composer = await this.activeComposer(page);
+        const sendButton = composer
+          .locator("xpath=ancestor::form[1]")
+          .getByTestId("send-button");
+        await sendButton.waitFor({ state: "visible", timeout: browserStageTimeouts.send });
+        if (!await sendButton.isEnabled()) {
+          throw new Error("ChatGPT send button is disabled after the complete prompt was attached");
+        }
+        await sendButton.press("Enter");
         await userTurns.nth(initialUserTurnCount).waitFor({
           state: "visible",
           timeout: browserStageTimeouts.send,

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "1.0.0";
+export const VERSION = "1.0.1";

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -11,6 +11,13 @@ test("Codex context uses the owned CDP composer transport, never the operating-s
   expect(workerSource).not.toMatch(/\bclipboard\b|pbcopy|pbpaste/i);
 });
 
+test("completed prompts activate the scoped semantic send control", () => {
+  const workerSource = readFileSync(new URL("../src/adapters/chatgpt-web/browser-worker.ts", import.meta.url), "utf8");
+  expect(workerSource).toContain('.getByTestId("send-button")');
+  expect(workerSource).toContain('await sendButton.press("Enter")');
+  expect(workerSource).not.toContain('getByTestId("send-button").dispatchEvent("click")');
+});
+
 test("connector verification and real tool turns share one Playwright selector", () => {
   const workerSource = readFileSync(new URL("../src/adapters/chatgpt-web/browser-worker.ts", import.meta.url), "utf8");
   expect(workerSource.match(/this\.selectConnector\(page\)/g)?.length).toBe(2);


### PR DESCRIPTION
## What changed

- activate ChatGPT's scoped semantic Send control for both launcher smoke tests and real Codex Web turns
- fail explicitly if the send control cannot be focused or is disabled
- ad-hoc sign macOS bundles when no Developer ID identity is configured
- verify the complete macOS app signature in release CI
- bump the release to 1.0.1

## Root cause

The packaged launcher relied on ChatGPT accepting Enter while the composer retained focus. The same build accepted that interaction earlier and later ignored it, leaving the prepared message unsent. The macOS artifact also lacked a complete sealed resource envelope when built without a signing identity.

## Validation

- `bun run verify` (138 core tests, 120 launcher tests, typechecks, renderer build, relocatable runtime smoke)
- packaged launcher smoke
- strict recursive `codesign` verification of the extracted 1.0.1 app
- live CDP proof that activating the scoped Send control creates the expected user turn