### PR TITLE
Pin the local route to HTTP/SSE with a managed model provider

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -76,13 +76,21 @@ launcher runtime from a stale or external process. Legacy macOS launchd services
 removed during an explicit launcher migration; launchd remains only for the advanced terminal-only
 mode.
 
-Setup keeps Codex's built-in `openai` provider and switches only `openai_base_url`. The daemon
-forwards the authenticated official model catalog and appends only the routed models owned by the
+Setup switches `openai_base_url` and installs one managed provider, `codex-chatgpt-web`, that is
+identical to Codex's built-in `openai` provider except for `base_url` and
+`supports_websockets = false`. Codex's built-in providers are not overridable — a user-supplied
+`[model_providers.openai]` table is discarded by `merge_configured_model_providers` — so pinning
+the transport requires a separate provider id plus the top-level `model_provider` assignment. Both
+are recorded in the integration journal and reversed by uninstall. The daemon forwards the
+authenticated official model catalog and appends only the routed models owned by the
 `chatgpt-web/` namespace; no static catalog is installed.
 
-The built-in provider attempts a Responses WebSocket prewarm. The local route explicitly returns
-HTTP `426`, which is Codex's native capability-negotiation signal for an immediate, session-sticky
-switch to its HTTP/SSE transport. No model or provider fallback occurs.
+The managed provider never negotiates a Responses WebSocket, so the loopback route is reached over
+HTTP/SSE on the first attempt. `GET /v1/responses` still returns HTTP `426` as a defensive signal
+for any client that tries to upgrade. Without the provider, Codex opens a WebSocket against the
+loopback route on every turn and spends its entire `stream_max_retries` budget — the visible
+`Reconnecting 1/5 … 5/5` banner — before falling back to HTTP. No model or provider fallback
+occurs.
 
 Setup never restarts an already loaded daemon implicitly. A requested stop, restart, replacement,
 or uninstall first calls a private authenticated drain endpoint. The daemon rejects new turns and

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -51,7 +51,7 @@ Setup options:
   --app-name NAME              ChatGPT connector name (default: Codex Native)
   --tunnel-id ID               Existing OpenAI tunnel id (full mode)
   --runtime-key-file PATH      File containing a Tunnels Read+Use runtime key
-  --replace-codex-route        Reversibly replace an existing openai_base_url
+  --replace-codex-route        Reversibly replace an existing openai_base_url/model_provider
   --restart-service            Explicitly restart this project's daemon after an update
   --login                      Refresh the stored ChatGPT login even if one exists
   --auto-approve-tool-calls    Opt in to per-call browser clicks on "Allow once" prompts

--- a/src/codex-integration.ts
+++ b/src/codex-integration.ts
@@ -7,6 +7,31 @@ import { atomicWriteFile, expandUserPath, getConfigDir } from "./config";
 
 const MANAGED_COMMENT = "# Managed by codex-chatgpt-web; `codex-chatgpt-web uninstall` restores prior values.";
 
+/**
+ * Codex only offers Responses over WebSocket on providers that advertise it, and built-in
+ * providers are not overridable (`merge_configured_model_providers` uses `or_insert`). The local
+ * route serves HTTP/SSE only, so the bridge installs its own provider that is byte-identical to
+ * the built-in `openai` provider except for `base_url` and `supports_websockets = false`. Without
+ * it Codex opens a WebSocket against the loopback route on every turn and burns its full
+ * `stream_max_retries` budget ("Reconnecting 1/5 ... 5/5") before falling back to HTTP.
+ */
+const MANAGED_PROVIDER_ID = "codex-chatgpt-web";
+const MANAGED_PROVIDER_HEADER = `[model_providers.${MANAGED_PROVIDER_ID}]`;
+const MANAGED_PROVIDER_COMMENT = "# Managed by codex-chatgpt-web; the local route has no Responses WebSocket, so this pins HTTP/SSE.";
+
+function managedProviderLines(installedUrl: string): string[] {
+  return [
+    MANAGED_PROVIDER_COMMENT,
+    MANAGED_PROVIDER_HEADER,
+    'name = "OpenAI"',
+    `base_url = ${JSON.stringify(installedUrl)}`,
+    'wire_api = "responses"',
+    "requires_openai_auth = true",
+    "supports_websockets = false",
+    "supports_standalone_web_search = true",
+  ];
+}
+
 interface PreviousAssignment {
   present: boolean;
   rawLine?: string;
@@ -17,6 +42,21 @@ interface PreviousAssignment {
 type ManagedAssignmentKey = "openai_base_url" | "model_provider" | "model_catalog_json";
 
 export interface CodexIntegrationJournal {
+  version: 5;
+  active: boolean;
+  configPath: string;
+  installed: {
+    openai_base_url: string;
+    model_provider: string;
+  };
+  previous: Record<ManagedAssignmentKey, PreviousAssignment>;
+  format?: {
+    lineEnding: "\n" | "\r\n";
+    trailingNewline: boolean;
+  };
+}
+
+interface LegacyCodexIntegrationJournalV4 {
   version: 4;
   active: boolean;
   configPath: string;
@@ -59,7 +99,15 @@ interface LegacyCodexIntegrationJournal {
   };
 }
 
-type ManagedRouteJournal = CodexIntegrationJournal | LegacyCodexIntegrationJournalV3;
+type ManagedRouteJournal =
+  | CodexIntegrationJournal
+  | LegacyCodexIntegrationJournalV4
+  | LegacyCodexIntegrationJournalV3;
+
+/** The managed provider id a journal installed, or `undefined` for pre-v5 base-url-only routes. */
+function journalManagedProvider(journal: ManagedRouteJournal): string | undefined {
+  return journal.version === 5 ? journal.installed.model_provider : undefined;
+}
 type AnyCodexIntegrationJournal = ManagedRouteJournal | LegacyCodexIntegrationJournal;
 
 interface FileSnapshot {
@@ -327,6 +375,52 @@ function removeManagedComment(document: CodexConfigDocument): void {
   }
 }
 
+/** Locate the managed `[model_providers.codex-chatgpt-web]` table as a half-open `[start, end)`. */
+function findManagedProviderBlock(lines: string[]): { start: number; end: number } | undefined {
+  const header = lines.findIndex(line => line.trim() === MANAGED_PROVIDER_HEADER);
+  if (header < 0) return undefined;
+  let start = header;
+  if (start > 0 && lines[start - 1] === MANAGED_PROVIDER_COMMENT) start -= 1;
+  let end = header + 1;
+  while (end < lines.length && !/^\s*\[/.test(lines[end]!)) end += 1;
+  while (end - 1 > header && lines[end - 1]!.trim() === "") end -= 1;
+  return { start, end };
+}
+
+function removeManagedProviderBlock(document: CodexConfigDocument): boolean {
+  const block = findManagedProviderBlock(document.lines);
+  if (!block) return false;
+  let start = block.start;
+  if (start > 0 && document.lines[start - 1]!.trim() === "") start -= 1;
+  for (let index = block.end - 1; index >= start; index -= 1) removeDocumentLine(document, index);
+  return true;
+}
+
+/**
+ * Appends the managed provider table. The separating blank line is written here and consumed by
+ * {@link removeManagedProviderBlock}, so install/uninstall is byte-symmetric.
+ */
+function appendManagedProviderBlock(document: CodexConfigDocument, installedUrl: string): void {
+  const lines = managedProviderLines(installedUrl);
+  if (document.lines.length > 0) lines.unshift("");
+  for (const line of lines) insertDocumentLine(document, document.lines.length, line);
+}
+
+/** Point the top-level `model_provider` at the managed provider and rewrite its table. */
+function writeManagedProvider(document: CodexConfigDocument, installedUrl: string): void {
+  const assignment = `model_provider = ${JSON.stringify(MANAGED_PROVIDER_ID)}`;
+  const existing = findTopLevelAssignment(document.lines, "model_provider");
+  if (existing.index !== undefined) {
+    document.lines[existing.index] = assignment;
+  } else {
+    const baseUrl = findTopLevelAssignment(document.lines, "openai_base_url");
+    if (baseUrl.index === undefined) throw new Error("Managed Codex openai_base_url is missing");
+    insertDocumentLine(document, baseUrl.index + 1, assignment);
+  }
+  removeManagedProviderBlock(document);
+  appendManagedProviderBlock(document, installedUrl);
+}
+
 function installRoute(
   text: string,
   installedUrl: string,
@@ -357,6 +451,7 @@ function installRoute(
   removeManagedComment(document);
   const installedBaseUrl = findTopLevelAssignment(document.lines, "openai_base_url");
   insertDocumentLine(document, installedBaseUrl.index!, MANAGED_COMMENT);
+  writeManagedProvider(document, installedUrl);
   return { text: renderDocument(document), previous };
 }
 
@@ -366,7 +461,20 @@ function verifyInstalledRoute(text: string, journal: ManagedRouteJournal): void 
   if (current.openai_base_url.value !== journal.installed.openai_base_url) {
     throw new Error("Codex openai_base_url changed after setup; refusing to overwrite the user's newer value");
   }
-  if (current.model_provider.present || current.model_catalog_json.present) {
+  const managedProvider = journalManagedProvider(journal);
+  if (managedProvider === undefined) {
+    if (current.model_provider.present) {
+      throw new Error("Codex model_provider or model_catalog_json changed after setup; refusing to overwrite the user's newer value");
+    }
+  } else {
+    if (current.model_provider.value !== managedProvider) {
+      throw new Error("Codex model_provider changed after setup; refusing to overwrite the user's newer value");
+    }
+    if (!findManagedProviderBlock(lines)) {
+      throw new Error("Managed Codex model provider block changed after setup; refusing to overwrite it");
+    }
+  }
+  if (current.model_catalog_json.present) {
     throw new Error("Codex model_provider or model_catalog_json changed after setup; refusing to overwrite the user's newer value");
   }
   if (!lines.includes(MANAGED_COMMENT)) {
@@ -379,7 +487,7 @@ function previousAssignmentMatches(current: PreviousAssignment, previous: Previo
     && (!current.present || current.value === previous.value);
 }
 
-function verifyRestoredRoute(text: string, journal: CodexIntegrationJournal): void {
+function verifyRestoredRoute(text: string, journal: ManagedRouteJournal): void {
   const lines = splitLines(text);
   const current = assignments(lines);
   for (const key of ["openai_base_url", "model_provider", "model_catalog_json"] as const) {
@@ -389,6 +497,9 @@ function verifyRestoredRoute(text: string, journal: CodexIntegrationJournal): vo
   }
   if (lines.includes(MANAGED_COMMENT)) {
     throw new Error("Managed Codex route marker is present while the bridge is disconnected");
+  }
+  if (findManagedProviderBlock(lines)) {
+    throw new Error("Managed Codex model provider block is present while the bridge is disconnected");
   }
 }
 
@@ -406,7 +517,13 @@ function assertPreservedPreviousAssignments(
 function restoreManagedRoute(text: string, journal: ManagedRouteJournal): string {
   verifyInstalledRoute(text, journal);
   const document = parseDocument(text);
+  removeManagedProviderBlock(document);
   removeManagedComment(document);
+  if (journalManagedProvider(journal) !== undefined) {
+    const installedProvider = findTopLevelAssignment(document.lines, "model_provider");
+    if (installedProvider.index === undefined) throw new Error("Managed Codex model_provider is missing");
+    removeDocumentLine(document, installedProvider.index);
+  }
   const currentBaseUrl = findTopLevelAssignment(document.lines, "openai_base_url");
   if (currentBaseUrl.index === undefined) throw new Error("Managed Codex openai_base_url is missing");
   const previousBaseUrl = journal.previous.openai_base_url;
@@ -459,12 +576,19 @@ function readJournal(): AnyCodexIntegrationJournal | undefined {
   const path = getCodexJournalPath();
   if (!existsSync(path)) return undefined;
   const value = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
-  if (value.version === 4
+  if (value.version === 5
     && typeof value.active === "boolean"
     && value.installed
     && value.previous
     && typeof value.configPath === "string") {
     return value as unknown as CodexIntegrationJournal;
+  }
+  if (value.version === 4
+    && typeof value.active === "boolean"
+    && value.installed
+    && value.previous
+    && typeof value.configPath === "string") {
+    return value as unknown as LegacyCodexIntegrationJournalV4;
   }
   if (value.version === 3 && value.installed && value.previous && typeof value.configPath === "string") {
     return value as unknown as LegacyCodexIntegrationJournalV3;
@@ -499,8 +623,8 @@ export function preflightCodexIntegration(
   const existing = readJournal();
   const installedUrl = routeUrl(config);
   if (existing) assertJournalTargetsConfig(existing, configPath);
-  if (existing?.version === 3 || existing?.version === 4) {
-    if (existing.version === 4 && !existing.active) verifyRestoredRoute(currentText, existing);
+  if (existing?.version === 3 || existing?.version === 4 || existing?.version === 5) {
+    if (existing.version !== 3 && !existing.active) verifyRestoredRoute(currentText, existing);
     else verifyInstalledRoute(currentText, existing);
     return;
   }
@@ -525,9 +649,9 @@ export function installCodexIntegration(
   const installedUrl = routeUrl(config);
   if (existing) assertJournalTargetsConfig(existing, configPath);
 
-  if (existing?.version === 3 || existing?.version === 4) {
+  if (existing?.version === 3 || existing?.version === 4 || existing?.version === 5) {
     let installedText: string;
-    if (existing.version === 4 && !existing.active) {
+    if (existing.version !== 3 && !existing.active) {
       verifyRestoredRoute(currentText, existing);
       const patched = installRoute(currentText, installedUrl, true);
       assertPreservedPreviousAssignments(patched.previous, existing.previous);
@@ -537,13 +661,15 @@ export function installCodexIntegration(
       const document = parseDocument(currentText);
       const current = findTopLevelAssignment(document.lines, "openai_base_url");
       document.lines[current.index!] = `openai_base_url = ${JSON.stringify(installedUrl)}`;
+      // Also upgrades a v3/v4 base-url-only route in place by adding the managed provider.
+      writeManagedProvider(document, installedUrl);
       installedText = renderDocument(document);
     }
     const updated: CodexIntegrationJournal = {
       ...existing,
-      version: 4,
+      version: 5,
       active: true,
-      installed: { openai_base_url: installedUrl },
+      installed: { openai_base_url: installedUrl, model_provider: MANAGED_PROVIDER_ID },
     };
     writeFilesWithCompensation([
       { path: configPath, data: installedText },
@@ -561,10 +687,10 @@ export function installCodexIntegration(
   }
   const patched = installRoute(baseline, installedUrl, options.replaceExistingRoute === true);
   const journal: CodexIntegrationJournal = {
-    version: 4,
+    version: 5,
     active: true,
     configPath,
-    installed: { openai_base_url: installedUrl },
+    installed: { openai_base_url: installedUrl, model_provider: MANAGED_PROVIDER_ID },
     previous: patched.previous,
     format: textFormat(baseline),
   };
@@ -585,15 +711,16 @@ export function deactivateCodexIntegration(): SetCodexIntegrationActiveResult {
   assertJournalTargetsConfig(existing, getCodexConfigPath());
   if (!existsSync(existing.configPath)) throw new Error(`Codex config is missing: ${existing.configPath}`);
   const current = readFileSync(existing.configPath, "utf8");
-  if (existing.version === 4 && !existing.active) {
+  if (existing.version !== 3 && !existing.active) {
     verifyRestoredRoute(current, existing);
     return { changed: false, active: false };
   }
   const restored = restoreManagedRoute(current, existing);
   const disconnected: CodexIntegrationJournal = {
     ...existing,
-    version: 4,
+    version: 5,
     active: false,
+    installed: { openai_base_url: existing.installed.openai_base_url, model_provider: MANAGED_PROVIDER_ID },
   };
   writeFilesWithCompensation([
     { path: existing.configPath, data: restored },
@@ -618,7 +745,12 @@ export function activateCodexIntegration(): SetCodexIntegrationActiveResult {
   verifyRestoredRoute(current, existing);
   const patched = installRoute(current, existing.installed.openai_base_url, true);
   assertPreservedPreviousAssignments(patched.previous, existing.previous);
-  const connected: CodexIntegrationJournal = { ...existing, active: true };
+  const connected: CodexIntegrationJournal = {
+    ...existing,
+    version: 5,
+    active: true,
+    installed: { openai_base_url: existing.installed.openai_base_url, model_provider: MANAGED_PROVIDER_ID },
+  };
   writeFilesWithCompensation([
     { path: existing.configPath, data: patched.text },
     { path: getCodexJournalPath(), data: `${JSON.stringify(connected, null, 2)}\n` },
@@ -637,7 +769,7 @@ export function uninstallCodexIntegration(): UninstallCodexIntegrationResult {
       throw new Error(`Managed legacy catalog changed after setup: ${journal.catalogPath}`);
     }
     restored = restoreLegacyV2(current, journal);
-  } else if (journal.version === 4 && !journal.active) {
+  } else if (journal.version !== 3 && !journal.active) {
     verifyRestoredRoute(current, journal);
     restored = current;
   } else {
@@ -683,8 +815,8 @@ export function inspectCodexIntegration(): {
     try {
       assertJournalTargetsConfig(journal, getCodexConfigPath());
       const text = readFileSync(journal.configPath, "utf8");
-      if (journal.version === 4 && !journal.active) verifyRestoredRoute(text, journal);
-      else if (journal.version === 3 || journal.version === 4) verifyInstalledRoute(text, journal);
+      if (journal.version !== 2 && journal.version !== 3 && !journal.active) verifyRestoredRoute(text, journal);
+      else if (journal.version === 3 || journal.version === 4 || journal.version === 5) verifyInstalledRoute(text, journal);
       else {
         const lines = splitLines(text);
         for (const key of ["model_provider", "model_catalog_json"] as const) {
@@ -700,9 +832,11 @@ export function inspectCodexIntegration(): {
   }
   return {
     installed: Boolean(journal),
-    active: journal?.version === 4 ? journal.active : Boolean(journal),
+    active: journal?.version === 4 || journal?.version === 5 ? journal.active : Boolean(journal),
     configPath: getCodexConfigPath(),
-    ...(journal?.version === 3 || journal?.version === 4 ? { routeUrl: journal.installed.openai_base_url } : {}),
+    ...(journal?.version === 3 || journal?.version === 4 || journal?.version === 5
+      ? { routeUrl: journal.installed.openai_base_url }
+      : {}),
     ...(journal ? { journal } : {}),
     errors,
   };

--- a/tests/codex-integration.test.ts
+++ b/tests/codex-integration.test.ts
@@ -18,6 +18,18 @@ import { defaultConfig } from "../src/config";
 
 const roots: string[] = [];
 
+const MANAGED_COMMENT = "# Managed by codex-chatgpt-web; `codex-chatgpt-web uninstall` restores prior values.";
+const MANAGED_PROVIDER_BLOCK = [
+  "# Managed by codex-chatgpt-web; the local route has no Responses WebSocket, so this pins HTTP/SSE.",
+  "[model_providers.codex-chatgpt-web]",
+  'name = "OpenAI"',
+  'base_url = "http://127.0.0.1:17841/v1"',
+  'wire_api = "responses"',
+  "requires_openai_auth = true",
+  "supports_websockets = false",
+  "supports_standalone_web_search = true",
+].join("\n");
+
 function fixture(): { root: string; codexHome: string; appHome: string } {
   const root = join(tmpdir(), `codex-chatgpt-web-integration-${process.pid}-${Date.now()}-${Math.random()}`);
   const codexHome = join(root, "codex");
@@ -54,7 +66,7 @@ describe("reversible native Codex route integration", () => {
     });
   });
 
-  test("installs only openai_base_url and keeps the built-in openai provider", () => {
+  test("installs an HTTP-only managed provider so Codex never opens a WebSocket to the local route", () => {
     const { codexHome } = fixture();
     const configPath = join(codexHome, "config.toml");
     const original = `model = "gpt-5.6-sol"\n\n[features]\ngoals = true\n`;
@@ -62,11 +74,17 @@ describe("reversible native Codex route integration", () => {
 
     const journal = installCodexIntegration(defaultConfig("browser-only"));
     const installed = readFileSync(configPath, "utf8");
-    expect(journal.version).toBe(4);
+    expect(journal.version).toBe(5);
+    expect(journal.installed.model_provider).toBe("codex-chatgpt-web");
     expect(installed).toContain('openai_base_url = "http://127.0.0.1:17841/v1"');
-    expect(installed).not.toMatch(/^\s*model_provider\s*=/m);
+    expect(installed).toMatch(/^model_provider = "codex-chatgpt-web"$/m);
+    expect(installed).toContain(MANAGED_PROVIDER_BLOCK);
+    expect(installed).toContain("supports_websockets = false");
+    // The managed provider must stay otherwise identical to the built-in `openai` provider.
+    expect(installed).toContain('name = "OpenAI"');
+    expect(installed).toContain("requires_openai_auth = true");
+    expect(installed).toContain("supports_standalone_web_search = true");
     expect(installed).not.toMatch(/^\s*model_catalog_json\s*=/m);
-    expect(installed).not.toContain("[model_providers.codex-chatgpt-web]");
 
     expect(uninstallCodexIntegration()).toEqual({ changed: true });
     expect(readFileSync(configPath, "utf8")).toBe(original);
@@ -99,7 +117,8 @@ describe("reversible native Codex route integration", () => {
     installCodexIntegration(config, { replaceExistingRoute: true });
     const installed = readFileSync(configPath, "utf8");
     expect(installed).toContain('openai_base_url = "http://127.0.0.1:17841/v1"');
-    expect(installed).not.toMatch(/^\s*model_provider\s*=/m);
+    expect(installed).toMatch(/^model_provider = "codex-chatgpt-web"$/m);
+    expect(installed).not.toContain("existing-provider");
     expect(installed).not.toMatch(/^\s*model_catalog_json\s*=/m);
 
     uninstallCodexIntegration();
@@ -163,7 +182,7 @@ describe("reversible native Codex route integration", () => {
     deactivateCodexIntegration();
 
     expect(JSON.parse(readFileSync(getCodexJournalPath(), "utf8"))).toMatchObject({
-      version: 4,
+      version: 5,
       active: false,
     });
     expect(inspectCodexIntegration()).toMatchObject({ installed: true, active: false, errors: [] });
@@ -175,18 +194,78 @@ describe("reversible native Codex route integration", () => {
     const configPath = join(codexHome, "config.toml");
     const original = 'model = "gpt-5.6-sol"\n';
     writeFileSync(configPath, original);
-    installCodexIntegration(defaultConfig("browser-only"));
-    const previous = JSON.parse(readFileSync(getCodexJournalPath(), "utf8"));
-    delete previous.active;
-    previous.version = 3;
-    writeFileSync(getCodexJournalPath(), `${JSON.stringify(previous, null, 2)}\n`);
+    // A v3 install only rewrote openai_base_url; it never wrote a managed provider.
+    writeFileSync(
+      configPath,
+      `model = "gpt-5.6-sol"\n${MANAGED_COMMENT}\nopenai_base_url = "http://127.0.0.1:17841/v1"\n`,
+    );
+    mkdirSync(join(getCodexJournalPath(), ".."), { recursive: true });
+    writeFileSync(getCodexJournalPath(), `${JSON.stringify({
+      version: 3,
+      configPath,
+      installed: { openai_base_url: "http://127.0.0.1:17841/v1" },
+      previous: {
+        openai_base_url: { present: false },
+        model_provider: { present: false },
+        model_catalog_json: { present: false },
+      },
+      format: { lineEnding: "\n", trailingNewline: true },
+    }, null, 2)}\n`);
 
     expect(deactivateCodexIntegration()).toEqual({ changed: true, active: false });
     expect(readFileSync(configPath, "utf8")).toBe(original);
     expect(JSON.parse(readFileSync(getCodexJournalPath(), "utf8"))).toMatchObject({
-      version: 4,
+      version: 5,
       active: false,
+      installed: { model_provider: "codex-chatgpt-web" },
     });
+  });
+
+  test("upgrades a live v4 base-url-only route to the managed HTTP-only provider", () => {
+    const { codexHome } = fixture();
+    const configPath = join(codexHome, "config.toml");
+    const original = 'model = "gpt-5.6-sol"\n';
+    writeFileSync(configPath, original);
+    writeFileSync(
+      configPath,
+      `model = "gpt-5.6-sol"\n${MANAGED_COMMENT}\nopenai_base_url = "http://127.0.0.1:17841/v1"\n`,
+    );
+    mkdirSync(join(getCodexJournalPath(), ".."), { recursive: true });
+    writeFileSync(getCodexJournalPath(), `${JSON.stringify({
+      version: 4,
+      active: true,
+      configPath,
+      installed: { openai_base_url: "http://127.0.0.1:17841/v1" },
+      previous: {
+        openai_base_url: { present: false },
+        model_provider: { present: false },
+        model_catalog_json: { present: false },
+      },
+      format: { lineEnding: "\n", trailingNewline: true },
+    }, null, 2)}\n`);
+
+    const journal = installCodexIntegration(defaultConfig("browser-only"));
+    expect(journal.version).toBe(5);
+    const installed = readFileSync(configPath, "utf8");
+    expect(installed).toMatch(/^model_provider = "codex-chatgpt-web"$/m);
+    expect(installed).toContain(MANAGED_PROVIDER_BLOCK);
+    expect(inspectCodexIntegration()).toMatchObject({ installed: true, active: true, errors: [] });
+
+    uninstallCodexIntegration();
+    expect(readFileSync(configPath, "utf8")).toBe(original);
+  });
+
+  test("fails closed when the managed provider block is edited after setup", () => {
+    const { codexHome } = fixture();
+    const configPath = join(codexHome, "config.toml");
+    writeFileSync(configPath, 'model = "gpt-5.6-sol"\n');
+    installCodexIntegration(defaultConfig("browser-only"));
+    const tampered = readFileSync(configPath, "utf8")
+      .replace("[model_providers.codex-chatgpt-web]", "[model_providers.someone-else]");
+    writeFileSync(configPath, tampered);
+
+    expect(() => uninstallCodexIntegration()).toThrow("model provider block changed after setup");
+    expect(readFileSync(configPath, "utf8")).toBe(tampered);
   });
 
   test("fails closed when the native route changes while the bridge is disconnected", () => {
@@ -271,8 +350,10 @@ describe("reversible native Codex route integration", () => {
     const installed = readFileSync(configPath, "utf8");
     expect(installed).not.toContain("opencodex-catalog");
     expect(installed).not.toContain("model_catalog_json");
-    expect(installed).not.toContain("model_provider");
+    expect(installed).not.toContain('name = "Codex + ChatGPT Web"');
     expect(installed).toContain('openai_base_url = "http://127.0.0.1:17841/v1"');
+    expect(installed).toMatch(/^model_provider = "codex-chatgpt-web"$/m);
+    expect(installed).toContain(MANAGED_PROVIDER_BLOCK);
   });
 
   test("fails closed when the installed route changed after setup", () => {


### PR DESCRIPTION
Setup only rewrote `openai_base_url`, which leaves Codex on its built-in `openai` provider. That provider advertises Responses-over-WebSocket, so Codex opened a WebSocket against the loopback route on every native-model turn. The route serves HTTP/SSE only, and the connect failure is treated as a retryable stream error, so Codex spent its whole `stream_max_retries` budget -- the visible "Reconnecting 1/5 ... 5/5" banner -- before falling back to HTTP (openai/codex#19821). The 426 on `GET /v1/responses` only helps clients that surface it as an HTTP status from the handshake.

Built-in providers are not overridable: `merge_configured_model_providers` uses `or_insert`, so a user-supplied `[model_providers.openai]` table is silently discarded. Pinning the transport therefore requires a separate provider id plus the top-level `model_provider` assignment.

Setup now installs `codex-chatgpt-web`, identical to the built-in provider except for `base_url` and `supports_websockets = false`, and claims `model_provider`. The journal is bumped to v5 and records both, so verify, disconnect, reconnect and uninstall reverse them byte-for-byte; v3 and v4 journals upgrade in place on the next install or reconnect.

- Journal v5 carries `installed.model_provider`; v4 becomes a legacy shape.
- `verifyInstalledRoute` requires the managed provider and its table for v5 journals and keeps the "no provider" contract for older ones.
- `verifyRestoredRoute` additionally fails closed if the table survives a disconnect.