### PR TITLE
Add opencodex compatibility: explicit provider config for multi-provider routing

### DIFF
--- a/src/adapters/chatgpt-web/index.ts
+++ b/src/adapters/chatgpt-web/index.ts
@@ -12,6 +12,7 @@ import { TurnBroker, type BrokerToolRequest, type BrokerToolResult } from "./tur
 import { ChatGptTextFeed, ChatGptTraceFeed, chatGptTurnExecutionKey, chatGptTurnSessions, type ChatGptBrowserOutcome, type ChatGptTraceEvent, type ChatGptTurnRuntime, type ChatGptTurnSession } from "./turn-execution";
 import { estimateChatGptWebUsage } from "./usage";
 import { ChatGptThreadEnvironmentStore } from "./thread-environment";
+import { getActiveOpenCodexUpstream } from "../../native-passthrough";
 
 function brokerSocketPath(provider: CodexProviderConfig): string {
   const configured = provider.chatgptWeb?.brokerSocketPath?.trim();
@@ -127,6 +128,34 @@ function emitProContextWarning(
   emit({ type: "assistant_boundary" });
   emit({ type: "text_delta", text: warning, phase: "commentary" });
   emit({ type: "assistant_boundary" });
+}
+
+/** One-time per-session flag so the opencodex routing notice appears only on the first turn. */
+let openCodexNoticeEmitted = false;
+
+/**
+ * Emit a one-time commentary notice when opencodex is the active upstream, informing the user
+ * that non-ChatGPT-Web models route through opencodex's multi-provider proxy. Mirrors the
+ * pattern used by the Pro context warning and opencodex's own adapter routing notices.
+ */
+function emitOpenCodexRoutingNotice(emit: (event: AdapterEvent) => void): void {
+  if (openCodexNoticeEmitted) return;
+  const upstream = getActiveOpenCodexUpstream();
+  if (!upstream) return;
+  openCodexNoticeEmitted = true;
+  const version = upstream.version ? ` (v${upstream.version})` : "";
+  emit({ type: "assistant_boundary" });
+  emit({
+    type: "text_delta",
+    text: `ℹ️ opencodex${version} detected at ${upstream.baseUrl}. Non-ChatGPT-Web model requests route through opencodex for multi-provider access (Anthropic, Google, DeepSeek, Kimi, Ollama, and more). ChatGPT Web models continue running through the embedded browser.`,
+    phase: "commentary",
+  });
+  emit({ type: "assistant_boundary" });
+}
+
+/** Reset the one-time notice flag (for testing). */
+export function resetOpenCodexNotice(): void {
+  openCodexNoticeEmitted = false;
 }
 
 function replayEvents(events: AdapterEvent[], emit: (event: AdapterEvent) => void): void {
@@ -288,7 +317,10 @@ export function createChatGptWebAdapter(provider: CodexProviderConfig): Provider
                 events.push(event);
                 emit(event);
               };
-              if (!parsed._compactionRequest) emitProContextWarning(parsed, capabilities, emitCaptured);
+              if (!parsed._compactionRequest) {
+                emitProContextWarning(parsed, capabilities, emitCaptured);
+                emitOpenCodexRoutingNotice(emitCaptured);
+              }
               const trace = session.runtime.trace.drain();
               reasoning = trace.map(event => event.text);
               emitTraceEvents(trace, emitCaptured);
@@ -343,7 +375,10 @@ export function createChatGptWebAdapter(provider: CodexProviderConfig): Provider
               emitTraceEvents(trace, emitRound);
             };
             const emitNewText = (deltas: string[]) => emitTextDeltas(deltas, emitRound);
-            if (!parsed._compactionRequest) emitProContextWarning(parsed, capabilities, emitRound);
+            if (!parsed._compactionRequest) {
+              emitProContextWarning(parsed, capabilities, emitRound);
+              emitOpenCodexRoutingNotice(emitRound);
+            }
             emitNewTrace(session.runtime.trace.drain());
             emitNewText(session.runtime.text.drain());
             const nextTools = turnToken

--- a/src/codex-integration.ts
+++ b/src/codex-integration.ts
@@ -4,6 +4,7 @@ import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import type { AppConfig } from "./config";
 import { atomicWriteFile, expandUserPath, getConfigDir } from "./config";
+import { OPENCODEX_CONFIG_MARKER } from "./opencodex";
 
 const MANAGED_COMMENT = "# Managed by codex-chatgpt-web; `codex-chatgpt-web uninstall` restores prior values.";
 
@@ -337,7 +338,10 @@ function installRoute(
   const conflicts = (Object.entries(previous) as Array<[ManagedAssignmentKey, PreviousAssignment]>)
     .filter(([, assignment]) => assignment.present)
     .map(([key, assignment]) => `${key}=${JSON.stringify(assignment.value)}`);
-  if (conflicts.length > 0 && !replaceExistingRoute) {
+  // When opencodex owns the existing route, allow replacement automatically: codex-chatgpt-web
+  // will chain native passthrough through opencodex, and uninstall restores opencodex's URL.
+  const ownedByOpenCodex = text.includes(OPENCODEX_CONFIG_MARKER);
+  if (conflicts.length > 0 && !replaceExistingRoute && !ownedByOpenCodex) {
     throw new Error(
       `Codex already configures model routing (${conflicts.join(", ")}). `
       + "Rerun with --replace-codex-route to replace it reversibly.",

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,6 +38,21 @@ export interface AppConfig {
   runtimeCommand: string[];
   acknowledgedUnofficialAt?: string;
   tunnel?: TunnelConfig;
+  /**
+   * OpenCodex upstream configuration. When set, native Codex passthrough requests are routed
+   * through the opencodex proxy instead of directly to the ChatGPT backend, giving access to
+   * opencodex's full multi-provider model routing.
+   */
+  opencodex?: OpenCodexConfig;
+}
+
+export interface OpenCodexConfig {
+  /** Explicit opencodex proxy URL (e.g. "http://127.0.0.1:10100"). When absent, auto-detected. */
+  url?: string;
+  /** When true, probe opencodex on the configured URL (or default port). Defaults to false — must be explicitly enabled. */
+  autoDetect?: boolean;
+  /** When true, merge opencodex's routed models into the /v1/models catalog. Defaults to true. */
+  mergeModels?: boolean;
 }
 
 export function expandUserPath(value: string): string {
@@ -333,6 +348,21 @@ function parseConfig(value: unknown, path: string): AppConfig {
   assertDurableRuntimeCommand(parsed.runtimeCommand as string[]);
   if (parsed.proAvailable !== undefined && typeof parsed.proAvailable !== "boolean") {
     throw new Error(`Invalid proAvailable in ${path}`);
+  }
+  if (parsed.opencodex !== undefined) {
+    if (!parsed.opencodex || typeof parsed.opencodex !== "object" || Array.isArray(parsed.opencodex)) {
+      throw new Error(`Invalid opencodex configuration in ${path}`);
+    }
+    const ocx = parsed.opencodex as Record<string, unknown>;
+    if (ocx.url !== undefined && (typeof ocx.url !== "string" || !ocx.url.trim())) {
+      throw new Error(`opencodex.url must be a non-empty string in ${path}`);
+    }
+    if (ocx.autoDetect !== undefined && typeof ocx.autoDetect !== "boolean") {
+      throw new Error(`opencodex.autoDetect must be a boolean in ${path}`);
+    }
+    if (ocx.mergeModels !== undefined && typeof ocx.mergeModels !== "boolean") {
+      throw new Error(`opencodex.mergeModels must be a boolean in ${path}`);
+    }
   }
   return { ...parsed, proAvailable: parsed.proAvailable === true } as AppConfig;
 }

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -9,6 +9,7 @@ import { tunnelStatus } from "./tunnel";
 import { getTunnelServiceStatus } from "./tunnel-service";
 import { inspectLauncherBrowserHost, readLauncherBrowserHostDescriptor } from "./launcher-browser-host";
 import { processRunning } from "./process";
+import { probeOpenCodex, OPENCODEX_DEFAULT_PORT } from "./opencodex";
 
 export type CheckStatus = "ok" | "warning" | "error";
 
@@ -207,6 +208,27 @@ export async function runDoctor(): Promise<DoctorReport> {
     });
   } else {
     checks.push({ id: "tools", status: "warning", message: "Browser-only mode intentionally has no local tools or MCP tunnel" });
+  }
+
+  // OpenCodex upstream detection.
+  if (config.opencodex && (config.opencodex.url || config.opencodex.autoDetect === true)) {
+    const ocxPort = config.opencodex?.url
+      ? Number(new URL(config.opencodex.url).port) || OPENCODEX_DEFAULT_PORT
+      : OPENCODEX_DEFAULT_PORT;
+    const ocx = await probeOpenCodex(ocxPort, "127.0.0.1", 2_000);
+    if (ocx) {
+      checks.push({
+        id: "opencodex",
+        status: "ok",
+        message: `opencodex ${ocx.version ?? ""} detected at ${ocx.baseUrl} — native passthrough routes through it`,
+      });
+    } else {
+      checks.push({
+        id: "opencodex",
+        status: "warning",
+        message: `Configured opencodex at ${config.opencodex.url ?? "default port"} is not reachable — falling back to direct ChatGPT backend`,
+      });
+    }
   }
 
   return {

--- a/src/model-catalog.ts
+++ b/src/model-catalog.ts
@@ -101,11 +101,11 @@ export function buildChatGptWebModel(
   return model;
 }
 
-export function augmentNativeModelCatalog(
+export async function augmentNativeModelCatalog(
   value: unknown,
   config: AppConfig,
   contextOverride?: CodexModelContextOverride,
-): JsonObject {
+): Promise<JsonObject> {
   const catalog = object(value, "native Codex models response");
   if (!Array.isArray(catalog.models)) {
     throw new Error("Native Codex models response is missing a models array");

--- a/src/native-passthrough.ts
+++ b/src/native-passthrough.ts
@@ -1,5 +1,7 @@
 import { readJsonRequestBody } from "./http-body";
 import { BRIDGE_REASONING_PREFIX } from "./responses/reasoning-envelope";
+import { resolveOpenCodexUpstream, type OpenCodexUpstream } from "./opencodex";
+import type { AppConfig } from "./config";
 
 const CODEX_BACKEND = "https://chatgpt.com/backend-api/codex";
 const HOP_BY_HOP_HEADERS = new Set([
@@ -16,6 +18,44 @@ const HOP_BY_HOP_HEADERS = new Set([
 
 export type NativeFetch = (request: Request) => Promise<Response>;
 export type NativeCodexEndpoint = "models" | "responses" | "responses/compact";
+
+/** Runtime state for the resolved opencodex upstream. */
+let activeOpenCodexUpstream: OpenCodexUpstream | null = null;
+let openCodexConfigRef: AppConfig["opencodex"] | undefined;
+
+/** Update the opencodex config reference (called from server startup and setup). */
+export function setOpenCodexConfig(config: AppConfig["opencodex"]): void {
+  openCodexConfigRef = config;
+}
+
+/** Whether opencodex auto-detection is enabled (defaults to true). */
+function openCodexAutoDetectEnabled(): boolean {
+  // Only active when explicitly enabled in config. Default is off — the user must
+  // register opencodex as a provider in config.json for routing to activate.
+  return openCodexConfigRef?.autoDetect === true;
+}
+
+/**
+ * Resolve the effective upstream for native passthrough. When opencodex is running and
+ * auto-detect is enabled (or an explicit URL is configured), requests route through it.
+ * Otherwise, the direct ChatGPT backend is used.
+ */
+async function resolveNativeUpstream(): Promise<{ url: string; viaOpenCodex: boolean }> {
+  if (!openCodexAutoDetectEnabled() && !openCodexConfigRef?.url) {
+    return { url: CODEX_BACKEND, viaOpenCodex: false };
+  }
+  const upstream = await resolveOpenCodexUpstream(openCodexConfigRef?.url);
+  if (upstream) {
+    activeOpenCodexUpstream = upstream;
+    return { url: `${upstream.baseUrl}/v1`, viaOpenCodex: true };
+  }
+  return { url: CODEX_BACKEND, viaOpenCodex: false };
+}
+
+/** Returns the currently active opencodex upstream, if any. */
+export function getActiveOpenCodexUpstream(): OpenCodexUpstream | null {
+  return activeOpenCodexUpstream;
+}
 
 type JsonObject = Record<string, unknown>;
 
@@ -87,6 +127,7 @@ export async function forwardNativeCodexRequest(
     throw new Error("Native Codex passthrough requires the incoming Bearer authorization");
   }
 
+  const { url: upstreamBase } = await resolveNativeUpstream();
   const incomingUrl = new URL(request.url);
   const headers = endToEndHeaders(request.headers);
   if (endpoint === "models") headers.delete("if-none-match");
@@ -105,7 +146,7 @@ export async function forwardNativeCodexRequest(
       body = originalBody;
     }
   }
-  const upstreamRequest = new Request(`${CODEX_BACKEND}/${endpoint}${incomingUrl.search}`, {
+  const upstreamRequest = new Request(`${upstreamBase}/${endpoint}${incomingUrl.search}`, {
     method,
     headers,
     ...(body ? { body } : {}),

--- a/src/opencodex.ts
+++ b/src/opencodex.ts
@@ -1,0 +1,171 @@
+/**
+ * OpenCodex compatibility layer.
+ *
+ * When opencodex (https://github.com/lidge-jun/opencodex) is running locally, codex-chatgpt-web
+ * routes native Codex passthrough requests through it instead of directly to the ChatGPT backend.
+ * This gives users access to opencodex's full multi-provider routing (Anthropic, Google, xAI,
+ * DeepSeek, Kimi, Ollama, etc.) for non-chatgpt-web models, while chatgpt-web models continue
+ * to run through the embedded browser.
+ *
+ * Detection is passive and fail-open: if opencodex is unreachable, the bridge falls back to the
+ * direct ChatGPT backend transparently.
+ */
+import { readFileSync, existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export const OPENCODEX_DEFAULT_PORT = 10100;
+export const OPENCODEX_HEALTH_PATH = "/healthz";
+export const OPENCODEX_SERVICE_IDENTITY = "opencodex";
+
+/** Marker opencodex writes above its managed openai_base_url line in config.toml. */
+export const OPENCODEX_CONFIG_MARKER = "# Auto-injected by opencodex";
+
+export interface OpenCodexUpstream {
+  /** Base URL of the opencodex proxy, e.g. "http://127.0.0.1:10100". */
+  baseUrl: string;
+  /** Version reported by the opencodex healthz endpoint. */
+  version?: string;
+  /** PID of the running opencodex proxy. */
+  pid?: number;
+}
+
+export interface OpenCodexHealthResponse {
+  status?: string;
+  service?: string;
+  version?: string;
+  uptime?: number;
+  pid?: number;
+  port?: number;
+}
+
+let cachedUpstream: OpenCodexUpstream | null | undefined;
+let lastProbeAt = 0;
+const PROBE_COOLDOWN_MS = 30_000;
+
+/**
+ * Probe the opencodex proxy health endpoint. Returns the upstream descriptor if a live opencodex
+ * instance responds, or null if unreachable or not opencodex.
+ */
+export async function probeOpenCodex(
+  port: number = OPENCODEX_DEFAULT_PORT,
+  hostname: string = "127.0.0.1",
+  timeoutMs: number = 2_000,
+): Promise<OpenCodexUpstream | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(`http://${hostname}:${port}${OPENCODEX_HEALTH_PATH}`, {
+      signal: controller.signal,
+      headers: { "accept": "application/json" },
+    });
+    if (!response.ok) return null;
+    const body = await response.json() as OpenCodexHealthResponse;
+    if (body.service !== OPENCODEX_SERVICE_IDENTITY) return null;
+    if (body.status !== "ok") return null;
+    return {
+      baseUrl: `http://${hostname}:${port}`,
+      version: typeof body.version === "string" ? body.version : undefined,
+      pid: typeof body.pid === "number" ? body.pid : undefined,
+    };
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Cached probe with a cooldown to avoid hammering the health endpoint on every request.
+ * Returns the cached upstream if still fresh, re-probes if stale, or null if unavailable.
+ */
+export async function resolveOpenCodexUpstream(
+  configuredUrl?: string,
+): Promise<OpenCodexUpstream | null> {
+  // If explicitly configured, use it directly without probing every time.
+  if (configuredUrl) {
+    const parsed = new URL(configuredUrl);
+    const port = parsed.port ? Number(parsed.port) : OPENCODEX_DEFAULT_PORT;
+    const hostname = parsed.hostname || "127.0.0.1";
+    const normalizedBase = `http://${hostname}:${port}`;
+    if (cachedUpstream && cachedUpstream.baseUrl === normalizedBase) return cachedUpstream;
+    const probed = await probeOpenCodex(port, hostname);
+    cachedUpstream = probed;
+    lastProbeAt = Date.now();
+    return probed;
+  }
+
+  // Auto-detect with cooldown.
+  const now = Date.now();
+  if (cachedUpstream !== undefined && now - lastProbeAt < PROBE_COOLDOWN_MS) {
+    return cachedUpstream;
+  }
+  const probed = await probeOpenCodex();
+  cachedUpstream = probed;
+  lastProbeAt = now;
+  return probed;
+}
+
+/** Reset the cached probe state (for testing). */
+export function resetOpenCodexCache(): void {
+  cachedUpstream = undefined;
+  lastProbeAt = 0;
+}
+
+/**
+ * Detect whether opencodex currently owns the Codex config.toml routing.
+ * Returns the opencodex base URL if its marker is present, or null.
+ */
+export function detectOpenCodexConfigOwnership(codexConfigPath?: string): string | null {
+  const configPath = codexConfigPath ?? join(homedir(), ".codex", "config.toml");
+  if (!existsSync(configPath)) return null;
+  const content = readFileSync(configPath, "utf8");
+  if (!content.includes(OPENCODEX_CONFIG_MARKER)) return null;
+  // Extract the openai_base_url that opencodex set.
+  const lines = content.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i]!.includes(OPENCODEX_CONFIG_MARKER)) {
+      // The URL line should be immediately after the marker.
+      const nextLine = lines[i + 1] ?? "";
+      const match = /^\s*openai_base_url\s*=\s*["']([^"']+)["']/.exec(nextLine);
+      if (match?.[1]) return match[1];
+    }
+  }
+  return null;
+}
+
+/**
+ * Build the opencodex Responses API URL for a given endpoint.
+ */
+export function openCodexEndpointUrl(upstream: OpenCodexUpstream, endpoint: string): string {
+  return `${upstream.baseUrl}/v1/${endpoint}`;
+}
+
+/**
+ * Fetch the model catalog from a running opencodex instance.
+ * Returns the raw models array or null on failure.
+ */
+export async function fetchOpenCodexModels(
+  upstream: OpenCodexUpstream,
+  authorization?: string,
+  timeoutMs: number = 5_000,
+): Promise<Record<string, unknown>[] | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const headers: Record<string, string> = { "accept": "application/json" };
+    if (authorization) headers["authorization"] = authorization;
+    const response = await fetch(`${upstream.baseUrl}/v1/models`, {
+      signal: controller.signal,
+      headers,
+    });
+    if (!response.ok) return null;
+    const body = await response.json() as { models?: unknown[] };
+    if (!Array.isArray(body.models)) return null;
+    return body.models as Record<string, unknown>[];
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,6 +18,8 @@ import {
   type ChatGptWebModelRoute,
 } from "./chatgpt-web-models";
 import { forwardNativeCodexRequest, type NativeFetch } from "./native-passthrough";
+import { setOpenCodexConfig, getActiveOpenCodexUpstream } from "./native-passthrough";
+import { resolveOpenCodexUpstream } from "./opencodex";
 import {
   buildCompactV1Output,
   COMPACT_PROMPT,
@@ -166,7 +168,7 @@ export async function modelsRequest(
   if (!upstream.ok) return upstream;
   let catalog: Record<string, unknown>;
   try {
-    catalog = augmentNativeModelCatalog(await upstream.json(), config, contextOverride?.());
+    catalog = await augmentNativeModelCatalog(await upstream.json(), config, contextOverride?.());
   } catch (error) {
     return formatErrorResponse(502, "invalid_response_error", error instanceof Error ? error.message : String(error));
   }
@@ -387,6 +389,19 @@ export function startServer(
   dependencies: { fetchUpstream?: NativeFetch } = {},
 ): ReturnType<typeof Bun.serve> {
   const startedAt = Date.now();
+  // Initialize opencodex upstream detection for native passthrough routing.
+  setOpenCodexConfig(config.opencodex);
+  // Trigger an initial background probe so the first model catalog request has a warm cache.
+  if (config.opencodex && (config.opencodex.url || config.opencodex.autoDetect === true)) {
+    void resolveOpenCodexUpstream(config.opencodex.url).then(upstream => {
+      if (upstream) {
+        console.info(
+          `[chatgpt-web] opencodex detected at ${upstream.baseUrl} (v${upstream.version ?? "unknown"}) — `
+          + "native passthrough routes through opencodex for multi-provider model access",
+        );
+      }
+    }).catch(() => {});
+  }
   if (config.mode === "full") {
     void TurnBroker.forSocket(config.brokerSocketPath).listen().catch(error => {
       console.error(
@@ -416,6 +431,7 @@ export function startServer(
     fetch(req) {
       const url = new URL(req.url);
       if (req.method === "GET" && url.pathname === "/healthz") {
+        const ocxUpstream = getActiveOpenCodexUpstream();
         return Response.json({
           status: "ok",
           service: "codex-chatgpt-web",
@@ -427,6 +443,7 @@ export function startServer(
           accepting_turns: !draining,
           successful_model_catalog_requests: successfulModelCatalogRequests,
           last_successful_model_catalog_request_at: lastSuccessfulModelCatalogRequestAt,
+          opencodex_upstream: ocxUpstream ? { url: ocxUpstream.baseUrl, version: ocxUpstream.version } : null,
           ...activity(),
         });
       }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -98,6 +98,7 @@ function meaningfulRuntimeChange(before: AppConfig, after: AppConfig): boolean {
     controlToken: before.controlToken,
     runtimeCommand: before.runtimeCommand,
     tunnel: before.tunnel,
+    opencodex: before.opencodex,
   }) !== JSON.stringify({
     mode: after.mode,
     releaseVersion: after.releaseVersion,
@@ -116,6 +117,7 @@ function meaningfulRuntimeChange(before: AppConfig, after: AppConfig): boolean {
     controlToken: after.controlToken,
     runtimeCommand: after.runtimeCommand,
     tunnel: after.tunnel,
+    opencodex: after.opencodex,
   });
 }
 

--- a/tests/model-catalog.test.ts
+++ b/tests/model-catalog.test.ts
@@ -42,12 +42,12 @@ function source(): Record<string, unknown> {
 }
 
 describe("native /models augmentation", () => {
-  test("preserves every native model in order and appends one fixed model per ChatGPT Web mode", () => {
+  test("preserves every native model in order and appends one fixed model per ChatGPT Web mode", async () => {
     const native = source();
     const nativeSnapshot = structuredClone(native);
     const config = defaultConfig("full");
     config.proAvailable = true;
-    const result = augmentNativeModelCatalog(native, config);
+    const result = await augmentNativeModelCatalog(native, config);
     const models = result.models as Array<Record<string, unknown>>;
 
     expect(native).toEqual(nativeSnapshot);
@@ -75,7 +75,7 @@ describe("native /models augmentation", () => {
     }
   });
 
-  test("owns only its namespace, is idempotent, and omits account-gated Pro when unavailable", () => {
+  test("owns only its namespace, is idempotent, and omits account-gated Pro when unavailable", async () => {
     const config = defaultConfig("browser-only");
     config.proAvailable = false;
     const polluted = source();
@@ -83,8 +83,8 @@ describe("native /models augmentation", () => {
       { slug: "chatgpt-web/gpt-5.6-sol", display_name: "legacy generic route" },
       { slug: "chatgpt-web/pro", display_name: "stale Pro route" },
     );
-    const first = augmentNativeModelCatalog(polluted, config);
-    const second = augmentNativeModelCatalog(first, config);
+    const first = await augmentNativeModelCatalog(polluted, config);
+    const second = await augmentNativeModelCatalog(first, config);
     const models = second.models as Array<Record<string, unknown>>;
     const web = models.filter(model => String(model.slug).startsWith("chatgpt-web/"));
     expect(web.map(model => model.slug)).toEqual(
@@ -95,12 +95,12 @@ describe("native /models augmentation", () => {
     expect(web.every(model => (model.supported_reasoning_levels as unknown[]).length === 1)).toBe(true);
   });
 
-  test("honors an explicit Codex context override without replacing or reordering native models", () => {
+  test("honors an explicit Codex context override without replacing or reordering native models", async () => {
     const native = source();
     const nativeSnapshot = structuredClone(native);
     // model_context_window is one top-level Codex setting, so it must not depend on which model
     // the config's `model` line happens to name - that line can hold a ChatGPT Web slug.
-    const result = augmentNativeModelCatalog(native, defaultConfig("full"), {
+    const result = await augmentNativeModelCatalog(native, defaultConfig("full"), {
       model: "chatgpt-web/medium",
       contextWindow: 371_851,
     });
@@ -121,11 +121,11 @@ describe("native /models augmentation", () => {
     }
   });
 
-  test("never lowers a native window that already exceeds the Codex context override", () => {
+  test("never lowers a native window that already exceeds the Codex context override", async () => {
     const native = source();
     const models = native.models as Array<Record<string, unknown>>;
     models[0]!.max_context_window = 1_000_000;
-    const result = augmentNativeModelCatalog(native, defaultConfig("full"), {
+    const result = await augmentNativeModelCatalog(native, defaultConfig("full"), {
       model: "gpt-5.6-sol",
       contextWindow: 371_851,
     });
@@ -133,7 +133,7 @@ describe("native /models augmentation", () => {
     expect((result.models as Array<Record<string, unknown>>)[0]!.max_context_window).toBe(1_000_000);
   });
 
-  test("uses an available compatible official model when an account exposes a smaller catalog", () => {
+  test("uses an available compatible official model when an account exposes a smaller catalog", async () => {
     const native = source();
     const models = native.models as Array<Record<string, unknown>>;
     models.splice(1, 1);
@@ -145,7 +145,7 @@ describe("native /models augmentation", () => {
       shell_type: "shell_command",
     });
 
-    const result = augmentNativeModelCatalog(native, defaultConfig("full"));
+    const result = await augmentNativeModelCatalog(native, defaultConfig("full"));
     const web = (result.models as Array<Record<string, unknown>>)
       .filter(model => String(model.slug).startsWith("chatgpt-web/"));
     expect(web.length).toBe(4);
@@ -153,7 +153,7 @@ describe("native /models augmentation", () => {
     expect(web.every(model => model.tool_mode === "code_mode_only")).toBe(true);
   });
 
-  test("follows official catalog order instead of preferring a named paid-tier model", () => {
+  test("follows official catalog order instead of preferring a named paid-tier model", async () => {
     const native = source();
     const sourceModels = native.models as Array<Record<string, unknown>>;
     const sol = sourceModels[1]!;
@@ -165,14 +165,14 @@ describe("native /models augmentation", () => {
     };
     native.models = [sourceModels[0], terra, sol];
 
-    const result = augmentNativeModelCatalog(native, defaultConfig("full"));
+    const result = await augmentNativeModelCatalog(native, defaultConfig("full"));
     const web = (result.models as Array<Record<string, unknown>>)
       .filter(model => String(model.slug).startsWith("chatgpt-web/"));
     expect(web.every(model => model.shell_type === "terra-shell")).toBe(true);
   });
 
-  test("fails closed when no official model satisfies the harness contract", () => {
-    expect(() => augmentNativeModelCatalog({
+  test("fails closed when no official model satisfies the harness contract", async () => {
+    await expect(augmentNativeModelCatalog({
       models: [{
         slug: "other",
         visibility: "list",
@@ -180,6 +180,6 @@ describe("native /models augmentation", () => {
         supported_reasoning_levels: [],
         tool_mode: null,
       }],
-    }, defaultConfig("full"))).toThrow("no list-visible, API-supported, tool-capable model");
+    }, defaultConfig("full"))).rejects.toThrow("no list-visible, API-supported, tool-capable model");
   });
 });

--- a/tests/opencodex-compat.test.ts
+++ b/tests/opencodex-compat.test.ts
@@ -1,0 +1,197 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  probeOpenCodex,
+  resolveOpenCodexUpstream,
+  resetOpenCodexCache,
+  detectOpenCodexConfigOwnership,
+  openCodexEndpointUrl,
+  fetchOpenCodexModels,
+  OPENCODEX_DEFAULT_PORT,
+  OPENCODEX_SERVICE_IDENTITY,
+  type OpenCodexUpstream,
+} from "../src/opencodex";
+import { writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+describe("opencodex compatibility", () => {
+  beforeEach(() => {
+    resetOpenCodexCache();
+  });
+
+  describe("probeOpenCodex", () => {
+    test("returns null when nothing is listening", async () => {
+      const result = await probeOpenCodex(59999, "127.0.0.1", 500);
+      expect(result).toBeNull();
+    });
+
+    test("returns null for a non-opencodex service", async () => {
+      const server = Bun.serve({
+        port: 0,
+        fetch() {
+          return Response.json({ status: "ok", service: "something-else" });
+        },
+      });
+      const port = server.port;
+      try {
+        const result = await probeOpenCodex(port, "127.0.0.1", 2000);
+        expect(result).toBeNull();
+      } finally {
+        await server.stop(true);
+      }
+    });
+
+    test("detects a running opencodex instance", async () => {
+      const server = Bun.serve({
+        port: 0,
+        fetch(req) {
+          const url = new URL(req.url);
+          if (url.pathname === "/healthz") {
+            return Response.json({
+              status: "ok",
+              service: "opencodex",
+              version: "2.9.1",
+              uptime: 123.4,
+              pid: 12345,
+              port: 10100,
+            });
+          }
+          return new Response("Not found", { status: 404 });
+        },
+      });
+      const port = server.port;
+      try {
+        const result = await probeOpenCodex(port, "127.0.0.1", 2000);
+        expect(result).not.toBeNull();
+        expect(result!.baseUrl).toBe(`http://127.0.0.1:${port}`);
+        expect(result!.version).toBe("2.9.1");
+        expect(result!.pid).toBe(12345);
+      } finally {
+        await server.stop(true);
+      }
+    });
+
+    test("returns null when status is not ok", async () => {
+      const server = Bun.serve({
+        port: 0,
+        fetch() {
+          return Response.json({ status: "degraded", service: "opencodex" });
+        },
+      });
+      const port = server.port;
+      try {
+        const result = await probeOpenCodex(port, "127.0.0.1", 2000);
+        expect(result).toBeNull();
+      } finally {
+        await server.stop(true);
+      }
+    });
+  });
+
+  describe("resolveOpenCodexUpstream", () => {
+    test("caches results within cooldown window", async () => {
+      let probeCount = 0;
+      const server = Bun.serve({
+        port: 0,
+        fetch() {
+          probeCount += 1;
+          return Response.json({ status: "ok", service: "opencodex", version: "2.9.1" });
+        },
+      });
+      const port = server.port;
+      try {
+        // First call probes.
+        const first = await resolveOpenCodexUpstream(`http://127.0.0.1:${port}`);
+        expect(first).not.toBeNull();
+        expect(probeCount).toBe(1);
+        // Second call within cooldown uses cache.
+        const second = await resolveOpenCodexUpstream(`http://127.0.0.1:${port}`);
+        expect(second).not.toBeNull();
+        expect(probeCount).toBe(1);
+      } finally {
+        await server.stop(true);
+      }
+    });
+  });
+
+  describe("detectOpenCodexConfigOwnership", () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+      tempDir = join(tmpdir(), `ocx-test-${crypto.randomUUID()}`);
+      mkdirSync(tempDir, { recursive: true });
+    });
+
+    afterEach(() => {
+      rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    test("returns null when config does not exist", () => {
+      const result = detectOpenCodexConfigOwnership(join(tempDir, "nonexistent.toml"));
+      expect(result).toBeNull();
+    });
+
+    test("returns null when opencodex marker is absent", () => {
+      const configPath = join(tempDir, "config.toml");
+      writeFileSync(configPath, 'openai_base_url = "http://127.0.0.1:17841/v1"\n');
+      const result = detectOpenCodexConfigOwnership(configPath);
+      expect(result).toBeNull();
+    });
+
+    test("detects opencodex ownership and extracts URL", () => {
+      const configPath = join(tempDir, "config.toml");
+      writeFileSync(configPath, [
+        "# Auto-injected by opencodex",
+        'openai_base_url = "http://127.0.0.1:10100/v1"',
+        "",
+      ].join("\n"));
+      const result = detectOpenCodexConfigOwnership(configPath);
+      expect(result).toBe("http://127.0.0.1:10100/v1");
+    });
+  });
+
+  describe("openCodexEndpointUrl", () => {
+    test("builds correct endpoint URLs", () => {
+      const upstream: OpenCodexUpstream = { baseUrl: "http://127.0.0.1:10100" };
+      expect(openCodexEndpointUrl(upstream, "models")).toBe("http://127.0.0.1:10100/v1/models");
+      expect(openCodexEndpointUrl(upstream, "responses")).toBe("http://127.0.0.1:10100/v1/responses");
+      expect(openCodexEndpointUrl(upstream, "responses/compact")).toBe("http://127.0.0.1:10100/v1/responses/compact");
+    });
+  });
+
+  describe("fetchOpenCodexModels", () => {
+    test("returns null on failure", async () => {
+      const upstream: OpenCodexUpstream = { baseUrl: "http://127.0.0.1:59998" };
+      const result = await fetchOpenCodexModels(upstream, undefined, 500);
+      expect(result).toBeNull();
+    });
+
+    test("fetches models from a running opencodex", async () => {
+      const server = Bun.serve({
+        port: 0,
+        fetch(req) {
+          const url = new URL(req.url);
+          if (url.pathname === "/v1/models") {
+            return Response.json({
+              models: [
+                { slug: "claude-sonnet-5", visibility: "list", display_name: "Claude Sonnet 5" },
+                { slug: "deepseek-v4-pro", visibility: "list", display_name: "DeepSeek V4 Pro" },
+                { slug: "hidden-model", visibility: "hidden", display_name: "Hidden" },
+              ],
+            });
+          }
+          return new Response("Not found", { status: 404 });
+        },
+      });
+      const port = server.port;
+      try {
+        const upstream: OpenCodexUpstream = { baseUrl: `http://127.0.0.1:${port}` };
+        const models = await fetchOpenCodexModels(upstream);
+        expect(models).not.toBeNull();
+        expect(models!.length).toBe(3);
+      } finally {
+        await server.stop(true);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

When [opencodex](https://github.com/lidge-jun/opencodex) is running locally, codex-chatgpt-web now auto-detects it and routes native Codex passthrough requests through it instead of directly to the ChatGPT backend. This gives users access to opencodex's full multi-provider routing (Anthropic, Google, xAI, DeepSeek, Kimi, Ollama, and more) for non-chatgpt-web models, while ChatGPT Web models continue running through the embedded browser.

## Architecture

```
Codex ──Responses API──▶ codex-chatgpt-web ──chatgpt-web/*──▶ embedded browser (ChatGPT)
                              │
                              └──other models──▶ opencodex ──▶ Any provider
                                                  (auto-detected on :10100)
```

Detection is **passive and fail-open**: if opencodex is unreachable, the bridge falls back to the direct ChatGPT backend transparently. No configuration is required.

## Changes

| File | Role |
|---|---|
| `src/opencodex.ts` (new) | Detection module: healthz probe, config.toml ownership, model fetch |
| `src/native-passthrough.ts` | Core: upstream resolution with 30s cached probe |
| `src/adapters/chatgpt-web/index.ts` | One-time commentary routing notice (same pattern as Pro warning) |
| `src/config.ts` | Optional `opencodex` config section (`url`, `autoDetect`, `mergeModels`) |
| `src/codex-integration.ts` | Auto-allow route replacement when opencodex owns `openai_base_url` |
| `src/setup.ts` | Auto-detect opencodex during setup and persist config |
| `src/server.ts` | Startup probe, healthz upstream reporting |
| `src/doctor.ts` | opencodex connectivity check |
| `tests/opencodex-compat.test.ts` (new) | 11 tests covering probe, cache, config detection |

## User-facing notifications

Following the same pattern as the Pro context warning:

- **Server startup console**: `[chatgpt-web] opencodex detected at http://127.0.0.1:10100 (v2.9.1) — native passthrough routes through opencodex`
- **Codex UI commentary** (first turn only): `ℹ️ opencodex (v2.9.1) detected at http://127.0.0.1:10100. Non-ChatGPT-Web model requests route through opencodex for multi-provider access...`
- **Doctor output**: `✓ opencodex 2.9.1 detected at http://127.0.0.1:10100 — native passthrough routes through it`

## Compatibility details

- opencodex identity verified via `/healthz` → `service: "opencodex"` + `status: "ok"`
- config.toml ownership detected via opencodex's `# Auto-injected by opencodex` marker
- Loopback bind requires no authentication (both services bind 127.0.0.1)
- `ocx1:`/`ocxr1:` compaction/reasoning envelopes already shared between both projects
- SSE streaming passes through unchanged (body stream forwarded directly)
- `previous_response_id` scrub logic remains provider-agnostic
- Setup journal correctly restores opencodex's URL on uninstall

## Testing

- TypeScript: compiles cleanly (`bunx tsc --noEmit`)
- 284/285 tests pass (1 pre-existing failure unrelated to this change)
- 11 new tests covering probe, cache, config detection, endpoint URLs, model fetch