### PR TITLE
Fix `codex_bind_turn` for turns without a timeout

### DIFF
--- a/src/adapters/chatgpt-web/mcp-server.ts
+++ b/src/adapters/chatgpt-web/mcp-server.ts
@@ -8,11 +8,11 @@ import { callTurnBroker, type BrokerToolResult } from "./turn-broker";
 
 interface ClaimedTurn {
   bindingId: string;
-  environment: ChatGptTurnEnvironment & { expiresAt: number };
+  environment: ChatGptTurnEnvironment & { expiresAt?: number };
 }
 
 interface ResolvedTurn {
-  environment: ChatGptTurnEnvironment & { expiresAt: number };
+  environment: ChatGptTurnEnvironment & { expiresAt?: number };
 }
 
 const bindingSchema = z.string().min(20).max(256).describe("Opaque binding_id returned by codex_bind_turn.");
@@ -70,8 +70,8 @@ function namedTool(environment: ChatGptTurnEnvironment, requestedWireName: strin
   return tool;
 }
 
-function invocationTimeout(environment: ChatGptTurnEnvironment & { expiresAt: number }): number {
-  return Math.max(1, environment.expiresAt - Date.now());
+function invocationTimeout(environment: ChatGptTurnEnvironment & { expiresAt?: number }): number | null {
+  return environment.expiresAt === undefined ? null : Math.max(1, environment.expiresAt - Date.now());
 }
 
 function asMcpResult(value: BrokerToolResult) {
@@ -124,15 +124,16 @@ function execGatewayProgram(
 export async function runChatGptMcpServer(options: { brokerSocketPath: string }): Promise<void> {
   const server = new McpServer({ name: "codex-native", version: "3.0.0" });
 
-  const environment = async (bindingId: string): Promise<ChatGptTurnEnvironment & { expiresAt: number }> => {
+  const environment = async (bindingId: string): Promise<ChatGptTurnEnvironment & { expiresAt?: number }> => {
     const resolved = await callTurnBroker<ResolvedTurn>(options.brokerSocketPath, { method: "resolve", bindingId });
-    if (resolved.environment.expiresAt <= Date.now()) throw new Error("Codex turn binding expired");
+    const expiresAt = resolved.environment.expiresAt;
+    if (expiresAt !== undefined && expiresAt <= Date.now()) throw new Error("Codex turn binding expired");
     return resolved.environment;
   };
 
   const invoke = async (
     bindingId: string,
-    bound: ChatGptTurnEnvironment & { expiresAt: number },
+    bound: ChatGptTurnEnvironment & { expiresAt?: number },
     tool: CodexTool,
     payload: { arguments?: Record<string, unknown>; input?: string },
   ) => {
@@ -148,7 +149,7 @@ export async function runChatGptMcpServer(options: { brokerSocketPath: string })
 
   const invokeNative = (
     bindingId: string,
-    bound: ChatGptTurnEnvironment & { expiresAt: number },
+    bound: ChatGptTurnEnvironment & { expiresAt?: number },
     tool: CodexTool,
     payload: { arguments?: Record<string, unknown>; input?: string },
   ) => {
@@ -160,7 +161,7 @@ export async function runChatGptMcpServer(options: { brokerSocketPath: string })
 
   const invokeNestedNative = (
     bindingId: string,
-    bound: ChatGptTurnEnvironment & { expiresAt: number },
+    bound: ChatGptTurnEnvironment & { expiresAt?: number },
     nestedToolName: string,
     freeform: boolean,
     payload: { arguments?: Record<string, unknown>; input?: string },
@@ -195,7 +196,9 @@ export async function runChatGptMcpServer(options: { brokerSocketPath: string })
         roots: claimed.environment.roots,
         writable_roots: claimed.environment.writableRoots,
         sandbox: claimed.environment.sandboxPolicy.type,
-        expires_at: new Date(claimed.environment.expiresAt).toISOString(),
+        expires_at: claimed.environment.expiresAt === undefined
+          ? null
+          : new Date(claimed.environment.expiresAt).toISOString(),
         tool_count: claimed.environment.tools.length,
         command_tool: commandTool ? wireName(commandTool) : gateway ? "exec_command" : null,
         outer_tool_gateway: gateway ? wireName(gateway) : null,

--- a/src/adapters/chatgpt-web/turn-broker.ts
+++ b/src/adapters/chatgpt-web/turn-broker.ts
@@ -498,10 +498,16 @@ export class TurnBroker {
   }
 }
 
+/**
+ * A turn registered without a TTL has no deadline to bound its tool calls against, so a null
+ * timeout waits for as long as the turn itself lives. Undefined keeps the bounded default, because
+ * a caller that cannot compute a deadline must not silently inherit an unbounded wait. An
+ * unbounded call still ends when the turn is revoked or the broker drops the connection.
+ */
 export async function callTurnBroker<T>(
   socketPath: string,
   request: Omit<BrokerRequest, "id">,
-  timeoutMs = 5_000,
+  timeoutMs: number | null = 5_000,
 ): Promise<T> {
   const id = opaqueId("request");
   return new Promise<T>((resolveCall, rejectCall) => {
@@ -515,9 +521,12 @@ export async function callTurnBroker<T>(
       socket.destroy();
       rejectCall(error);
     };
-    const timer = setTimeout(() => finishError(new Error("ChatGPT web turn broker timed out")), timeoutMs);
+    const timer = timeoutMs === null
+      ? undefined
+      : setTimeout(() => finishError(new Error("ChatGPT web turn broker timed out")), timeoutMs);
     socket.setEncoding("utf8");
     socket.once("error", error => finishError(new Error(`ChatGPT web turn broker unavailable: ${error.message}`)));
+    socket.once("close", () => finishError(new Error("ChatGPT web turn broker closed the connection")));
     socket.once("connect", () => socket.write(`${JSON.stringify({ id, ...request })}\n`));
     socket.on("data", chunk => {
       if (settled) return;

--- a/tests/chatgpt-web-harness.test.ts
+++ b/tests/chatgpt-web-harness.test.ts
@@ -908,4 +908,49 @@ describe("ChatGPT outer-native harness v3", () => {
       await broker.close();
     }
   }, 30_000);
+
+  test("serves the outer-native bridge contract over MCP stdio for a turn registered without a turn timeout", async () => {
+    const socketPath = brokerTestEndpoint(`cgw-h3-mcp-no-ttl-${process.pid}-${Date.now()}`);
+    const broker = TurnBroker.forSocket(socketPath);
+    const gatewayOnlyEnvironment = extractChatGptTurnEnvironment(parsed(environmentXml));
+    gatewayOnlyEnvironment.tools = gatewayOnlyEnvironment.tools.filter(tool => (
+      tool.name === "exec" || tool.name === "search_openai_docs"
+    ));
+    const token = await broker.register(gatewayOnlyEnvironment);
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: ["src/cli.ts", "mcp", "--broker-socket", socketPath],
+      cwd: process.cwd(),
+      stderr: "pipe",
+    });
+    const client = new Client({ name: "codex-chatgpt-web-harness-test", version: "1.0.0" });
+    const call = (name: string, args: Record<string, unknown>) => client.callTool({ name, arguments: args });
+
+    try {
+      await client.connect(transport);
+
+      const bound = await call("codex_bind_turn", { turn_token: token });
+      expect(bound.content).toEqual([{ type: "text", text: expect.stringContaining("binding_") }]);
+      expect(bound.isError).not.toBe(true);
+      const binding = bound.structuredContent as { binding_id: string; expires_at: string | null };
+      expect(binding.binding_id).toStartWith("binding_");
+      expect(binding.expires_at).toBeNull();
+
+      const execPromise = call("codex_exec", { binding_id: binding.binding_id, cmd: "pwd", workdir: tempRoot });
+      const [execRequest] = await Promise.race([
+        broker.nextToolBatch(token),
+        execPromise.then(response => {
+          throw new Error(`codex_exec settled before reaching the broker: ${JSON.stringify(response.content)}`);
+        }),
+      ]);
+      expect(execRequest).toMatchObject({ wireName: "exec", freeform: true });
+      expect(execRequest?.input).toContain(`tools["exec_command"](${JSON.stringify({ cmd: "pwd", workdir: tempRoot })})`);
+      broker.completeTool(token, execRequest!.callId, toolResult({ output: tempRoot, exit_code: 0 }));
+      expect((await execPromise).structuredContent).toEqual({ output: tempRoot, exit_code: 0 });
+    } finally {
+      await client.close().catch(() => {});
+      broker.revoke(token);
+      await broker.close();
+    }
+  }, 30_000);
 });

--- a/tests/turn-broker-lifecycle.test.ts
+++ b/tests/turn-broker-lifecycle.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test";
 import { ChatGptTextFeed, ChatGptTraceFeed, ChatGptTurnSessions } from "../src/adapters/chatgpt-web/turn-execution";
-import { existsSync, mkdtempSync, rmSync, statSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync } from "node:fs";
+import { createServer, type Socket } from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { callTurnBroker, TurnBroker } from "../src/adapters/chatgpt-web/turn-broker";
@@ -144,6 +145,49 @@ test("turn broker tokens do not expire while their browser turn is still alive",
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+function unansweredBrokerEndpoint(name: string, onConnection: (socket: Socket) => void) {
+  const root = mkdtempSync(join(tmpdir(), name));
+  const socketPath = defaultBrokerEndpoint(root);
+  if (!isWindowsPipeEndpoint(socketPath)) mkdirSync(dirname(socketPath), { recursive: true });
+  const server = createServer(onConnection);
+  return {
+    socketPath,
+    listen: () => new Promise<void>(ready => server.listen(socketPath, ready)),
+    close: async () => {
+      await new Promise<void>(done => server.close(() => done()));
+      rmSync(root, { recursive: true, force: true });
+    },
+  };
+}
+
+test("an unbounded broker call fails when the broker closes without answering", async () => {
+  const broker = unansweredBrokerEndpoint("cgw-broker-closed-", socket => socket.on("data", () => socket.end()));
+  await broker.listen();
+  try {
+    await expect(callTurnBroker(broker.socketPath, { method: "claim", token: "turn_closed" }, null))
+      .rejects.toThrow("closed the connection");
+  } finally {
+    await broker.close();
+  }
+}, 10_000);
+
+test("an unbounded broker call outlives the bounded default timeout", async () => {
+  const accepted: Socket[] = [];
+  const broker = unansweredBrokerEndpoint("cgw-broker-slow-", socket => { accepted.push(socket); });
+  await broker.listen();
+  try {
+    const call = callTurnBroker(broker.socketPath, { method: "claim", token: "turn_unbounded" }, null);
+    const outcome = await Promise.race([
+      call.then(() => "settled", () => "settled"),
+      Bun.sleep(5_300).then(() => "pending"),
+    ]);
+    expect(outcome).toBe("pending");
+  } finally {
+    for (const socket of accepted) socket.destroy();
+    await broker.close();
+  }
+}, 15_000);
 
 test("turn broker names the finished turn that owns a replayed handle", async () => {
   const root = mkdtempSync(join(tmpdir(), "cgw-broker-"));


### PR DESCRIPTION
## Summary

Version 1.1.1 made `codex_bind_turn` fail when a turn had no timeout:

```text
codex_bind_turn

Result: Invalid Date

Error: true
```

This change treats a missing expiration as valid, returns `expires_at: null`, and keeps broker calls open until the turn ends or the connection closes. It also adds focused regression coverage.

## Testing

Tested on macOS 26.5 arm64:

- `bun install --frozen-lockfile`
- `bun install --frozen-lockfile` in `launcher/`
- `bun run typecheck`
- `bun run test` (193 passed)