### PR TITLE
Back up Codex config.toml before route install

### DIFF
--- a/src/codex-config-backup.ts
+++ b/src/codex-config-backup.ts
@@ -1,0 +1,193 @@
+import { copyFileSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync, chmodSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { expandUserPath } from "./config";
+
+export const CODEX_CONFIG_BACKUP_DIRNAME = "backup-codex-chatgpt-web";
+
+export interface CodexConfigBackupManifest {
+  scriptVersion: string;
+  installedAt: string;
+  originalConfigExisted: boolean;
+  configPath: string;
+  codexHome: string;
+  routeUrl?: string;
+}
+
+function resolveCodexHome(): string {
+  const configured = process.env.CODEX_HOME?.trim();
+  if (configured) return expandUserPath(configured);
+  return join(homedir(), ".codex");
+}
+
+function resolveCodexConfigPath(codexHome = resolveCodexHome()): string {
+  return join(codexHome, "config.toml");
+}
+
+export function getCodexConfigBackupDir(codexHome = resolveCodexHome()): string {
+  return join(codexHome, CODEX_CONFIG_BACKUP_DIRNAME);
+}
+
+export function getCodexConfigBackupPath(codexHome = resolveCodexHome()): string {
+  return join(getCodexConfigBackupDir(codexHome), "config.toml");
+}
+
+export function getCodexConfigBackupManifestPath(codexHome = resolveCodexHome()): string {
+  return join(getCodexConfigBackupDir(codexHome), "manifest.txt");
+}
+
+function formatInstalledAt(date = new Date()): string {
+  const pad = (value: number) => String(value).padStart(2, "0");
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} `
+    + `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+}
+
+function chmodBestEffort(path: string, mode: number): void {
+  try {
+    chmodSync(path, mode);
+  } catch {
+    // Best-effort on platforms without POSIX modes.
+  }
+}
+
+export function parseCodexConfigBackupManifest(text: string): CodexConfigBackupManifest {
+  const values = new Map<string, string>();
+  for (const line of text.split(/\r?\n/)) {
+    if (!line || line.startsWith("---")) break;
+    const index = line.indexOf("=");
+    if (index <= 0) continue;
+    values.set(line.slice(0, index), line.slice(index + 1));
+  }
+  const original = values.get("original_config_existed");
+  if (original !== "0" && original !== "1") {
+    throw new Error("Codex config backup manifest is missing original_config_existed");
+  }
+  const configPath = values.get("config_path");
+  const codexHome = values.get("codex_home");
+  if (!configPath || !codexHome) {
+    throw new Error("Codex config backup manifest is missing config_path or codex_home");
+  }
+  return {
+    scriptVersion: values.get("script_version") || "unknown",
+    installedAt: values.get("installed_at") || "unknown",
+    originalConfigExisted: original === "1",
+    configPath,
+    codexHome,
+    ...(values.get("route_url") ? { routeUrl: values.get("route_url") } : {}),
+  };
+}
+
+function writeManifest(path: string, manifest: CodexConfigBackupManifest, report: string[] = []): void {
+  const lines = [
+    `script_version=${manifest.scriptVersion}`,
+    `installed_at=${manifest.installedAt}`,
+    `original_config_existed=${manifest.originalConfigExisted ? "1" : "0"}`,
+    `config_path=${manifest.configPath}`,
+    `codex_home=${manifest.codexHome}`,
+    ...(manifest.routeUrl ? [`route_url=${manifest.routeUrl}`] : []),
+    "--- changes made to config.toml ---",
+    ...report,
+    "",
+  ];
+  writeFileSync(path, lines.join("\n"), { mode: 0o600 });
+  chmodBestEffort(path, 0o600);
+}
+
+/**
+ * DeepSeek-style full-file backup of ~/.codex/config.toml.
+ * Creates the backup only on the first install; later updates keep the original snapshot.
+ */
+export function ensureCodexConfigBackup(options: {
+  routeUrl?: string;
+  report?: string[];
+  version?: string;
+} = {}): { created: boolean; path: string; originalConfigExisted: boolean } {
+  const codexHome = resolveCodexHome();
+  const configPath = resolveCodexConfigPath(codexHome);
+  const backupDir = getCodexConfigBackupDir(codexHome);
+  const backupPath = getCodexConfigBackupPath(codexHome);
+  const manifestPath = getCodexConfigBackupManifestPath(codexHome);
+
+  if (existsSync(backupDir)) {
+    if (!existsSync(manifestPath)) {
+      throw new Error(
+        `Codex config backup directory exists but is incomplete: ${backupDir}. `
+        + "Restore or delete it before running setup again.",
+      );
+    }
+    const manifest = parseCodexConfigBackupManifest(readFileSync(manifestPath, "utf8"));
+    if (manifest.originalConfigExisted && !existsSync(backupPath)) {
+      throw new Error(`Codex config backup is corrupted: missing ${backupPath}`);
+    }
+    return {
+      created: false,
+      path: backupDir,
+      originalConfigExisted: manifest.originalConfigExisted,
+    };
+  }
+
+  mkdirSync(backupDir, { recursive: true, mode: 0o700 });
+  chmodBestEffort(backupDir, 0o700);
+
+  const originalConfigExisted = existsSync(configPath);
+  if (originalConfigExisted) {
+    copyFileSync(configPath, backupPath);
+    chmodBestEffort(backupPath, 0o600);
+  }
+
+  writeManifest(manifestPath, {
+    scriptVersion: options.version || "1.1.1",
+    installedAt: formatInstalledAt(),
+    originalConfigExisted,
+    configPath,
+    codexHome,
+    ...(options.routeUrl ? { routeUrl: options.routeUrl } : {}),
+  }, options.report || [
+    "Saved a full copy of config.toml before codex-chatgpt-web modified the Codex route.",
+  ]);
+
+  return { created: true, path: backupDir, originalConfigExisted };
+}
+
+/**
+ * Restore ~/.codex/config.toml from the full-file backup and delete the backup directory.
+ * Returns null when no backup exists (caller should fall back to journal restore).
+ */
+export function restoreCodexConfigBackup(): {
+  restored: boolean;
+  deletedConfig: boolean;
+  backupDir: string;
+} | null {
+  const backupDir = getCodexConfigBackupDir();
+  const backupPath = getCodexConfigBackupPath();
+  const manifestPath = getCodexConfigBackupManifestPath();
+  if (!existsSync(backupDir)) return null;
+  if (!existsSync(manifestPath)) {
+    throw new Error(`Codex config backup is corrupted: missing ${manifestPath}`);
+  }
+
+  const manifest = parseCodexConfigBackupManifest(readFileSync(manifestPath, "utf8"));
+  const configPath = resolveCodexConfigPath();
+  let deletedConfig = false;
+
+  if (manifest.originalConfigExisted) {
+    if (!existsSync(backupPath)) {
+      throw new Error(`Codex config backup is corrupted: missing ${backupPath}`);
+    }
+    copyFileSync(backupPath, configPath);
+    chmodBestEffort(configPath, 0o600);
+  } else if (existsSync(configPath)) {
+    rmSync(configPath);
+    deletedConfig = true;
+  }
+
+  rmSync(backupDir, { recursive: true, force: true });
+  return { restored: true, deletedConfig, backupDir };
+}
+
+export function discardCodexConfigBackup(): boolean {
+  const backupDir = getCodexConfigBackupDir();
+  if (!existsSync(backupDir)) return false;
+  rmSync(backupDir, { recursive: true, force: true });
+  return true;
+}

--- a/src/codex-integration.ts
+++ b/src/codex-integration.ts
@@ -4,6 +4,8 @@ import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import type { AppConfig } from "./config";
 import { atomicWriteFile, expandUserPath, getConfigDir } from "./config";
+import { discardCodexConfigBackup, ensureCodexConfigBackup, restoreCodexConfigBackup } from "./codex-config-backup";
+import { VERSION } from "./version";
 
 const MANAGED_COMMENT = "# Managed by codex-chatgpt-web; `codex-chatgpt-web uninstall` restores prior values.";
 const MANAGED_REMOTE_COMPACTION_LINE =
@@ -957,6 +959,17 @@ export function installCodexIntegration(
   const currentText = existsSync(configPath) ? readFileSync(configPath, "utf8") : "";
   const existing = readJournal();
   const installedUrl = routeUrl(config);
+  // Full-file backup before the first mutation (DeepSeek-style). Later updates keep the original snapshot.
+  ensureCodexConfigBackup({
+    routeUrl: installedUrl,
+    version: VERSION,
+    report: [
+      "Saved a full copy of config.toml before codex-chatgpt-web modified the Codex route.",
+      ...(options.replaceExistingRoute
+        ? ["Install used --replace-codex-route to replace an existing Codex model route."]
+        : []),
+    ],
+  });
   if (existing) assertJournalTargetsConfig(existing, configPath);
 
   if (existing?.version === 6) {
@@ -1250,7 +1263,10 @@ export function activateCodexIntegration(): SetCodexIntegrationActiveResult {
 
 export function uninstallCodexIntegration(): UninstallCodexIntegrationResult {
   const journal = readJournal();
-  if (!journal) return { changed: false };
+  if (!journal) {
+    const fullBackup = restoreCodexConfigBackup();
+    return { changed: Boolean(fullBackup) };
+  }
   if (!existsSync(journal.configPath)) throw new Error(`Codex config is missing: ${journal.configPath}`);
   const current = readFileSync(journal.configPath, "utf8");
   let restored: string;
@@ -1273,6 +1289,8 @@ export function uninstallCodexIntegration(): UninstallCodexIntegrationResult {
     if (catalogSnapshot?.exists) rmSync(catalogSnapshot.path);
     rmSync(modelsCacheSnapshot.path, { force: true });
     rmSync(getCodexJournalPath(), { force: true });
+    // Full-file backup is a safety snapshot of the pre-install config; drop it after a verified restore.
+    discardCodexConfigBackup();
   } catch (error) {
     const rollbackFailures: string[] = [];
     for (const snapshot of [modelsCacheSnapshot, catalogSnapshot, configSnapshot]) {

--- a/tests/codex-integration.test.ts
+++ b/tests/codex-integration.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync, writeFileSync, existsSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -72,12 +72,35 @@ describe("reversible native Codex route integration", () => {
     expect(installed).not.toMatch(/^\s*model_provider\s*=/m);
     expect(installed).not.toMatch(/^\s*model_catalog_json\s*=/m);
     expect(installed).not.toContain("[model_providers.codex-chatgpt-web]");
+    const backupPath = join(codexHome, "backup-codex-chatgpt-web", "config.toml");
+    expect(readFileSync(backupPath, "utf8")).toBe(original);
 
     expect(uninstallCodexIntegration()).toEqual({ changed: true });
     expect(readFileSync(configPath, "utf8")).toBe(original);
+    expect(existsSync(join(codexHome, "backup-codex-chatgpt-web"))).toBe(false);
     expect(uninstallCodexIntegration()).toEqual({ changed: false });
   });
 
+  test("keeps the first full config.toml backup across later setup updates", () => {
+    const { codexHome } = fixture();
+    const configPath = join(codexHome, "config.toml");
+    const original = `model = "gpt-5.6-sol"\nmodel_provider = "openai"\n\n[features]\ngoals = true\n`;
+    writeFileSync(configPath, original);
+
+    installCodexIntegration(defaultConfig("browser-only"), { replaceExistingRoute: true });
+    const backupDir = join(codexHome, "backup-codex-chatgpt-web");
+    const backupPath = join(backupDir, "config.toml");
+    const manifestPath = join(backupDir, "manifest.txt");
+    expect(readFileSync(backupPath, "utf8")).toBe(original);
+    expect(readFileSync(manifestPath, "utf8")).toContain("original_config_existed=1");
+
+    installCodexIntegration(defaultConfig("browser-only"));
+    expect(readFileSync(backupPath, "utf8")).toBe(original);
+
+    expect(uninstallCodexIntegration()).toEqual({ changed: true });
+    expect(readFileSync(configPath, "utf8")).toBe(original);
+    expect(existsSync(backupDir)).toBe(false);
+  });
   test("restores an explicit remote_compaction_v2 setting byte-for-byte", () => {
     const { codexHome } = fixture();
     const configPath = join(codexHome, "config.toml");


### PR DESCRIPTION
## Summary
- Adds a DeepSeek-style full-file backup of `~/.codex/config.toml` under `~/.codex/backup-codex-chatgpt-web/` (`config.toml` + `manifest.txt`) before the first route install.
- Later setup updates keep the original snapshot instead of overwriting it.
- Verified journal uninstall still fail-closes on drift; the backup directory is discarded after a successful restore. If no journal remains, uninstall can restore from the full-file backup.

## Test plan
- [ ] Fresh install creates `~/.codex/backup-codex-chatgpt-web/config.toml` matching the pre-install file
- [ ] Re-running setup does not overwrite that backup
- [ ] Uninstall restores the prior route and deletes the backup directory
- [ ] Drift fail-closed uninstall tests still pass: `bun test tests/codex-integration.test.ts`