### PR TITLE
Fix ChatGPT effort slider selection

### DIFF
--- a/launcher/electron/browser-host.cjs
+++ b/launcher/electron/browser-host.cjs
@@ -1542,7 +1542,37 @@ class BrowserHost {
   }
 
   async inspectSession(detectPro = false) {
-    return await this.withManualOperation("session inspection", () => this.runSessionInspection(detectPro));
+    return await this.withManualOperation("session inspection", () => detectPro
+      ? this.withInteractiveHomeView(() => this.runSessionInspection(true))
+      : this.runSessionInspection(false));
+  }
+
+  async withInteractiveHomeView(action) {
+    if (browserViewVisible(this.visible, this.surfaceActive, this.boundsReady)) {
+      return await action();
+    }
+    const originalBounds = { ...this.bounds };
+    const [contentWidth, contentHeight] = this.boundsReady
+      ? [originalBounds.width, originalBounds.height]
+      : this.window.getContentSize();
+    const interactiveBounds = this.boundsReady
+      ? originalBounds
+      : { x: 0, y: 0, width: contentWidth, height: contentHeight };
+    const resize = () => this.view.webContents
+      .executeJavaScript("window.dispatchEvent(new Event('resize'))", true)
+      .catch(() => {});
+    this.view.setBounds(interactiveBounds);
+    this.view.setVisible(true);
+    try {
+      await resize();
+      await sleep(50);
+      return await action();
+    } finally {
+      this.view.setVisible(false);
+      this.view.setBounds(originalBounds);
+      this.syncViewVisibility();
+      await resize();
+    }
   }
 
   async runSessionInspection(detectPro = false) {
@@ -1562,10 +1592,18 @@ class BrowserHost {
     if (detectPro) {
       const control = await this.waitForEffortControl(30_000, 200);
       let menu = await this.readEffortMenu(0);
-      if (!menu.target) {
-        menu = menu.open || control.expanded === "true"
-          ? await this.waitForEffortMenu(0, 70_000, 200)
-          : await this.openEffortMenu(0, 70_000, 200, control);
+      if (!menu.target && !menu.slider) {
+        if (menu.open) {
+          menu = await this.waitForEffortMenu(0, 70_000, 200);
+        } else {
+          let activationControl = control;
+          if (control.expanded === "true") {
+            this.pressBrowserKey("Escape");
+            await sleep(200);
+            activationControl = { ...control, expanded: "false" };
+          }
+          menu = await this.openEffortMenu(0, 70_000, 200, activationControl);
+        }
       }
       proAvailable = menu.count >= 5;
       this.pressBrowserKey("Escape");

--- a/launcher/electron/browser-host.cjs
+++ b/launcher/electron/browser-host.cjs
@@ -43,6 +43,13 @@ const EFFORT_MENU_SELECTOR = [
   '[role="menu"]:has([role="menuitemradio"])',
   '[role="group"]:has([role="menuitemradio"])',
 ].join(", ");
+const EFFORT_SLIDER_ROOT_SELECTOR = [
+  '[data-testid="composer-intelligence-picker-content"]:has([data-model-reasoning-effort-slider])',
+  '[role="menu"]:has([data-model-reasoning-effort-slider])',
+  '[role="group"]:has([data-model-reasoning-effort-slider])',
+].join(", ");
+const EFFORT_SLIDER_SELECTOR = '[data-model-reasoning-effort-slider] [role="slider"]';
+const EFFORT_SLIDER_MAX_OPTIONS = 5;
 const COMPLETION_ACTION_SELECTOR = 'button[data-testid="copy-turn-action-button"]';
 const ASSISTANT_TURN_SELECTOR = [
   '[data-testid^="conversation-turn-"][data-turn="assistant"]',
@@ -1280,6 +1287,7 @@ class BrowserHost {
         const roots = [
           ...(controlled ? [controlled] : []),
           ...Array.from(document.querySelectorAll(${JSON.stringify(EFFORT_MENU_SELECTOR)})),
+          ...Array.from(document.querySelectorAll(${JSON.stringify(EFFORT_SLIDER_ROOT_SELECTOR)})),
         ];
         const candidates = [...new Set(roots)].filter(visible).map((menu) => ({
           menu,
@@ -1288,8 +1296,41 @@ class BrowserHost {
           .sort((left, right) => right.items.length - left.items.length);
         const candidate = candidates[0];
         const target = candidate?.items[targetIndex];
+        const slider = [...new Set(roots.flatMap(root => (
+          root.matches(${JSON.stringify(EFFORT_SLIDER_SELECTOR)})
+            ? [root]
+            : Array.from(root.querySelectorAll(${JSON.stringify(EFFORT_SLIDER_SELECTOR)}))
+        )))].filter(visible).at(-1);
+        const sliderControl = slider?.closest('[role="menuitem"]');
+        if (!target && slider && sliderControl && visible(sliderControl)) {
+          const parseIntegerAttribute = (raw) => {
+            if (raw === null || !/^-?\\d+$/.test(raw)) return null;
+            const parsed = Number(raw);
+            return Number.isSafeInteger(parsed) ? parsed : null;
+          };
+          const min = parseIntegerAttribute(slider.getAttribute('aria-valuemin'));
+          const max = parseIntegerAttribute(slider.getAttribute('aria-valuemax'));
+          const value = parseIntegerAttribute(slider.getAttribute('aria-valuenow'));
+          const optionCount = min === null || max === null ? 0 : max - min + 1;
+          const sliderState = min !== null
+            && max !== null
+            && value !== null
+            && Number.isSafeInteger(optionCount)
+            && optionCount >= 1
+            && optionCount <= ${EFFORT_SLIDER_MAX_OPTIONS}
+            && value >= min
+            && value <= max
+            ? { min, max, value }
+            : null;
+          return {
+            open: true,
+            count: sliderState ? optionCount : 0,
+            target: null,
+            slider: sliderState,
+          };
+        }
         if (!candidate || !target) {
-          return { open: Boolean(candidate), count: candidate?.items.length || 0, target: null };
+          return { open: Boolean(candidate), count: candidate?.items.length || 0, target: null, slider: null };
         }
         const rect = target.getBoundingClientRect();
         return {
@@ -1300,6 +1341,7 @@ class BrowserHost {
             checked: target.getAttribute('aria-checked'),
             point: { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 },
           },
+          slider: null,
         };
       })()`);
   }
@@ -1329,12 +1371,59 @@ class BrowserHost {
     await this.clickTrustedBrowserPoint(menu.target.point);
   }
 
+  async focusEffortSlider() {
+    return await this.evaluateBrowserPage(`(() => {
+      /* effort-slider-focus */
+      const visible = (element) => {
+        const style = getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return style.display !== 'none' && style.visibility !== 'hidden' && rect.width > 0 && rect.height > 0;
+      };
+      const sliders = Array.from(document.querySelectorAll(${JSON.stringify(EFFORT_SLIDER_SELECTOR)}))
+        .filter(visible);
+      const control = sliders.at(-1)?.closest('[role="menuitem"]');
+      if (!control || !visible(control)) return false;
+      control.focus({ preventScroll: true });
+      return document.activeElement === control;
+    })()`);
+  }
+
+  async chooseEffortSlider(targetIndex, knownMenu) {
+    const menu = knownMenu?.slider ? knownMenu : await this.readEffortMenu(targetIndex);
+    const slider = menu.slider;
+    const optionCount = slider ? slider.max - slider.min + 1 : 0;
+    if (!slider
+      || ![slider.min, slider.max, slider.value, optionCount].every(Number.isSafeInteger)
+      || optionCount < 1
+      || optionCount > EFFORT_SLIDER_MAX_OPTIONS
+      || slider.value < slider.min
+      || slider.value > slider.max) {
+      throw new Error("ChatGPT effort slider did not expose a safe integer range and current value");
+    }
+    const targetValue = slider.min + targetIndex;
+    if (targetIndex < 0 || targetValue > slider.max) {
+      throw new Error(
+        `ChatGPT effort slider does not expose item index ${targetIndex}`
+        + ` (min=${slider.min}; max=${slider.max})`,
+      );
+    }
+    if (slider.value === targetValue) return false;
+    if (!await this.focusEffortSlider()) {
+      throw new Error("ChatGPT effort slider could not receive focus");
+    }
+    const key = targetValue > slider.value ? "ArrowRight" : "ArrowLeft";
+    for (let value = slider.value; value !== targetValue; value += key === "ArrowRight" ? 1 : -1) {
+      await this.pressTrustedBrowserKey(key);
+    }
+    return true;
+  }
+
   async waitForEffortMenu(targetIndex, timeoutMs, pollMs) {
     const deadline = Date.now() + timeoutMs;
     let menu;
     do {
       menu = await this.readEffortMenu(targetIndex);
-      if (menu.target) return menu;
+      if (menu.target || menu.slider) return menu;
       await sleep(pollMs);
     } while (Date.now() < deadline);
     throw new Error(
@@ -1356,6 +1445,23 @@ class BrowserHost {
       menu = menu.open || control.expanded === "true"
         ? await this.waitForEffortMenu(targetIndex, optionTimeoutMs, pollMs)
         : await this.openEffortMenu(targetIndex, optionTimeoutMs, pollMs, control);
+    }
+    if (menu.slider) {
+      const changed = await this.chooseEffortSlider(targetIndex, menu);
+      const deadline = Date.now() + confirmTimeoutMs;
+      let confirmed = menu;
+      do {
+        confirmed = await this.readEffortMenu(targetIndex);
+        if (confirmed.slider && confirmed.slider.value === confirmed.slider.min + targetIndex) {
+          this.pressBrowserKey("Escape");
+          return { effort: "High", changed };
+        }
+        await sleep(pollMs);
+      } while (Date.now() < deadline);
+      throw new Error(
+        `ChatGPT did not confirm effort slider index ${targetIndex}`
+        + ` (aria-valuenow=${JSON.stringify(confirmed?.slider?.value ?? null)})`,
+      );
     }
     if (menu.target.checked !== "true" && menu.target.checked !== "false") {
       throw new Error(`ChatGPT effort item index ${targetIndex} has no semantic checked state`);

--- a/launcher/electron/cdp-input.cjs
+++ b/launcher/electron/cdp-input.cjs
@@ -12,21 +12,22 @@ async function withWebContentsDebugger(debuggerClient, action) {
 }
 
 async function dispatchTrustedKey({ debuggerClient, key }) {
-  if (key !== "Enter") {
-    throw new Error(`Unsupported CDP key: ${String(key)}`);
-  }
+  const virtualKeyCode = key === "Enter" ? 13
+    : key === "ArrowLeft" ? 37
+      : key === "ArrowRight" ? 39
+        : undefined;
+  if (virtualKeyCode === undefined) throw new Error(`Unsupported CDP key: ${String(key)}`);
   const event = {
-    key: "Enter",
-    code: "Enter",
-    windowsVirtualKeyCode: 13,
-    nativeVirtualKeyCode: 13,
+    key,
+    code: key,
+    windowsVirtualKeyCode: virtualKeyCode,
+    nativeVirtualKeyCode: virtualKeyCode,
   };
   await withWebContentsDebugger(debuggerClient, async (sendCommand) => {
     await sendCommand("Input.dispatchKeyEvent", {
       ...event,
       type: "keyDown",
-      text: "\r",
-      unmodifiedText: "\r",
+      ...(key === "Enter" ? { text: "\r", unmodifiedText: "\r" } : {}),
     });
     await sendCommand("Input.dispatchKeyEvent", {
       ...event,

--- a/launcher/tests/browser-host.test.cjs
+++ b/launcher/tests/browser-host.test.cjs
@@ -591,6 +591,68 @@ test("effort selection waits for an already-open menu to hydrate instead of clos
   ]);
 });
 
+test("effort selection supports the slider-based ChatGPT control", async () => {
+  let sliderValue = 3;
+  const trustedKeys = [];
+  const inputEvents = [];
+  const fixture = {
+    pressBrowserKey: BrowserHost.prototype.pressBrowserKey,
+    pressTrustedBrowserKey: BrowserHost.prototype.pressTrustedBrowserKey,
+    waitForEffortControl: async () => ({ found: true, expanded: "true" }),
+    readEffortMenu: async () => ({
+      open: true,
+      count: 5,
+      target: null,
+      slider: { min: 0, max: 4, value: sliderValue },
+    }),
+    waitForEffortMenu: BrowserHost.prototype.waitForEffortMenu,
+    openEffortMenu: async () => {
+      throw new Error("must not toggle an already-open slider");
+    },
+    chooseEffortSlider: BrowserHost.prototype.chooseEffortSlider,
+    focusEffortSlider: async () => true,
+    dispatchTrustedKey: async ({ key }) => {
+      trustedKeys.push(key);
+      if (key === "ArrowLeft") sliderValue -= 1;
+      if (key === "ArrowRight") sliderValue += 1;
+    },
+    view: {
+      webContents: {
+        debugger: {},
+        sendInputEvent: event => inputEvents.push(event),
+      },
+    },
+  };
+
+  const result = await BrowserHost.prototype.selectHighEffort.call(fixture, {
+    readyTimeoutMs: 100,
+    optionTimeoutMs: 100,
+    confirmTimeoutMs: 100,
+    pollMs: 1,
+  });
+
+  assert.deepEqual(result, { effort: "High", changed: true });
+  assert.deepEqual(trustedKeys, ["ArrowLeft"]);
+  assert.deepEqual(inputEvents, [
+    { type: "keyDown", keyCode: "Escape" },
+    { type: "keyUp", keyCode: "Escape" },
+  ]);
+});
+
+test("effort slider selection rejects unsafe ranges before dispatching input", async () => {
+  const invalidStates = [
+    { min: 0, max: 4, value: 9 },
+    { min: 0, max: 5, value: 3 },
+    { min: Number.NaN, max: 4, value: 3 },
+  ];
+  for (const slider of invalidStates) {
+    await assert.rejects(
+      BrowserHost.prototype.chooseEffortSlider.call({}, 2, { slider }),
+      /safe integer range and current value/,
+    );
+  }
+});
+
 test("smoke submission focuses the send button before trusted Enter and waits for an accepted user turn", async () => {
   const keys = [];
   let sendReads = 0;

--- a/launcher/tests/browser-host.test.cjs
+++ b/launcher/tests/browser-host.test.cjs
@@ -173,6 +173,119 @@ test("session inspection navigates an authenticated ordinary chat surface to Tem
   });
 });
 
+test("session inspection detects Pro capability from the slider-based effort control", async () => {
+  const inputEvents = [];
+  const openedControls = [];
+  const fixture = {
+    pressBrowserKey: BrowserHost.prototype.pressBrowserKey,
+    view: {
+      webContents: {
+        getURL: () => "https://chatgpt.com/?temporary-chat=true",
+        sendInputEvent: event => inputEvents.push(event),
+      },
+    },
+    probeAuthentication: async () => ({ authenticated: true }),
+    waitForEffortControl: async () => ({ found: true, expanded: "true" }),
+    readEffortMenu: async () => ({
+      open: false,
+      count: 0,
+      target: null,
+      slider: null,
+    }),
+    openEffortMenu: async (_targetIndex, _timeoutMs, _pollMs, control) => {
+      openedControls.push(control);
+      return {
+        open: true,
+        count: 5,
+        target: null,
+        slider: { min: 0, max: 4, value: 2 },
+      };
+    },
+  };
+
+  const inspected = await BrowserHost.prototype.runSessionInspection.call(fixture, true);
+
+  assert.deepEqual(inspected, {
+    authenticated: true,
+    temporary: true,
+    url: "https://chatgpt.com/?temporary-chat=true",
+    proAvailable: true,
+  });
+  assert.deepEqual(openedControls, [{ found: true, expanded: "false" }]);
+  assert.deepEqual(inputEvents, [
+    { type: "keyDown", keyCode: "Escape" },
+    { type: "keyUp", keyCode: "Escape" },
+    { type: "keyDown", keyCode: "Escape" },
+    { type: "keyUp", keyCode: "Escape" },
+  ]);
+});
+
+test("hidden capability inspection stages the home view with usable bounds", async () => {
+  const events = [];
+  const originalBounds = { x: 240, y: 120, width: 960, height: 640 };
+  const fixture = {
+    visible: true,
+    surfaceActive: false,
+    boundsReady: true,
+    bounds: originalBounds,
+    view: {
+      setBounds: bounds => events.push(["bounds", bounds]),
+      setVisible: visible => events.push(["visible", visible]),
+      webContents: {
+        executeJavaScript: async () => events.push(["resize"]),
+      },
+    },
+    syncViewVisibility: () => events.push(["sync"]),
+  };
+
+  const result = await BrowserHost.prototype.withInteractiveHomeView.call(fixture, async () => {
+    events.push(["inspect"]);
+    return "ok";
+  });
+
+  assert.equal(result, "ok");
+  assert.deepEqual(events, [
+    ["bounds", originalBounds],
+    ["visible", true],
+    ["resize"],
+    ["inspect"],
+    ["visible", false],
+    ["bounds", originalBounds],
+    ["sync"],
+    ["resize"],
+  ]);
+});
+
+test("hidden capability inspection derives bounds after a launcher restart", async () => {
+  const events = [];
+  const fixture = {
+    visible: false,
+    surfaceActive: false,
+    boundsReady: false,
+    bounds: { x: 0, y: 0, width: 1, height: 1 },
+    window: { getContentSize: () => [1100, 720] },
+    view: {
+      setBounds: bounds => events.push(["bounds", bounds]),
+      setVisible: visible => events.push(["visible", visible]),
+      webContents: { executeJavaScript: async () => {} },
+    },
+    syncViewVisibility: () => events.push(["sync"]),
+  };
+
+  await BrowserHost.prototype.withInteractiveHomeView.call(fixture, async () => {
+    events.push(["inspect"]);
+  });
+
+  assert.deepEqual(events, [
+    ["bounds", { x: 0, y: 0, width: 1100, height: 720 }],
+    ["visible", true],
+    ["inspect"],
+    ["visible", false],
+    ["bounds", { x: 0, y: 0, width: 1, height: 1 }],
+    ["sync"],
+  ]);
+});
+
 test("browser surface reactivation preserves its last measured bounds", () => {
   const visibility = [];
   const fixture = {

--- a/launcher/tests/cdp-input.test.cjs
+++ b/launcher/tests/cdp-input.test.cjs
@@ -85,6 +85,36 @@ test("trusted Enter is dispatched through the owned Electron WebContents target"
   assert.equal(detached(), true);
 });
 
+test("trusted effort slider arrows are dispatched through the owned Electron WebContents target", async () => {
+  for (const [key, virtualKeyCode] of [["ArrowLeft", 37], ["ArrowRight", 39]]) {
+    const { client, commands, detached } = createDebugger();
+    await dispatchTrustedKey({ debuggerClient: client, key });
+    assert.deepEqual(commands, [
+      {
+        method: "Input.dispatchKeyEvent",
+        params: {
+          type: "keyDown",
+          key,
+          code: key,
+          windowsVirtualKeyCode: virtualKeyCode,
+          nativeVirtualKeyCode: virtualKeyCode,
+        },
+      },
+      {
+        method: "Input.dispatchKeyEvent",
+        params: {
+          type: "keyUp",
+          key,
+          code: key,
+          windowsVirtualKeyCode: virtualKeyCode,
+          nativeVirtualKeyCode: virtualKeyCode,
+        },
+      },
+    ]);
+    assert.equal(detached(), true);
+  }
+});
+
 test("trusted pointer activation is dispatched at the resolved DOM point", async () => {
   const { client, commands, detached } = createDebugger();
   await dispatchTrustedClick({

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -57,10 +57,25 @@ export const CHATGPT_TOOL_CONFIRMATION_TIMEOUT_MS = 60_000;
  * editor has taken the previous one. This is headroom for that, not a readiness check.
  */
 export const CHATGPT_UI_SETTLE_MS = 250;
+export const CHATGPT_OPERATIONAL_VIEWPORT = { width: 1100, height: 720 } as const;
 
 const settleChatGptUi = (): Promise<void> => (
   new Promise(resolveSettle => setTimeout(resolveSettle, CHATGPT_UI_SETTLE_MS))
 );
+
+export async function ensureChatGptOperationalViewport(page: Page): Promise<void> {
+  const readViewport = () => page.evaluate(() => ({ width: window.innerWidth, height: window.innerHeight }));
+  let viewport = await readViewport();
+  if (viewport.width > 1 && viewport.height > 1) return;
+  await page.setViewportSize(CHATGPT_OPERATIONAL_VIEWPORT);
+  viewport = await readViewport();
+  if (viewport.width <= 1 || viewport.height <= 1) {
+    throw new Error(
+      `ChatGPT browser surface remained unusable after viewport recovery`
+      + ` (width=${viewport.width}; height=${viewport.height})`,
+    );
+  }
+}
 
 const chatGptRateLimitDialog = (page: Page): Locator => page.locator('[role="dialog"]')
   .filter({ hasText: /Too many requests/i })
@@ -1477,6 +1492,7 @@ export class ChatGptBrowserWorker {
         return connection.page;
       });
       if (!launcherSurfaceId) managedPage = page;
+      if (launcherSurfaceId) await ensureChatGptOperationalViewport(page);
       diagnosticPage = page;
       await diagnostics.capture(page, "browser-page-acquired");
       console.info(

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -18,9 +18,11 @@ import {
   CHATGPT_EFFORT_CONTROL_SELECTOR,
   CHATGPT_EFFORT_ITEM_SELECTOR,
   CHATGPT_EFFORT_MENU_SELECTOR,
+  CHATGPT_EFFORT_SLIDER_SELECTOR,
   CHATGPT_STOP_BUTTON_SELECTOR,
   CHATGPT_TEMPORARY_CHAT_URL,
   CHATGPT_USER_TURN_SELECTOR,
+  parseChatGptEffortSliderState,
 } from "../../chatgpt-session";
 import { loginVerificationMarkerPath } from "../../browser-login";
 import { connectLauncherBrowserHost, notifyLauncherTurn } from "../../launcher-browser-host";
@@ -799,13 +801,65 @@ export class ChatGptBrowserWorker {
     await captureDiagnostic?.("effort-menu-open-requested");
     const effortChoices = effortMenu.locator(CHATGPT_EFFORT_ITEM_SELECTOR);
     const effortChoice = effortChoices.nth(mode.uiEffortIndex);
+    const effortSlider = page.locator(CHATGPT_EFFORT_SLIDER_SELECTOR).filter({ visible: true }).last();
     const waitAbort = new AbortController();
     try {
       const ready = await Promise.race([
         effortChoice.waitFor({ state: "visible", timeout: 70_000, signal: waitAbort.signal }).then(() => "effort" as const),
+        effortSlider.waitFor({ state: "visible", timeout: 70_000, signal: waitAbort.signal }).then(() => "slider" as const),
         chatGptRateLimitDialog(page).waitFor({ state: "visible", timeout: 70_000, signal: waitAbort.signal }).then(() => "rate-limit" as const),
       ]);
       if (ready === "rate-limit") await throwIfChatGptRateLimitDialog(page);
+      if (ready === "slider") {
+        await captureDiagnostic?.("effort-slider-visible");
+        const sliderState = parseChatGptEffortSliderState(
+          await effortSlider.getAttribute("aria-valuemin"),
+          await effortSlider.getAttribute("aria-valuemax"),
+          await effortSlider.getAttribute("aria-valuenow"),
+        );
+        if (!sliderState) {
+          throw new Error("ChatGPT effort slider did not expose a safe integer range and current value");
+        }
+        const { min, max } = sliderState;
+        let current = sliderState.value;
+        const target = min + mode.uiEffortIndex;
+        if (mode.uiEffortIndex < 0 || target > max) {
+          throw new Error(
+            `ChatGPT effort slider does not expose item index ${mode.uiEffortIndex}`
+            + ` (min=${min}; max=${max})`,
+          );
+        }
+        if (current !== target) {
+          const sliderControl = effortSlider.locator('xpath=ancestor::*[@role="menuitem"][1]');
+          await sliderControl.waitFor({ state: "visible", timeout: 5_000 });
+          await sliderControl.focus();
+          const key = target > current ? "ArrowRight" : "ArrowLeft";
+          while (current !== target) {
+            await sliderControl.press(key);
+            current += key === "ArrowRight" ? 1 : -1;
+          }
+          const deadline = Date.now() + 40_000;
+          let confirmedState = sliderState;
+          while (Date.now() < deadline) {
+            confirmedState = parseChatGptEffortSliderState(
+              await effortSlider.getAttribute("aria-valuemin"),
+              await effortSlider.getAttribute("aria-valuemax"),
+              await effortSlider.getAttribute("aria-valuenow"),
+            ) ?? sliderState;
+            if (confirmedState.min === min && confirmedState.max === max && confirmedState.value === target) break;
+            await new Promise(resolveSleep => setTimeout(resolveSleep, 100));
+          }
+          if (confirmedState.min !== min || confirmedState.max !== max || confirmedState.value !== target) {
+            throw new Error(
+              `ChatGPT did not confirm effort slider index ${mode.uiEffortIndex}`
+              + ` (aria-valuenow=${JSON.stringify(confirmedState.value)})`,
+            );
+          }
+        }
+        await captureDiagnostic?.("effort-selected");
+        await page.keyboard.press("Escape");
+        return mode;
+      }
       await captureDiagnostic?.("effort-choice-visible");
     } catch (error) {
       if (error instanceof ChatGptWebAdapterError) throw error;

--- a/src/chatgpt-session.ts
+++ b/src/chatgpt-session.ts
@@ -13,6 +13,35 @@ export const CHATGPT_EFFORT_MENU_SELECTOR = [
   '[role="group"]:has([role="menuitemradio"])',
 ].join(", ");
 export const CHATGPT_EFFORT_ITEM_SELECTOR = '[role="menuitemradio"]';
+export const CHATGPT_EFFORT_SLIDER_SELECTOR = [
+  '[data-testid="composer-intelligence-picker-content"] [data-model-reasoning-effort-slider] [role="slider"]',
+  '[role="menu"] [data-model-reasoning-effort-slider] [role="slider"]',
+  '[role="group"] [data-model-reasoning-effort-slider] [role="slider"]',
+].join(", ");
+export const CHATGPT_EFFORT_SLIDER_MAX_OPTIONS = 5;
+export type ChatGptEffortSliderState = { min: number; max: number; value: number };
+
+export function parseChatGptEffortSliderState(
+  rawMin: string | null,
+  rawMax: string | null,
+  rawValue: string | null,
+): ChatGptEffortSliderState | null {
+  const parseIntegerAttribute = (raw: string | null): number | null => {
+    if (raw === null || !/^-?\d+$/.test(raw)) return null;
+    const parsed = Number(raw);
+    return Number.isSafeInteger(parsed) ? parsed : null;
+  };
+  const min = parseIntegerAttribute(rawMin);
+  const max = parseIntegerAttribute(rawMax);
+  const value = parseIntegerAttribute(rawValue);
+  if (min === null || max === null || value === null) return null;
+  const optionCount = max - min + 1;
+  if (!Number.isSafeInteger(optionCount) || optionCount < 1 || optionCount > CHATGPT_EFFORT_SLIDER_MAX_OPTIONS) {
+    return null;
+  }
+  if (value < min || value > max) return null;
+  return { min, max, value };
+}
 export const CHATGPT_STOP_BUTTON_SELECTOR = '[data-testid="stop-button"]';
 export const CHATGPT_COMPLETION_ACTION_SELECTOR = 'button[data-testid="copy-turn-action-button"]';
 export const CHATGPT_ASSISTANT_TURN_SELECTOR = [
@@ -62,8 +91,18 @@ export async function detectChatGptProCapability(page: Page): Promise<boolean> {
   if (!menuVisible && menuExpanded !== "true") await effortButton.click();
   try {
     const efforts = menu.locator(CHATGPT_EFFORT_ITEM_SELECTOR);
-    await efforts.first().waitFor({ state: "visible", timeout: 70_000 });
-    return await efforts.count() >= 5;
+    const slider = page.locator(CHATGPT_EFFORT_SLIDER_SELECTOR).filter({ visible: true }).last();
+    const visibleControl = await Promise.race([
+      efforts.first().waitFor({ state: "visible", timeout: 70_000 }).then(() => "menu" as const),
+      slider.waitFor({ state: "visible", timeout: 70_000 }).then(() => "slider" as const),
+    ]);
+    if (visibleControl === "menu") return await efforts.count() >= 5;
+    const sliderState = parseChatGptEffortSliderState(
+      await slider.getAttribute("aria-valuemin"),
+      await slider.getAttribute("aria-valuemax"),
+      await slider.getAttribute("aria-valuenow"),
+    );
+    return sliderState !== null && sliderState.max - sliderState.min + 1 >= 5;
   } finally {
     await page.keyboard.press("Escape").catch(() => {});
   }

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import type { Page } from "playwright-core";
-import { CHATGPT_PROMPT_INSERT_CHUNK_CHARS, ChatGptBrowserWorker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_TABS, assertChatGptWebInputWithinContextWindow, browserDiagnosticCheckpoint, chatGptSubmissionEvidence, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert } from "../src/adapters/chatgpt-web/browser-worker";
+import { CHATGPT_PROMPT_INSERT_CHUNK_CHARS, ChatGptBrowserWorker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_TABS, assertChatGptWebInputWithinContextWindow, browserDiagnosticCheckpoint, chatGptSubmissionEvidence, ensureChatGptOperationalViewport, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert } from "../src/adapters/chatgpt-web/browser-worker";
 import { defaultChromeExecutable } from "../src/config";
 import { parseChatGptEffortSliderState } from "../src/chatgpt-session";
 
@@ -103,6 +103,19 @@ test("browser stage timeout aborts late page acquisition", async () => {
 
   await expect(result).rejects.toThrow("ChatGPT browser stage timed out: browser_page");
   expect(acquisitionAborted).toBeTrue();
+});
+
+test("launcher turns expand a one-pixel hidden surface before browser interaction", async () => {
+  const sizes = [{ width: 1, height: 1 }, { width: 1100, height: 720 }];
+  const applied: Array<{ width: number; height: number }> = [];
+  const page = {
+    evaluate: async () => sizes.shift(),
+    setViewportSize: async (size: { width: number; height: number }) => applied.push(size),
+  } as unknown as Page;
+
+  await ensureChatGptOperationalViewport(page);
+
+  expect(applied).toEqual([{ width: 1100, height: 720 }]);
 });
 
 test("closing the launcher page is an immediate terminal turn error", async () => {

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import type { Page } from "playwright-core";
 import { CHATGPT_PROMPT_INSERT_CHUNK_CHARS, ChatGptBrowserWorker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_TABS, assertChatGptWebInputWithinContextWindow, browserDiagnosticCheckpoint, chatGptSubmissionEvidence, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert } from "../src/adapters/chatgpt-web/browser-worker";
 import { defaultChromeExecutable } from "../src/config";
+import { parseChatGptEffortSliderState } from "../src/chatgpt-session";
 
 test("Codex context uses the owned CDP composer transport, never the operating-system clipboard", () => {
   const workerSource = readFileSync(new URL("../src/adapters/chatgpt-web/browser-worker.ts", import.meta.url), "utf8");
@@ -478,7 +479,7 @@ test("image attachment readiness uses exact file tiles and not localized remove-
   expect(workerSource).not.toContain('aria-label^="Remove file "');
 });
 
-test("effort selection uses structural menu indices instead of localized labels", () => {
+test("effort selection supports structural menu and slider indices instead of localized labels", () => {
   const workerSource = readFileSync(new URL("../src/adapters/chatgpt-web/browser-worker.ts", import.meta.url), "utf8");
   const sessionSource = readFileSync(new URL("../src/chatgpt-session.ts", import.meta.url), "utf8");
   expect(workerSource).toContain("mode.uiEffortIndex");
@@ -488,13 +489,30 @@ test("effort selection uses structural menu indices instead of localized labels"
   expect(sessionSource).toContain('[role="menu"]:has([role="menuitemradio"])');
   expect(sessionSource).toContain('[role="group"]:has([role="menuitemradio"])');
   expect(sessionSource).toContain('[role="menuitemradio"]');
+  expect(sessionSource).toContain('[data-model-reasoning-effort-slider] [role="slider"]');
   expect(sessionSource).not.toContain(":popover-open");
   expect(sessionSource).not.toContain("data-radix-collection-item");
   expect(workerSource).toContain('getAttribute("aria-checked")');
   expect(workerSource).toContain('getAttribute("aria-expanded")');
+  expect(workerSource).toContain('getAttribute("aria-valuenow")');
+  expect(workerSource).toContain('sliderControl.press(key)');
   expect(workerSource).not.toContain("currentLabel === targetLabel");
   expect(workerSource).not.toContain("chatGptEffortLabelsMatch");
   expect(workerSource).not.toMatch(/getByRole\("button", \{\s*name: "(?:Instant|Medium|High|Extra High|Pro)"/);
+});
+
+test("effort slider ARIA state fails closed on malformed or unsafe ranges", () => {
+  expect(parseChatGptEffortSliderState("0", "4", "3")).toEqual({ min: 0, max: 4, value: 3 });
+  for (const attributes of [
+    [null, "4", "3"],
+    ["", "4", "3"],
+    ["0", "4", null],
+    ["0", "4", "9"],
+    ["0", "5", "3"],
+    ["9007199254740992", "9007199254740993", "9007199254740992"],
+  ] as const) {
+    expect(parseChatGptEffortSliderState(attributes[0], attributes[1], attributes[2])).toBeNull();
+  }
 });
 
 test("effort selection handles the known ChatGPT rate-limit dialog before trusted pointer activation", () => {


### PR DESCRIPTION
## Summary

* Support ChatGPT's current reasoning effort slider in the Electron launcher smoke test and the Playwright browser worker.
* Preserve the legacy `menuitemradio` path for accounts that still receive the previous UI.
* Fail closed when slider ARIA attributes are missing, malformed, outside the advertised range, or expose more options than the supported model routes.

## Root cause

ChatGPT replaced the reasoning effort radio menu with a slider. The existing selectors waited only for `role="menuitemradio"`, so launcher setup failed with `itemCount=0` before it could write `config.json` or install the model route.

The observed control exposes:

```text
role="slider"
aria-valuemin="0"
aria-valuemax="4"
aria-valuenow="3"
```

The slider is contained by a focusable `role="menuitem"` whose `ArrowLeft` and `ArrowRight` shortcuts update the selected effort.

## Implementation

The patch maps the existing structural effort index to `aria-valuemin + index`, focuses the owning menu item, sends trusted arrow key input, and confirms the final value from the live ARIA state. Pro capability detection uses the same bounded slider range. The old radio menu behavior is unchanged.

Related to #53 and #60.

## Validation

* `bun run verify`
  * 243 runtime tests passed
  * 168 launcher tests passed
  * TypeScript checks, dependency audit, renderer build, runtime bundle build, license generation, and relocatable runtime smoke passed
* The packaged macOS launcher completed its real browser smoke test and received `CODEX WEB GPT READY`.
* A real `chatgpt-web/high` turn completed through the patched runtime and received `CODEX WEB MODEL OK`.
