### PR TITLE
Fix browser turn latency and tunnel startup readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,11 @@ checks. Use **Settings → Cancel retained browser turn** if a stopped task leav
 and **Settings → Remove Codex integration** before deleting the launcher so the previous Codex
 route is restored.
 
+Browser turn diagnostics save bounded JSON state at each checkpoint by default. Screenshots are
+reserved for stalled or failed turns so routine diagnostics do not delay successful responses. Set
+`CODEX_CHATGPT_WEB_BROWSER_DIAGNOSTICS=1` before starting the runtime to include screenshots at
+every checkpoint while investigating browser UI drift.
+
 ## Limitations and security
 
 - This is unofficial browser automation, not an OpenAI API. ChatGPT UI changes can break selectors;

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -417,6 +417,13 @@ export function browserDiagnosticCheckpoint(value: string): string {
   return safe || "checkpoint";
 }
 
+export function browserDiagnosticIncludesScreenshot(
+  checkpoint: string,
+  captureAll = process.env.CODEX_CHATGPT_WEB_BROWSER_DIAGNOSTICS === "1",
+): boolean {
+  return captureAll || checkpoint === "response-stalled-30s" || checkpoint === "turn-failed";
+}
+
 function privateDirectory(path: string): void {
   mkdirSync(path, { recursive: true, mode: 0o700 });
   try { chmodSync(path, 0o700); } catch { /* Windows ACLs are managed by the installer. */ }
@@ -458,8 +465,11 @@ class ChatGptBrowserDiagnostics {
       }
       const sequence = String(++this.sequence).padStart(2, "0");
       const stem = `${sequence}-${browserDiagnosticCheckpoint(checkpoint)}`;
+      const includeScreenshot = browserDiagnosticIncludesScreenshot(checkpoint);
       const [screenshot, state] = await Promise.all([
-        page.screenshot({ animations: "disabled", caret: "hide", timeout: 5_000, type: "png" }),
+        includeScreenshot
+          ? page.screenshot({ animations: "disabled", caret: "hide", timeout: 5_000, type: "png" })
+          : Promise.resolve(undefined),
         page.evaluate(({ composerSelector, effortControlSelector, effortItemSelector, assistantTurnSelector }) => {
           const visible = (element: Element): boolean => {
             const candidate = element as HTMLElement;
@@ -524,7 +534,7 @@ class ChatGptBrowserDiagnostics {
         }),
       ]);
       const capturedAt = new Date().toISOString();
-      atomicWriteFile(join(this.directory, `${stem}.png`), screenshot);
+      if (screenshot) atomicWriteFile(join(this.directory, `${stem}.png`), screenshot);
       atomicWriteFile(join(this.directory, `${stem}.json`), `${JSON.stringify({
         version: 1,
         capturedAt,

--- a/src/adapters/chatgpt-web/prompt.ts
+++ b/src/adapters/chatgpt-web/prompt.ts
@@ -154,10 +154,16 @@ export function chatGptReadOnlyContextWarning(
     message.role === "toolResult"
     || (message.role === "user" && isReadableCompactionSummaryText(message.content))
   );
+  const browserOnlyGuidance = !capabilities.localToolsEnabled
+    ? " This installation is in Browser-only mode. Open MCP in the launcher and connect the Full harness to give Instant through Extra High access to local tools."
+    : "";
   if (hasLocalEvidence) {
-    return `⚠️ ${label} cannot access the local Codex computer in this turn. It receives the complete accumulated task context, including earlier tool results or their compaction summary and attachments, but it cannot read or modify local files further. ChatGPT-native capabilities such as web search remain available when the product provides them.`;
+    return `⚠️ ${label} cannot access the local Codex computer in this turn. It receives the complete accumulated task context, including earlier tool results or their compaction summary and attachments, but it cannot read or modify local files further. ChatGPT-native capabilities such as web search remain available when the product provides them.${browserOnlyGuidance}`;
   }
-  return `⚠️ ${label} cannot access the local Codex computer in this turn. The accumulated context does not contain local tool results yet: it will see instructions and attachments, but not workspace contents. ChatGPT-native capabilities such as web search remain available when the product provides them. Prepare the local context with a tool-capable ChatGPT Web model first, then switch back.`;
+  const preparationGuidance = capabilities.localToolsEnabled
+    ? " Prepare the local context with a tool-capable ChatGPT Web model first, then switch back."
+    : browserOnlyGuidance;
+  return `⚠️ ${label} cannot access the local Codex computer in this turn. The accumulated context does not contain local tool results yet: it will see instructions and attachments, but not workspace contents. ChatGPT-native capabilities such as web search remain available when the product provides them.${preparationGuidance}`;
 }
 
 export function compileChatGptWebPrompt(

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -230,10 +230,13 @@ async function configureTunnel(config: AppConfig, existing: AppConfig | undefine
 async function bootstrapTunnelProfile(config: AppConfig): Promise<void> {
   let bootstrapError: unknown;
   try {
-    // `runtimes connect` writes the native profile and returns success only after its managed
-    // runtime is running, healthy, and ready. Setup stops that validation runtime transactionally;
-    // the launcher supervisor reconnects the same alias after the new configuration is committed.
+    // `runtimes connect` writes the native profile and returns once its managed runtime is healthy.
+    // Readiness follows after the first successful control-plane poll, so setup waits for it before
+    // stopping the validation runtime transactionally. The launcher supervisor reconnects the same
+    // alias after the new configuration is committed.
     connectTunnel(config);
+    const status = await waitForTunnelReady(config);
+    if (!status.ok) throw new Error(`Tunnel runtime did not become healthy and ready: ${status.detail}`);
   } catch (error) {
     bootstrapError = error;
   }

--- a/src/tunnel.ts
+++ b/src/tunnel.ts
@@ -292,7 +292,7 @@ export function tunnelConnectLaunchError(output: string): string | undefined {
   const running = parsed.running === true;
   const healthy = parsed.healthy === true;
   const ready = parsed.ready === true;
-  if (running && healthy && ready) return undefined;
+  if (running && healthy) return undefined;
   const diagnostics = nestedRecord(parsed, "launch_diagnostics");
   const exitCode = typeof parsed.exit_code === "number" ? parsed.exit_code
     : typeof diagnostics?.exit_code === "number" ? diagnostics.exit_code
@@ -308,7 +308,7 @@ export function tunnelConnectLaunchError(output: string): string | undefined {
     ...(exitCode !== undefined ? [`exit_code=${exitCode}`] : []),
     ...(remoteError ? [`remote_error=${remoteError}`] : []),
     ...(logTail ? [`runtime_log=${logTail}`] : []),
-    ...(!remoteError && !logTail ? ["runtime did not complete a healthy ready launch"] : []),
+    ...(!remoteError && !logTail ? ["runtime did not complete a healthy launch"] : []),
   ].join("; "));
 }
 

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import type { Page } from "playwright-core";
-import { CHATGPT_PROMPT_INSERT_CHUNK_CHARS, ChatGptBrowserWorker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_TABS, assertChatGptWebInputWithinContextWindow, browserDiagnosticCheckpoint, chatGptSubmissionEvidence, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert } from "../src/adapters/chatgpt-web/browser-worker";
+import { CHATGPT_PROMPT_INSERT_CHUNK_CHARS, ChatGptBrowserWorker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_TABS, assertChatGptWebInputWithinContextWindow, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptSubmissionEvidence, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert } from "../src/adapters/chatgpt-web/browser-worker";
 import { defaultChromeExecutable } from "../src/config";
 
 test("Codex context uses the owned CDP composer transport, never the operating-system clipboard", () => {
@@ -729,6 +729,14 @@ test("browser stage diagnostics use safe bounded artifact names", () => {
   expect(browserDiagnosticCheckpoint("effort menu / before click")).toBe("effort-menu-before-click");
   expect(browserDiagnosticCheckpoint("../turn_token secret")).toBe("turn_token-secret");
   expect(browserDiagnosticCheckpoint("x".repeat(200))).toHaveLength(80);
+});
+
+test("routine browser diagnostics do not take blocking screenshots", () => {
+  expect(browserDiagnosticIncludesScreenshot("send-ready", false)).toBeFalse();
+  expect(browserDiagnosticIncludesScreenshot("response-visible", false)).toBeFalse();
+  expect(browserDiagnosticIncludesScreenshot("response-stalled-30s", false)).toBeTrue();
+  expect(browserDiagnosticIncludesScreenshot("turn-failed", false)).toBeTrue();
+  expect(browserDiagnosticIncludesScreenshot("send-ready", true)).toBeTrue();
 });
 
 test("browser stage diagnostics preserve every critical local checkpoint", () => {

--- a/tests/prompt-contract.test.ts
+++ b/tests/prompt-contract.test.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "bun:test";
-import { compileChatGptWebPrompt } from "../src/adapters/chatgpt-web/prompt";
+import { chatGptReadOnlyContextWarning, compileChatGptWebPrompt } from "../src/adapters/chatgpt-web/prompt";
 import { CHATGPT_WEB_MODEL_ID } from "../src/adapters/chatgpt-web/model";
 import type { CodexParsedRequest } from "../src/types";
 
-function request(reasoning: "low" | "high" | "max"): CodexParsedRequest {
+function request(reasoning: "low" | "medium" | "high" | "max"): CodexParsedRequest {
   return {
     modelId: CHATGPT_WEB_MODEL_ID,
     context: {
@@ -55,6 +55,18 @@ test("read-only prompts resume without exposing a bind capability", () => {
   expect(compiled.text).not.toContain("evidence inside");
   expect(compiled.text).toContain("Do not mention this transport contract, context packaging, or capability routing");
   expect(compiled.text).not.toContain("CODEX_INTERNAL_CONTEXT_COMPACT");
+});
+
+test("browser-only Medium directs users to the full harness", () => {
+  const capabilities = { localToolsEnabled: false, proAvailable: true };
+  const warning = chatGptReadOnlyContextWarning(request("medium"), capabilities);
+  expect(warning).toContain("Browser-only mode");
+  expect(warning).toContain("Full harness");
+  expect(warning).not.toContain("tool-capable ChatGPT Web model first");
+  expect(chatGptReadOnlyContextWarning(request("medium"), {
+    ...capabilities,
+    localToolsEnabled: true,
+  })).toBeUndefined();
 });
 
 test("compaction prompts are isolated summarization turns without local or native tool instructions", () => {

--- a/tests/tunnel.test.ts
+++ b/tests/tunnel.test.ts
@@ -49,7 +49,7 @@ describe("tunnel status boundary", () => {
     );
   });
 
-  test("requires connect to prove running, healthy, and ready before accepting its profile", () => {
+  test("accepts a healthy managed launch while the first control-plane poll is pending", () => {
     expect(tunnelConnectLaunchError(JSON.stringify({
       running: true,
       healthy: true,
@@ -60,7 +60,13 @@ describe("tunnel status boundary", () => {
       running: true,
       healthy: true,
       ready: false,
-    }))).toContain("running=true; healthy=true; ready=false");
+    }))).toBeUndefined();
+
+    expect(tunnelConnectLaunchError(JSON.stringify({
+      running: true,
+      healthy: false,
+      ready: false,
+    }))).toContain("running=true; healthy=false; ready=false");
 
     expect(tunnelConnectLaunchError("not json")).toBe("tunnel-client returned non-JSON connect output");
   });


### PR DESCRIPTION
## Summary

- keep routine browser diagnostics JSON-only and reserve screenshots for stalls and failures
- replace the misleading Browser-only model guidance with the Full harness path
- accept a healthy tunnel launch while the official client finishes readiness polling

## Verification

- `bun test`: 410 passed
- `bun run typecheck`
- isolated Browser-only Codex Web turn completed in about 8.5 seconds
- autoreview: clean, no actionable findings