### PR TITLE
fix(launcher): self-heal missing or broken Electron binary on dev startup

### DIFF
--- a/launcher/scripts/dev.cjs
+++ b/launcher/scripts/dev.cjs
@@ -1,11 +1,43 @@
 const { spawn, spawnSync } = require("node:child_process");
+const fs = require("node:fs");
 const path = require("node:path");
 
 const root = path.resolve(__dirname, "..");
+const bun = process.env.CODEX_WEB_GPT_BUN || process.execPath;
+
+// Self-heal missing/incomplete Electron installs by re-running install.js under Bun.
+const electronPkg = require.resolve("electron/package.json", { paths: [root] });
+const electronDir = path.dirname(electronPkg);
+
+function getElectronBin() {
+  try {
+    const electronPath = require.resolve("electron", { paths: [root] });
+    delete require.cache[electronPath];
+    const bin = require(electronPath);
+    return typeof bin === "string" && fs.existsSync(bin) ? bin : null;
+  } catch {
+    return null;
+  }
+}
+
+let electronBin = getElectronBin();
+if (!electronBin) {
+  const install = spawnSync(bun, ["install.js"], {
+    cwd: electronDir,
+    stdio: "inherit",
+    env: process.env,
+  });
+  electronBin = getElectronBin();
+  if (!electronBin) {
+    console.error(
+      "Electron is not installed correctly. Run `bun install.js` inside launcher/node_modules/electron (or delete it and run `bun install`) and try again."
+    );
+    process.exit(install.status ?? 1);
+  }
+}
+
 const vitePackage = require.resolve("vite/package.json", { paths: [root] });
 const viteBin = path.join(path.dirname(vitePackage), "bin", "vite.js");
-const electronBin = require("electron");
-const bun = process.env.CODEX_WEB_GPT_BUN || process.execPath;
 
 const helperBuild = spawnSync(bun, ["run", "scripts/build-browser-helper.ts"], {
   cwd: path.resolve(root, ".."),
@@ -37,7 +69,7 @@ const waitForVite = async () => {
     try {
       const response = await fetch("http://127.0.0.1:4178");
       if (response.ok) return;
-    } catch {}
+    } catch { }
     await new Promise((resolve) => setTimeout(resolve, 150));
   }
   throw new Error("Vite did not become ready on 127.0.0.1:4178");


### PR DESCRIPTION
Electron's `postinstall` step can occasionally leave the package in a partially installed state on some Node/Bun environments. Although `install.js` exits successfully, the extracted payload may be incomplete, leaving `path.txt` or the platform binary missing. As a result, `bun run app` and `bun run launcher:dev` fail immediately when `electron` is imported.

This issue appears related to Electron issue #51619, which reports install failures under Node.js 26.1.0+ and 24.16.0+. [Electron Issue](https://github.com/electron/electron/issues/51619)

This PR makes the launcher resilient to that failure mode by validating the Electron installation before startup. If the installation is incomplete, it automatically re-runs Electron's installer under Bun, verifies the result, and only proceeds once a valid binary is available.

---

## Problem

Running `bun run app` failed with:

```text
❯ bun run app
$ bun run scripts/start-launcher.ts
bun install v1.3.14-canary.1 (0d9b296a)

+ @types/bun@1.3.14
+ @types/turndown@5.0.5
+ typescript@5.9.3
+ @modelcontextprotocol/sdk@1.30.0
+ chromium-bidi@12.1.0
+ fflate@0.8.3
+ playwright-core@1.62.0
+ tiktoken@1.0.22
+ turndown@7.2.0
+ turndown-plugin-gfm@1.0.2
+ zod@4.4.3

108 packages installed [90.00ms]
bun install v1.3.14-canary.1 (0d9b296a)

+ electron@41.7.1

3 packages installed [259.00ms]
$ bun run scripts/dev.cjs
12 |     return path.join(process.env.ELECTRON_OVERRIDE_DIST_PATH, executablePath || 'electron');
13 |   }
14 |   if (executablePath) {
15 |     return path.join(__dirname, 'dist', executablePath);
16 |   } else {
17 |     throw new Error(
                   ^
error: Electron failed to install correctly, please delete node_modules/electron and try installing again
      at getElectronPath (/home/lucky/stuff/codex-chatgpt-web/launcher/node_modules/electron/index.js:17:15)
      at <anonymous> (/home/lucky/stuff/codex-chatgpt-web/launcher/node_modules/electron/index.js:23:18)
      at <anonymous> (/home/lucky/stuff/codex-chatgpt-web/launcher/scripts/dev.cjs:7:7)

Bun v1.3.14-canary.1+0d9b296af (Linux x64)
error: script "dev" exited with code 1
error: script "app" exited with code 1
```

The failure occurs before the Vite dev server starts because `require("electron")` throws while resolving the Electron executable.

---

## Root Cause

Electron's `postinstall` script executes `node install.js`, which downloads and extracts the platform archive. Under some Node/Bun combinations, `extract-zip` can terminate after only partially extracting the archive while still returning a successful exit status. The result is an incomplete installation, typically missing `path.txt` or the platform executable.

Previously, `launcher/scripts/dev.cjs` imported `electron` immediately during startup. Since Electron resolves its executable synchronously from the installation metadata, any incomplete installation caused the launcher to fail before it had an opportunity to recover.

---

## Changes

* Introduce `getElectronBin()` to safely resolve the Electron executable.
* Verify both the installation metadata and the resolved executable exist before startup.
* Clear `require.cache` before each validation so the current on-disk state is always used.
* If validation fails, re-run Electron's `install.js` using Bun from the Electron package directory.
* Validate the installation again after repair and report a clear error if it is still invalid.
* Resolve the Electron package location using `require.resolve("electron/package.json", { paths: [root] })` instead of relying on fixed relative paths, making the implementation workspace-safe.

---

## Verification

* `bun run launcher:typecheck`
* `bun run launcher:test` (166 test suites passing)
