### PR TITLE
fix(launcher): make Windows system-browser login compatible with Chrome 151

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,7 @@
       "devDependencies": {
         "@types/bun": "1.3.14",
         "@types/turndown": "5.0.5",
+        "tsx": "^4.23.11",
         "typescript": "5.9.3",
       },
     },
@@ -28,6 +29,58 @@
     "zod-to-json-schema": "3.25.1",
   },
   "packages": {
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.2", "", { "os": "android", "cpu": "arm" }, "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.2", "", { "os": "android", "cpu": "arm64" }, "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.2", "", { "os": "android", "cpu": "x64" }, "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.2", "", { "os": "linux", "cpu": "arm" }, "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.2", "", { "os": "linux", "cpu": "ia32" }, "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.2", "", { "os": "linux", "cpu": "none" }, "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.2", "", { "os": "linux", "cpu": "none" }, "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.2", "", { "os": "linux", "cpu": "none" }, "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.2", "", { "os": "linux", "cpu": "x64" }, "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.2", "", { "os": "none", "cpu": "arm64" }, "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.2", "", { "os": "none", "cpu": "x64" }, "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.2", "", { "os": "none", "cpu": "arm64" }, "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.2", "", { "os": "win32", "cpu": "x64" }, "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g=="],
+
     "@hono/node-server": ["@hono/node-server@2.0.12", "", { "peerDependencies": { "hono": "^4" } }, "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg=="],
 
     "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
@@ -88,6 +141,8 @@
 
     "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
 
+    "esbuild": ["esbuild@0.28.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.2", "@esbuild/android-arm": "0.28.2", "@esbuild/android-arm64": "0.28.2", "@esbuild/android-x64": "0.28.2", "@esbuild/darwin-arm64": "0.28.2", "@esbuild/darwin-x64": "0.28.2", "@esbuild/freebsd-arm64": "0.28.2", "@esbuild/freebsd-x64": "0.28.2", "@esbuild/linux-arm": "0.28.2", "@esbuild/linux-arm64": "0.28.2", "@esbuild/linux-ia32": "0.28.2", "@esbuild/linux-loong64": "0.28.2", "@esbuild/linux-mips64el": "0.28.2", "@esbuild/linux-ppc64": "0.28.2", "@esbuild/linux-riscv64": "0.28.2", "@esbuild/linux-s390x": "0.28.2", "@esbuild/linux-x64": "0.28.2", "@esbuild/netbsd-arm64": "0.28.2", "@esbuild/netbsd-x64": "0.28.2", "@esbuild/openbsd-arm64": "0.28.2", "@esbuild/openbsd-x64": "0.28.2", "@esbuild/openharmony-arm64": "0.28.2", "@esbuild/sunos-x64": "0.28.2", "@esbuild/win32-arm64": "0.28.2", "@esbuild/win32-ia32": "0.28.2", "@esbuild/win32-x64": "0.28.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA=="],
+
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
@@ -111,6 +166,8 @@
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -217,6 +274,8 @@
     "tiktoken": ["tiktoken@1.0.22", "", {}, "sha512-PKvy1rVF1RibfF3JlXBSP0Jrcw2uq3yXdgcEXtKTYn3QJ/cBRBHDnrJ5jHky+MENZ6DIPwNUGWpkVx+7joCpNA=="],
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "tsx": ["tsx@4.23.11", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-Ry2oTEUnhBdeEdWIztY8kf3/nBGnPnjMLVGL0YfdRXMORuPER5NlKmayqxtxRxwB1xBN+RivRaJfe7PM1rtiyw=="],
 
     "turndown": ["turndown@7.2.0", "", { "dependencies": { "@mixmark-io/domino": "^2.2.0" } }, "sha512-eCZGBN4nNNqM9Owkv9HAtWRYfLA4h909E/WGAWWBpmB275ehNhZyk87/Tpvjbp0jjNl9XwCsbe6bm6CqFsgD+A=="],
 

--- a/launcher/electron/browser-host.cjs
+++ b/launcher/electron/browser-host.cjs
@@ -189,9 +189,9 @@ function validateChatGptStorageState(value) {
     }
     const domain = boundedLoginStateString(raw.domain, "cookie domain", { allowEmpty: false });
     if (!isAllowedLoginCookieDomain(domain)) continue;
-    if (raw.partitionKey !== undefined) {
-      throw new Error("System-browser login state contains an unsupported partitioned ChatGPT/OpenAI cookie");
-    }
+    // Electron's public cookies API cannot preserve a CHIPS partition key. Do not
+    // widen the cookie's scope by importing it as an unpartitioned cookie.
+    if (raw.partitionKey !== undefined) continue;
     const name = boundedLoginStateString(raw.name, "cookie name", { allowEmpty: false });
     const cookieValue = boundedLoginStateString(raw.value, "cookie value");
     const cookiePath = boundedLoginStateString(raw.path, "cookie path", { allowEmpty: false });

--- a/launcher/electron/runtime-command.cjs
+++ b/launcher/electron/runtime-command.cjs
@@ -23,6 +23,29 @@ function sourceRuntimeInvocation(sourceRoot, args) {
   };
 }
 
+function nodeBrowserLoginInvocation({ app, sourceRoot, installedRuntimeRoot, args }) {
+  if (!Array.isArray(args)) throw new Error("Runtime arguments must be an array");
+  if (!app.isPackaged) {
+    return {
+      executable: "node",
+      args: ["--import", "tsx", path.join(sourceRoot, "src", "cli.ts"), ...args],
+      cwd: sourceRoot,
+      env: { ELECTRON_RUN_AS_NODE: "1" },
+    };
+  }
+  if (!installedRuntimeRoot || !path.isAbsolute(installedRuntimeRoot)) {
+    throw new Error("Packaged launcher runtime has not been installed into durable local storage");
+  }
+  const entrypoint = path.join(installedRuntimeRoot, "app", "cli-node.cjs");
+  if (!fs.existsSync(entrypoint)) throw new Error(`Bundled Node login entrypoint is missing: ${entrypoint}`);
+  return {
+    executable: process.execPath,
+    args: [entrypoint, ...args],
+    cwd: installedRuntimeRoot,
+    env: { ELECTRON_RUN_AS_NODE: "1" },
+  };
+}
+
 function runtimeInvocation({ app, sourceRoot, installedRuntimeRoot, args }) {
   if (!Array.isArray(args)) throw new Error("Runtime arguments must be an array");
   if (!app.isPackaged) return sourceRuntimeInvocation(sourceRoot, args);
@@ -55,6 +78,7 @@ function embeddedRuntimeInvocation({ app, sourceRoot, args }) {
 
 module.exports = {
   embeddedRuntimeInvocation,
+  nodeBrowserLoginInvocation,
   packagedRuntimePaths,
   runtimeBundlePaths,
   runtimeInvocation,

--- a/launcher/electron/runtime-install.cjs
+++ b/launcher/electron/runtime-install.cjs
@@ -18,7 +18,12 @@ function validateRuntimeBundle(runtimeRoot, { version, platform, arch, bundleId 
     );
   }
   const paths = runtimeBundlePaths(runtimeRoot, platform);
-  for (const required of [paths.executable, paths.entrypoint, path.join(runtimeRoot, "app", "browser-helper.cjs")]) {
+  for (const required of [
+    paths.executable,
+    paths.entrypoint,
+    path.join(runtimeRoot, "app", "cli-node.cjs"),
+    path.join(runtimeRoot, "app", "browser-helper.cjs"),
+  ]) {
     if (!fs.existsSync(required) || !fs.statSync(required).isFile()) {
       throw new Error(`Runtime bundle file is missing: ${required}`);
     }

--- a/launcher/electron/runtime.cjs
+++ b/launcher/electron/runtime.cjs
@@ -11,7 +11,7 @@ const {
   requireCurrentRuntimeConnectorName,
   validateConnectorName,
 } = require("./connector-identity.cjs");
-const { embeddedRuntimeInvocation, runtimeInvocation } = require("./runtime-command.cjs");
+const { embeddedRuntimeInvocation, nodeBrowserLoginInvocation, runtimeInvocation } = require("./runtime-command.cjs");
 const { redactText } = require("./logging.cjs");
 const { DETACH_OWNED_CHILD, terminateOwnedProcessTree } = require("./process-tree.cjs");
 
@@ -341,6 +341,7 @@ class RuntimeHost {
         ],
         {
           env: this.launcherControlEnvironment(),
+          nodeBrowserLogin: this.platform === "win32",
           message: "Sign in to ChatGPT in the system Chrome/Chromium window, then close that window",
           successMessage: "System-browser ChatGPT login verified",
         },
@@ -536,7 +537,14 @@ class RuntimeHost {
     this.publishOperation?.({ name, status: "running", message: options.message || name });
     this.logger.info("runtime.operation_started", { name, args: args.map((arg) => /key|token/i.test(arg) ? "[redacted]" : arg) });
     try {
-      const invocation = options.embedded
+      const invocation = options.nodeBrowserLogin
+        ? nodeBrowserLoginInvocation({
+          app: this.app,
+          sourceRoot: this.sourceRoot,
+          installedRuntimeRoot: this.installedRuntimeRoot,
+          args,
+        })
+        : options.embedded
         ? embeddedRuntimeInvocation({ app: this.app, sourceRoot: this.sourceRoot, args })
         : this.command(args);
       const result = await new Promise((resolve, reject) => {
@@ -545,6 +553,7 @@ class RuntimeHost {
           detached: DETACH_OWNED_CHILD,
           env: {
             ...process.env,
+            ...(invocation.env || {}),
             CODEX_CHATGPT_WEB_BROWSER_HOST_DESCRIPTOR: this.browserDescriptorPath,
             ...(options.env || {}),
           },

--- a/launcher/tests/browser-host.test.cjs
+++ b/launcher/tests/browser-host.test.cjs
@@ -463,6 +463,38 @@ test("system-browser storage transfer imports only allowlisted ChatGPT/OpenAI st
   assert.deepEqual(validated.localStorage, [{ name: "theme", value: "dark" }]);
 });
 
+test("system-browser storage transfer excludes partitioned cookies without widening their scope", () => {
+  const validated = validateChatGptStorageState({
+    cookies: [
+      {
+        name: "session",
+        value: "secret-session",
+        domain: ".chatgpt.com",
+        path: "/",
+        expires: -1,
+        httpOnly: true,
+        secure: true,
+        sameSite: "Lax",
+      },
+      {
+        name: "partitioned",
+        value: "must-not-be-unpartitioned",
+        domain: ".chatgpt.com",
+        path: "/",
+        expires: -1,
+        httpOnly: true,
+        secure: true,
+        sameSite: "None",
+        partitionKey: "https://chatgpt.com",
+      },
+    ],
+    origins: [],
+  });
+
+  assert.equal(validated.cookies.length, 1);
+  assert.equal(validated.cookies[0].name, "session");
+});
+
 test("system-browser login proves the Electron composer and cleans transfer state", async () => {
   const calls = [];
   const browserSession = {

--- a/launcher/tests/runtime-install.test.cjs
+++ b/launcher/tests/runtime-install.test.cjs
@@ -3,7 +3,7 @@ const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
-const { runtimeInvocation } = require("../electron/runtime-command.cjs");
+const { nodeBrowserLoginInvocation, runtimeInvocation } = require("../electron/runtime-command.cjs");
 const { ensurePackagedRuntime } = require("../electron/runtime-install.cjs");
 
 function runtimeFixture(root, version = "0.2.0", bundleId = "a".repeat(64)) {
@@ -14,6 +14,7 @@ function runtimeFixture(root, version = "0.2.0", bundleId = "a".repeat(64)) {
   fs.writeFileSync(executable, "bun");
   if (process.platform !== "win32") fs.chmodSync(executable, 0o755);
   fs.writeFileSync(path.join(source, "app", "cli.js"), "cli");
+  fs.writeFileSync(path.join(source, "app", "cli-node.cjs"), "node cli");
   fs.writeFileSync(path.join(source, "app", "browser-helper.cjs"), "helper");
   fs.writeFileSync(path.join(source, "manifest.json"), `${JSON.stringify({
     schemaVersion: 1,
@@ -45,6 +46,27 @@ test("packaged runtime is installed once into a durable versioned directory", ()
     assert.equal(invocation.cwd, installed);
     assert.equal(invocation.args[0], path.join(installed, "app", "cli.js"));
     assert.equal(invocation.args[1], "serve");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("Windows browser login uses Node while the packaged runtime stays on Bun", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-web-gpt-node-login-"));
+  const resourcesPath = runtimeFixture(root);
+  const coreHome = path.join(root, "core-home");
+  const app = { isPackaged: true, getVersion: () => "0.2.0" };
+  try {
+    const installed = ensurePackagedRuntime({ app, coreHome, resourcesPath });
+    const invocation = nodeBrowserLoginInvocation({
+      app,
+      sourceRoot: root,
+      installedRuntimeRoot: installed,
+      args: ["login", "--launcher-control"],
+    });
+    assert.equal(invocation.executable, process.execPath);
+    assert.equal(invocation.args[0], path.join(installed, "app", "cli-node.cjs"));
+    assert.equal(invocation.env.ELECTRON_RUN_AS_NODE, "1");
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   "devDependencies": {
     "@types/bun": "1.3.14",
     "@types/turndown": "5.0.5",
+    "tsx": "^4.23.11",
     "typescript": "5.9.3"
   },
   "engines": {

--- a/scripts/build-runtime-bundle.ts
+++ b/scripts/build-runtime-bundle.ts
@@ -54,6 +54,20 @@ if (!build.success) {
   throw new Error(`Runtime bundle failed: ${build.logs.map(log => log.message).join("; ")}`);
 }
 
+const nodeCliBuild = await Bun.build({
+  entrypoints: [join(root, "src", "cli.ts")],
+  target: "node",
+  format: "cjs",
+  minify: true,
+  external: ["playwright-core"],
+  packages: "external",
+  outdir: appDir,
+  naming: "cli-node.cjs",
+});
+if (!nodeCliBuild.success) {
+  throw new Error(`Node login bundle failed: ${nodeCliBuild.logs.map(log => log.message).join("; ")}`);
+}
+
 const browserHelperBuild = await Bun.build({
   entrypoints: [join(root, "src", "adapters", "chatgpt-web", "browser-helper-main.ts")],
   target: "node",
@@ -114,7 +128,7 @@ if (process.platform !== "win32") chmodSync(join(binDir, launcherName), 0o755);
 
 const playwrightPackage = join(appDir, "node_modules", "playwright-core", "package.json");
 const bundleId = createHash("sha256");
-for (const relativePath of ["app/cli.js", "app/browser-helper.cjs", "app/package.json", "app/bun.lock"]) {
+for (const relativePath of ["app/cli.js", "app/cli-node.cjs", "app/browser-helper.cjs", "app/package.json", "app/bun.lock"]) {
   bundleId.update(relativePath);
   bundleId.update("\0");
   bundleId.update(readFileSync(join(output, relativePath)));

--- a/src/browser-login.ts
+++ b/src/browser-login.ts
@@ -7,6 +7,7 @@ import { atomicWriteFile } from "./config";
 import {
   assertAuthenticatedChatGptPage,
   assertTemporaryChatPage,
+  CHATGPT_COMPOSER_SELECTOR,
   CHATGPT_TEMPORARY_CHAT_URL,
   detectChatGptAccountCapabilities,
 } from "./chatgpt-session";
@@ -59,7 +60,7 @@ async function inspectStoredState(
     try {
       const verifierPage = await verifierContext.newPage();
       await verifierPage.goto(CHATGPT_TEMPORARY_CHAT_URL, { waitUntil: "domcontentloaded", timeout: 60_000 });
-      await verifierPage.getByRole("textbox", { name: "Chat with ChatGPT" }).waitFor({ state: "visible", timeout: 60_000 });
+      await verifierPage.locator(CHATGPT_COMPOSER_SELECTOR).first().waitFor({ state: "visible", timeout: 60_000 });
       await assertAuthenticatedChatGptPage(verifierPage);
       await assertTemporaryChatPage(verifierPage);
       return { ...await detectChatGptAccountCapabilities(verifierPage), url: verifierPage.url() };
@@ -134,9 +135,7 @@ export async function loginToChatGpt(
       waitUntil: "domcontentloaded",
       timeout: 60_000,
     });
-    const composer = page.getByRole("textbox", { name: "Chat with ChatGPT" }).or(
-      page.locator('[data-testid="prompt-textarea"], [contenteditable="true"][data-lexical-editor="true"]'),
-    ).first();
+    const composer = page.locator(CHATGPT_COMPOSER_SELECTOR).first();
     try {
       await composer.waitFor({ state: "visible", timeout: options.timeoutMs ?? 60_000 });
     } catch {


### PR DESCRIPTION
## Summary

- run only the Windows system-browser login flow with Node instead of Bun
- include and validate a Node-compatible CLI bundle in packaged launchers
- reuse the locale-independent ChatGPT composer selector during login verification
- exclude partitioned cookies rather than importing them without their partition key

## Safety

Electron's public cookie API cannot preserve a CHIPS partition key. The launcher never converts a partitioned cookie into an unpartitioned cookie. The imported session must still pass the existing authenticated-composer verification.

## Validation

- `bun run verify`
- generated runtime bundle contains and runs `app/cli-node.cjs`
- Electron Node-mode launch verified on Windows
- manually verified the Launcher login flow on Windows 11 with Chrome 151