### PR TITLE
fix(launcher): repair Electron runtime before startup

### DIFF
--- a/launcher/package.json
+++ b/launcher/package.json
@@ -8,6 +8,7 @@
   "main": "electron/main.cjs",
   "scripts": {
     "dev": "bun run scripts/dev.cjs",
+    "ensure-electron": "bun run scripts/ensure-electron.cjs",
     "typecheck": "tsc --noEmit",
     "build:renderer": "vite build",
     "build": "bun run typecheck && bun run build:renderer",
@@ -18,7 +19,7 @@
     "package:linux": "bun run build && bun run build:runtime && bun run scripts/package.cjs --linux",
     "smoke:package": "bun run scripts/smoke-package.cjs",
     "test": "node --test tests/*.test.cjs",
-    "start": "electron ."
+    "start": "bun run ensure-electron && electron ."
   },
   "dependencies": {
     "motion": "^12.42.2",
@@ -35,6 +36,9 @@
     "typescript": "^5.9.3",
     "vite": "^6.0.0"
   },
+  "trustedDependencies": [
+    "electron"
+  ],
   "build": {
     "appId": "dev.codexwebgpt.launcher",
     "productName": "Codex Web GPT",

--- a/launcher/scripts/dev.cjs
+++ b/launcher/scripts/dev.cjs
@@ -1,9 +1,11 @@
 const { spawn, spawnSync } = require("node:child_process");
 const path = require("node:path");
+const { ensureElectron } = require("./ensure-electron.cjs");
 
 const root = path.resolve(__dirname, "..");
 const vitePackage = require.resolve("vite/package.json", { paths: [root] });
 const viteBin = path.join(path.dirname(vitePackage), "bin", "vite.js");
+ensureElectron();
 const electronBin = require("electron");
 const bun = process.env.CODEX_WEB_GPT_BUN || process.execPath;
 

--- a/launcher/scripts/ensure-electron.cjs
+++ b/launcher/scripts/ensure-electron.cjs
@@ -1,0 +1,104 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const launcherRoot = path.resolve(__dirname, "..");
+
+function platformExecutablePath(platform) {
+  switch (platform) {
+    case "darwin":
+    case "mas":
+      return "Electron.app/Contents/MacOS/Electron";
+    case "win32":
+      return "electron.exe";
+    case "freebsd":
+    case "linux":
+    case "openbsd":
+      return "electron";
+    default:
+      throw new Error(`Electron builds are not available on platform: ${platform}`);
+  }
+}
+
+function electronPackage() {
+  const manifestPath = require.resolve("electron/package.json", { paths: [launcherRoot] });
+  const packageRoot = path.dirname(manifestPath);
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  return { manifest, packageRoot };
+}
+
+function installationStatus({ manifest, packageRoot }) {
+  const platform = process.env.npm_config_platform || process.platform;
+  const expectedPath = platformExecutablePath(platform);
+  const pathFile = path.join(packageRoot, "path.txt");
+  const versionFile = path.join(packageRoot, "dist", "version");
+
+  let installedPath;
+  let installedVersion;
+  try {
+    installedPath = fs.readFileSync(pathFile, "utf8").trim();
+    installedVersion = fs.readFileSync(versionFile, "utf8").trim().replace(/^v/, "");
+  } catch {
+    return { ok: false, reason: "Electron's install markers are missing" };
+  }
+
+  if (installedVersion !== manifest.version) {
+    return {
+      ok: false,
+      reason: `Electron runtime version is ${installedVersion || "missing"}; expected ${manifest.version}`,
+    };
+  }
+  if (installedPath !== expectedPath) {
+    return {
+      ok: false,
+      reason: `Electron runtime path is ${installedPath || "missing"}; expected ${expectedPath}`,
+    };
+  }
+
+  const distRoot = process.env.ELECTRON_OVERRIDE_DIST_PATH || path.join(packageRoot, "dist");
+  const executable = path.join(distRoot, installedPath);
+  if (!fs.existsSync(executable)) {
+    return { ok: false, reason: `Electron executable is missing: ${executable}` };
+  }
+
+  return { ok: true, executable };
+}
+
+function ensureElectron() {
+  const electron = electronPackage();
+  const current = installationStatus(electron);
+  if (current.ok) return current.executable;
+
+  if (process.env.ELECTRON_OVERRIDE_DIST_PATH) {
+    throw new Error(
+      `${current.reason}. ELECTRON_OVERRIDE_DIST_PATH is set, so the launcher cannot repair the custom Electron runtime.`,
+    );
+  }
+  if (!fs.existsSync(path.join(electron.packageRoot, "install.js"))) {
+    throw new Error(`${current.reason}. Electron's install script is missing from ${electron.packageRoot}.`);
+  }
+
+  process.stderr.write(`Electron runtime is incomplete (${current.reason}); downloading it now...\n`);
+  const env = { ...process.env, force_no_cache: "true" };
+  delete env.ELECTRON_SKIP_BINARY_DOWNLOAD;
+  const result = spawnSync(process.execPath, [path.join(electron.packageRoot, "install.js")], {
+    cwd: electron.packageRoot,
+    env,
+    stdio: "inherit",
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`Electron's runtime download failed with exit code ${result.status ?? 1}`);
+  }
+
+  const repaired = installationStatus(electron);
+  if (!repaired.ok) {
+    throw new Error(`Electron's runtime is still incomplete after repair: ${repaired.reason}`);
+  }
+  process.stderr.write(`Electron runtime ready: ${repaired.executable}\n`);
+  return repaired.executable;
+}
+
+module.exports = { ensureElectron, installationStatus, platformExecutablePath };
+
+if (require.main === module) ensureElectron();

--- a/launcher/scripts/package.cjs
+++ b/launcher/scripts/package.cjs
@@ -2,6 +2,9 @@ const { spawnSync } = require("node:child_process");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
+const { ensureElectron } = require("./ensure-electron.cjs");
+
+ensureElectron();
 
 const root = path.resolve(__dirname, "..");
 const executable = process.execPath;

--- a/launcher/tests/ensure-electron.test.cjs
+++ b/launcher/tests/ensure-electron.test.cjs
@@ -1,0 +1,55 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const {
+  installationStatus,
+  platformExecutablePath,
+} = require("../scripts/ensure-electron.cjs");
+
+function temporaryPackageRoot() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "codex-web-gpt-electron-test-"));
+}
+
+function writeMarker(root, relativePath, value) {
+  const destination = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.writeFileSync(destination, value);
+}
+
+test("Electron installation status rejects missing install markers", () => {
+  const packageRoot = temporaryPackageRoot();
+  const result = installationStatus({ manifest: { version: "41.7.1" }, packageRoot });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "Electron's install markers are missing");
+});
+
+test("Electron installation status accepts a complete platform runtime", () => {
+  const packageRoot = temporaryPackageRoot();
+  const installedPath = platformExecutablePath("darwin");
+  writeMarker(packageRoot, "path.txt", `${installedPath}\n`);
+  writeMarker(packageRoot, "dist/version", "v41.7.1\n");
+  writeMarker(packageRoot, path.join("dist", installedPath), "runtime\n");
+
+  assert.deepEqual(
+    installationStatus({ manifest: { version: "41.7.1" }, packageRoot }),
+    {
+      ok: true,
+      executable: path.join(packageRoot, "dist", installedPath),
+    },
+  );
+});
+
+test("Electron installation status identifies a missing executable after valid markers", () => {
+  const packageRoot = temporaryPackageRoot();
+  const installedPath = platformExecutablePath("darwin");
+  writeMarker(packageRoot, "path.txt", `${installedPath}\n`);
+  writeMarker(packageRoot, "dist/version", "v41.7.1\n");
+
+  const result = installationStatus({ manifest: { version: "41.7.1" }, packageRoot });
+
+  assert.equal(result.ok, false);
+  assert.match(result.reason, /Electron executable is missing/);
+});

--- a/launcher/tests/packaging-contract.test.cjs
+++ b/launcher/tests/packaging-contract.test.cjs
@@ -11,6 +11,13 @@ const repositoryManifest = JSON.parse(fs.readFileSync(path.join(repositoryRoot, 
 test("the public launcher command uses the Electron bootstrap", () => {
   assert.equal(repositoryManifest.scripts.launcher, "bun run scripts/start-launcher.ts");
   assert.equal(repositoryManifest.scripts.launcher, repositoryManifest.scripts.app);
+  assert.equal(manifest.scripts["ensure-electron"], "bun run scripts/ensure-electron.cjs");
+  assert.deepEqual(manifest.trustedDependencies, ["electron"]);
+
+  const setup = fs.readFileSync(path.join(repositoryRoot, "scripts", "setup-launcher.ts"), "utf8");
+  const dev = fs.readFileSync(path.join(launcherRoot, "scripts", "dev.cjs"), "utf8");
+  assert.match(setup, /run\(\["run", "ensure-electron"\], launcher\)/);
+  assert.match(dev, /ensureElectron\(\)/);
 });
 
 test("launcher publishes native packages for all supported desktop operating systems", () => {

--- a/scripts/setup-launcher.ts
+++ b/scripts/setup-launcher.ts
@@ -20,5 +20,6 @@ function run(args: string[], cwd: string): void {
   if (result.exitCode !== 0) process.exit(result.exitCode);
 }
 
-run(["run", "scripts/setup-launcher.ts"], root);
-run(["run", "dev"], launcher);
+run(["install", "--frozen-lockfile"], root);
+run(["install", "--frozen-lockfile"], launcher);
+run(["run", "ensure-electron"], launcher);


### PR DESCRIPTION
## Summary

Electron can report as installed while its platform runtime is incomplete, causing the launcher to fail during startup with:

> Electron failed to install correctly

This PR adds a validated Electron bootstrap and repair flow.

## Changes

- Add `ensure-electron.cjs` to validate:
  - Electron install markers
  - Installed Electron version
  - Platform-specific executable path
  - Actual runtime executable presence
- Automatically rerun Electron’s installer when the runtime is incomplete.
- Run Electron validation before development, standalone start, and packaging.
- Add a reusable launcher setup script that:
  - Installs root dependencies with the frozen lockfile
  - Installs launcher dependencies with the frozen lockfile
  - Repairs/verifies Electron before startup
- Mark Electron as a trusted dependency for Bun installation.
- Add regression tests for missing markers, valid installations, missing executables, and packaging contracts.
- Preserve explicit failure behavior for custom `ELECTRON_OVERRIDE_DIST_PATH` installations.

## Scope

This PR is limited to Electron installation and launcher bootstrap reliability. Default-browser resolution and ChatGPT session-transfer fixes are included in the subsequent PRs.

## Validation

- `bun install --frozen-lockfile`
- `cd launcher && bun install --frozen-lockfile`
- `bun run typecheck`
- `bun run launcher:typecheck`
- `bun run launcher:test`
- `bun test tests/*.test.ts`
- `git diff --check`