### PR TITLE
fix(browser): harden long prompt attachment at chunk boundaries

### DIFF
--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -252,8 +252,9 @@ export const CHATGPT_PROMPT_INSERT_CHUNK_CHARS = 16_000;
 const CHATGPT_PROMPT_INSERT_BOUNDARY_LOOKBACK_CHARS = 4_096;
 const CHATGPT_PROMPT_GRAPHEME_SEGMENTER = new Intl.Segmenter(undefined, { granularity: "grapheme" });
 const CHATGPT_PROMPT_WHITESPACE = /\s/u;
-const CHATGPT_PROMPT_VERIFICATION_ATTEMPTS = 5;
-const CHATGPT_PROMPT_VERIFICATION_SETTLE_MS = 200;
+const CHATGPT_PROMPT_INTERMEDIATE_VERIFY_TIMEOUT_MS = 20_000;
+const CHATGPT_PROMPT_FINAL_VERIFY_TIMEOUT_MS = 10_000;
+const CHATGPT_PROMPT_VERIFICATION_POLL_MS = 100;
 export const CHATGPT_COMPOSER_DOCUMENT_END_KEY = process.platform === "darwin"
   ? "Meta+ArrowDown"
   : "Control+End";
@@ -286,6 +287,19 @@ function promptCommonPrefixChars(expected: string, observed: string): number {
   let commonPrefix = 0;
   while (commonPrefix < expected.length && expected[commonPrefix] === observed[commonPrefix]) commonPrefix += 1;
   return commonPrefix;
+}
+
+export interface ChatGptPromptReadbackPart {
+  text: string;
+  ignored: boolean;
+}
+
+export function composeChatGptPromptReadback(parts: readonly ChatGptPromptReadbackPart[]): string {
+  return parts
+    .filter(part => !part.ignored)
+    .map(part => part.text)
+    .join("\n")
+    .trimStart();
 }
 
 interface ChatGptPromptSubmissionBaseline {
@@ -1180,7 +1194,7 @@ export class ChatGptBrowserWorker {
 
   private async attachedPromptText(page: Page): Promise<string> {
     const composer = await this.activeComposer(page);
-    return composer.evaluate(element => {
+    const parts = await composer.evaluate(element => {
       const ignoredSelector = '[data-id^="plugin:"][data-keyword], [data-inline-selection-pill-cursor-target]';
       const visibleText = (node: Node): string => {
         if (node instanceof Element && node.matches(ignoredSelector)) return "";
@@ -1190,10 +1204,12 @@ export class ChatGptBrowserWorker {
         return text;
       };
       return [...element.childNodes]
-        .map(child => visibleText(child))
-        .join("\n")
-        .trimStart();
+        .map(child => ({
+          text: visibleText(child),
+          ignored: child instanceof Element && child.matches(ignoredSelector),
+        }));
     }, undefined, { timeout: 20_000 });
+    return composeChatGptPromptReadback(parts);
   }
 
   private async promptSubmissionBaseline(page: Page): Promise<ChatGptPromptSubmissionBaseline> {
@@ -1230,17 +1246,18 @@ export class ChatGptBrowserWorker {
   }
 
   private async waitForPromptComposerSettle(): Promise<void> {
-    await new Promise(resolveSleep => setTimeout(resolveSleep, CHATGPT_PROMPT_VERIFICATION_SETTLE_MS));
+    await new Promise(resolveSleep => setTimeout(resolveSleep, CHATGPT_PROMPT_VERIFICATION_POLL_MS));
   }
 
   private async exactPromptSnapshot(
     page: Page,
     prompt: string,
     baseline: ChatGptPromptSubmissionBaseline = { initialUserTurnCount: 0, initialAssistantTurnCount: 0 },
+    timeoutMs = CHATGPT_PROMPT_FINAL_VERIFY_TIMEOUT_MS,
   ): Promise<string> {
+    const deadline = Date.now() + timeoutMs;
     let observed = "";
-    for (let attempt = 0; attempt < CHATGPT_PROMPT_VERIFICATION_ATTEMPTS; attempt += 1) {
-      await this.waitForPromptComposerSettle();
+    for (;;) {
       const snapshot = await this.promptAttachmentSnapshot(page, baseline);
       observed = snapshot.text;
       if (snapshot.submissionEvidence) {
@@ -1249,8 +1266,9 @@ export class ChatGptBrowserWorker {
         );
       }
       if (observed === prompt) return observed;
+      if (Date.now() >= deadline) return observed;
+      await this.waitForPromptComposerSettle();
     }
-    return observed;
   }
 
   private async assertPromptAttached(
@@ -1258,7 +1276,7 @@ export class ChatGptBrowserWorker {
     prompt: string,
     baseline: ChatGptPromptSubmissionBaseline = { initialUserTurnCount: 0, initialAssistantTurnCount: 0 },
   ): Promise<void> {
-    const observed = await this.exactPromptSnapshot(page, prompt, baseline);
+    const observed = await this.exactPromptSnapshot(page, prompt, baseline, CHATGPT_PROMPT_FINAL_VERIFY_TIMEOUT_MS);
     if (observed === prompt) return;
     const commonPrefix = promptCommonPrefixChars(prompt, observed);
     throw new Error(
@@ -1476,10 +1494,9 @@ export class ChatGptBrowserWorker {
       const end = promptInsertChunkEnd(text, offset);
       await page.keyboard.insertText(text.slice(offset, end));
       if (end < text.length) {
-        // Lexical can rebuild the active block after an exact commit and move the native
-        // selection. Re-anchor only after the verified prefix is stable, before the next input.
+        // Keep the native selection produced by Input.insertText. Replacing it with a DOM Range
+        // after each commit can move Lexical's logical caret into the middle of the active block.
         await this.waitForPromptChunkAttached(page, text.slice(0, end).trimStart(), baseline);
-        await this.reanchorPromptCaret(page);
       }
       offset = end;
     }
@@ -1490,7 +1507,7 @@ export class ChatGptBrowserWorker {
     expected: string,
     baseline: ChatGptPromptSubmissionBaseline = { initialUserTurnCount: 0, initialAssistantTurnCount: 0 },
   ): Promise<void> {
-    const observed = await this.exactPromptSnapshot(page, expected, baseline);
+    const observed = await this.exactPromptSnapshot(page, expected, baseline, CHATGPT_PROMPT_INTERMEDIATE_VERIFY_TIMEOUT_MS);
     if (observed === expected) return;
     const commonPrefix = promptCommonPrefixChars(expected, observed);
     throw new Error(

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -244,15 +244,54 @@ const browserStageTimeouts = {
 } as const;
 
 /**
- * CDP accepts large Input.insertText payloads, but a single oversized edit can outrun ChatGPT's
- * Lexical update path. Keep every browser edit below the 139,331-character Send ceiling measured
- * on the current Free/Luna composer. This chunks only the input event; the resulting user message
- * remains one exact prompt and is verified byte-for-byte after insertion.
+ * Keep each native edit small enough that ChatGPT's Lexical editor can commit it without rebuilding
+ * the active block around a six-figure insertion boundary. The resulting user message remains one
+ * exact prompt and is verified after every edit.
  */
-export const CHATGPT_PROMPT_INSERT_CHUNK_CHARS = 100_000;
+export const CHATGPT_PROMPT_INSERT_CHUNK_CHARS = 16_000;
+const CHATGPT_PROMPT_INSERT_BOUNDARY_LOOKBACK_CHARS = 4_096;
+const CHATGPT_PROMPT_GRAPHEME_SEGMENTER = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+const CHATGPT_PROMPT_WHITESPACE = /\s/u;
+const CHATGPT_PROMPT_VERIFICATION_ATTEMPTS = 5;
+const CHATGPT_PROMPT_VERIFICATION_SETTLE_MS = 200;
 export const CHATGPT_COMPOSER_DOCUMENT_END_KEY = process.platform === "darwin"
   ? "Meta+ArrowDown"
   : "Control+End";
+
+function promptInsertChunkEnd(text: string, offset: number): number {
+  const hardEnd = Math.min(offset + CHATGPT_PROMPT_INSERT_CHUNK_CHARS, text.length);
+  if (hardEnd === text.length) return hardEnd;
+
+  const minimumPreferredEnd = Math.max(offset + 1, hardEnd - CHATGPT_PROMPT_INSERT_BOUNDARY_LOOKBACK_CHARS);
+  for (let candidate = hardEnd; candidate >= minimumPreferredEnd; candidate -= 1) {
+    if (!CHATGPT_PROMPT_WHITESPACE.test(text[candidate] ?? "")) continue;
+    let whitespaceStart = candidate;
+    while (whitespaceStart > offset && CHATGPT_PROMPT_WHITESPACE.test(text[whitespaceStart - 1] ?? "")) {
+      whitespaceStart -= 1;
+    }
+    if (whitespaceStart > offset) return whitespaceStart;
+  }
+
+  const segments = CHATGPT_PROMPT_GRAPHEME_SEGMENTER.segment(text);
+  const containingBoundary = segments.containing(hardEnd);
+  let safeEnd = containingBoundary?.index ?? hardEnd;
+  if (safeEnd === hardEnd) {
+    const previousGrapheme = segments.containing(hardEnd - 1);
+    if (previousGrapheme && previousGrapheme.segment.length > 1) safeEnd = previousGrapheme.index;
+  }
+  return safeEnd > offset ? safeEnd : hardEnd;
+}
+
+function promptCommonPrefixChars(expected: string, observed: string): number {
+  let commonPrefix = 0;
+  while (commonPrefix < expected.length && expected[commonPrefix] === observed[commonPrefix]) commonPrefix += 1;
+  return commonPrefix;
+}
+
+interface ChatGptPromptSubmissionBaseline {
+  initialUserTurnCount: number;
+  initialAssistantTurnCount: number;
+}
 
 export interface BrowserTurn {
   traceId: string;
@@ -582,6 +621,21 @@ class ChatGptBrowserDiagnostics {
             }));
           const composers = [...document.querySelectorAll(composerSelector)].filter(rendered);
           const assistantTurns = [...document.querySelectorAll(assistantTurnSelector)].filter(rendered);
+          const selection = window.getSelection();
+          const nodePath = (root: Element, node: Node | null): number[] | null => {
+            if (!node || (node !== root && !root.contains(node))) return null;
+            const path: number[] = [];
+            let current: Node = node;
+            while (current !== root) {
+              const parent = current.parentNode;
+              if (!parent) return null;
+              const siblingIndex = [...parent.childNodes].findIndex(child => child === current);
+              if (siblingIndex < 0) return null;
+              path.unshift(siblingIndex);
+              current = parent;
+            }
+            return path;
+          };
           return {
             url: location.href,
             title: document.title,
@@ -591,6 +645,17 @@ class ChatGptBrowserDiagnostics {
             composer: {
               visibleCount: composers.length,
               textChars: composers.map(element => (element.textContent ?? "").length),
+              structures: composers.map(element => ({
+                childTextChars: [...element.childNodes].map(child => (child.textContent ?? "").length),
+                childNodeNames: [...element.childNodes].map(child => child.nodeName),
+                selection: selection ? {
+                  collapsed: selection.isCollapsed,
+                  anchorPath: nodePath(element, selection.anchorNode),
+                  anchorOffset: selection.anchorOffset,
+                  focusPath: nodePath(element, selection.focusNode),
+                  focusOffset: selection.focusOffset,
+                } : null,
+              })),
               selectedConnectors: rows('[data-id^="plugin:"][data-keyword]', 20),
             },
             effortControls: rows(effortControlSelector, 10),
@@ -1116,28 +1181,86 @@ export class ChatGptBrowserWorker {
   private async attachedPromptText(page: Page): Promise<string> {
     const composer = await this.activeComposer(page);
     return composer.evaluate(element => {
-      const clone = element.cloneNode(true) as HTMLElement;
-      clone.querySelectorAll(
-        '[data-id^="plugin:"][data-keyword], [data-inline-selection-pill-cursor-target]',
-      )
-        .forEach(part => part.remove());
-      return [...clone.childNodes]
-        .map(child => child.textContent ?? "")
+      const ignoredSelector = '[data-id^="plugin:"][data-keyword], [data-inline-selection-pill-cursor-target]';
+      const visibleText = (node: Node): string => {
+        if (node instanceof Element && node.matches(ignoredSelector)) return "";
+        if (node.nodeType === Node.TEXT_NODE) return node.textContent ?? "";
+        let text = "";
+        for (const child of node.childNodes) text += visibleText(child);
+        return text;
+      };
+      return [...element.childNodes]
+        .map(child => visibleText(child))
         .join("\n")
         .trimStart();
     }, undefined, { timeout: 20_000 });
   }
 
-  private async assertPromptAttached(page: Page, prompt: string): Promise<void> {
-    const deadline = Date.now() + 10_000;
+  private async promptSubmissionBaseline(page: Page): Promise<ChatGptPromptSubmissionBaseline> {
+    const [initialUserTurnCount, initialAssistantTurnCount] = await Promise.all([
+      page.locator(CHATGPT_USER_TURN_SELECTOR).count(),
+      page.locator(CHATGPT_ASSISTANT_TURN_SELECTOR).count(),
+    ]);
+    return { initialUserTurnCount, initialAssistantTurnCount };
+  }
+
+  private async promptAttachmentSnapshot(
+    page: Page,
+    baseline: ChatGptPromptSubmissionBaseline = { initialUserTurnCount: 0, initialAssistantTurnCount: 0 },
+  ): Promise<{
+    text: string;
+    submissionEvidence?: ChatGptSubmissionEvidence;
+  }> {
+    const [text, userTurnCount, assistantTurnCount, generationRunning] = await Promise.all([
+      this.attachedPromptText(page),
+      page.locator(CHATGPT_USER_TURN_SELECTOR).count(),
+      page.locator(CHATGPT_ASSISTANT_TURN_SELECTOR).count(),
+      page.locator(CHATGPT_STOP_BUTTON_SELECTOR).filter({ visible: true }).count().then(count => count > 0),
+    ]);
+    return {
+      text,
+      submissionEvidence: chatGptSubmissionEvidence({
+        initialUserTurnCount: baseline.initialUserTurnCount,
+        userTurnCount,
+        initialAssistantTurnCount: baseline.initialAssistantTurnCount,
+        assistantTurnCount,
+        generationRunning,
+      }),
+    };
+  }
+
+  private async waitForPromptComposerSettle(): Promise<void> {
+    await new Promise(resolveSleep => setTimeout(resolveSleep, CHATGPT_PROMPT_VERIFICATION_SETTLE_MS));
+  }
+
+  private async exactPromptSnapshot(
+    page: Page,
+    prompt: string,
+    baseline: ChatGptPromptSubmissionBaseline = { initialUserTurnCount: 0, initialAssistantTurnCount: 0 },
+  ): Promise<string> {
     let observed = "";
-    while (Date.now() < deadline) {
-      observed = await this.attachedPromptText(page);
-      if (observed === prompt) return;
-      await new Promise(resolveSleep => setTimeout(resolveSleep, 50));
+    for (let attempt = 0; attempt < CHATGPT_PROMPT_VERIFICATION_ATTEMPTS; attempt += 1) {
+      await this.waitForPromptComposerSettle();
+      const snapshot = await this.promptAttachmentSnapshot(page, baseline);
+      observed = snapshot.text;
+      if (snapshot.submissionEvidence) {
+        throw new Error(
+          `ChatGPT submitted before prompt verification completed (evidence=${snapshot.submissionEvidence})`,
+        );
+      }
+      if (observed === prompt) return observed;
     }
-    let commonPrefix = 0;
-    while (commonPrefix < prompt.length && prompt[commonPrefix] === observed[commonPrefix]) commonPrefix += 1;
+    return observed;
+  }
+
+  private async assertPromptAttached(
+    page: Page,
+    prompt: string,
+    baseline: ChatGptPromptSubmissionBaseline = { initialUserTurnCount: 0, initialAssistantTurnCount: 0 },
+  ): Promise<void> {
+    const observed = await this.exactPromptSnapshot(page, prompt, baseline);
+    if (observed === prompt) return;
+    const commonPrefix = promptCommonPrefixChars(prompt, observed);
     throw new Error(
       `ChatGPT composer did not preserve the complete prompt (expectedChars=${prompt.length}, actualChars=${observed.length}, commonPrefixChars=${commonPrefix})`,
     );
@@ -1261,6 +1384,7 @@ export class ChatGptBrowserWorker {
     localTools: boolean,
     captureDiagnostic?: (checkpoint: string) => Promise<void>,
   ): Promise<void> {
+    const submissionBaseline = await this.promptSubmissionBaseline(page);
     if (!localTools) {
       const composer = await this.activeComposer(page);
       // Playwright's multiline fill maps through an input action that ChatGPT's Lexical editor can
@@ -1268,40 +1392,107 @@ export class ChatGptBrowserWorker {
       // then transport the complete text in one CDP Input.insertText command.
       await composer.fill("");
       await composer.focus();
-      await this.insertPromptText(page, prompt);
-      await this.assertPromptAttached(page, prompt);
+      await this.insertPromptText(page, prompt, submissionBaseline);
+      await this.assertPromptAttached(page, prompt, submissionBaseline);
       return;
     }
-    const selectedComposer = await this.selectConnector(page, captureDiagnostic);
-    await selectedComposer.focus();
-    await page.keyboard.press(CHATGPT_COMPOSER_DOCUMENT_END_KEY);
-    await this.insertPromptText(page, ` ${prompt}`);
-    await this.assertPromptAttached(page, prompt);
+    await this.selectConnector(page, captureDiagnostic);
+    await this.reanchorPromptCaret(page);
+    await this.insertPromptText(page, ` ${prompt}`, submissionBaseline);
+    await this.assertPromptAttached(page, prompt, submissionBaseline);
   }
 
-  private async insertPromptText(page: Page, text: string): Promise<void> {
-    for (let offset = 0; offset < text.length; offset += CHATGPT_PROMPT_INSERT_CHUNK_CHARS) {
-      const end = Math.min(offset + CHATGPT_PROMPT_INSERT_CHUNK_CHARS, text.length);
-      await page.keyboard.insertText(text.slice(offset, end));
-      if (end < text.length) {
-        await this.waitForPromptChunkAttached(page, text.slice(0, end).trimStart());
-        // Input.insertText leaves the native caret after the committed edit. Keep that exact
-        // insertion point: a document-end shortcut makes Lexical reconstruct the boundary block
-        // and can preserve the length while changing prompt text around the chunk boundary.
+  private async reanchorPromptCaret(page: Page): Promise<void> {
+    const composer = await this.activeComposer(page);
+    await composer.focus();
+    const anchored = await composer.evaluate(element => {
+      const ignoredSelector = '[data-id^="plugin:"][data-keyword], [data-inline-selection-pill-cursor-target]';
+      const editableBlocks: Element[] = [];
+      const collectEditableBlocks = (node: Node): void => {
+        if (node instanceof Element && node.matches(ignoredSelector)) return;
+        if (node instanceof Element && node.tagName === "P") editableBlocks.push(node);
+        for (const child of node.childNodes) collectEditableBlocks(child);
+      };
+      for (const child of element.childNodes) collectEditableBlocks(child);
+
+      const lastEditableBlock = editableBlocks[editableBlocks.length - 1];
+      if (!lastEditableBlock) return false;
+      const textNodes: Text[] = [];
+      const collectTextNodes = (node: Node): void => {
+        if (node instanceof Element && node.matches(ignoredSelector)) return;
+        if (node.nodeType === Node.TEXT_NODE) {
+          if ((node.textContent ?? "").length > 0) textNodes.push(node as Text);
+          return;
+        }
+        for (const child of node.childNodes) collectTextNodes(child);
+      };
+      collectTextNodes(lastEditableBlock);
+      const cursorTarget = lastEditableBlock.querySelector("[data-inline-selection-pill-cursor-target]");
+      const cursorTargetParent = cursorTarget?.parentNode ?? null;
+
+      const selection = window.getSelection();
+      if (!selection) return false;
+      const lastTextNode = textNodes[textNodes.length - 1];
+      const alreadyAtDocumentEnd = selection.isCollapsed && (
+        lastTextNode
+          ? selection.anchorNode === lastTextNode && selection.anchorOffset === lastTextNode.data.length
+          : cursorTargetParent
+            ? selection.anchorNode === cursorTargetParent
+              && cursorTarget instanceof Node
+              && selection.anchorOffset === [...cursorTargetParent.childNodes].indexOf(cursorTarget)
+            : selection.anchorNode === lastEditableBlock
+              && selection.anchorOffset === lastEditableBlock.childNodes.length
+      );
+      if (alreadyAtDocumentEnd) return true;
+
+      const range = document.createRange();
+      if (lastTextNode) {
+        range.setStart(lastTextNode, lastTextNode.data.length);
+        range.collapse(true);
+      } else if (cursorTarget) {
+        range.setStartBefore(cursorTarget);
+        range.collapse(true);
+      } else {
+        range.selectNodeContents(lastEditableBlock);
+        range.collapse(false);
       }
+      selection.removeAllRanges();
+      selection.addRange(range);
+      return selection.isCollapsed
+        && selection.anchorNode !== null
+        && lastEditableBlock.contains(selection.anchorNode);
+    }, undefined, { timeout: 20_000 });
+    if (!anchored) {
+      throw new Error("ChatGPT composer could not re-anchor the prompt caret at the document end");
     }
   }
 
-  private async waitForPromptChunkAttached(page: Page, expected: string): Promise<void> {
-    const deadline = Date.now() + 20_000;
-    let observed = "";
-    do {
-      observed = await this.attachedPromptText(page);
-      if (observed === expected) return;
-      await new Promise(resolveSleep => setTimeout(resolveSleep, 100));
-    } while (Date.now() < deadline);
-    let commonPrefix = 0;
-    while (commonPrefix < expected.length && expected[commonPrefix] === observed[commonPrefix]) commonPrefix += 1;
+  private async insertPromptText(
+    page: Page,
+    text: string,
+    baseline: ChatGptPromptSubmissionBaseline = { initialUserTurnCount: 0, initialAssistantTurnCount: 0 },
+  ): Promise<void> {
+    for (let offset = 0; offset < text.length;) {
+      const end = promptInsertChunkEnd(text, offset);
+      await page.keyboard.insertText(text.slice(offset, end));
+      if (end < text.length) {
+        // Lexical can rebuild the active block after an exact commit and move the native
+        // selection. Re-anchor only after the verified prefix is stable, before the next input.
+        await this.waitForPromptChunkAttached(page, text.slice(0, end).trimStart(), baseline);
+        await this.reanchorPromptCaret(page);
+      }
+      offset = end;
+    }
+  }
+
+  private async waitForPromptChunkAttached(
+    page: Page,
+    expected: string,
+    baseline: ChatGptPromptSubmissionBaseline = { initialUserTurnCount: 0, initialAssistantTurnCount: 0 },
+  ): Promise<void> {
+    const observed = await this.exactPromptSnapshot(page, expected, baseline);
+    if (observed === expected) return;
+    const commonPrefix = promptCommonPrefixChars(expected, observed);
     throw new Error(
       `ChatGPT composer did not commit a complete prompt insertion chunk`
       + ` (expectedChars=${expected.length}, actualChars=${observed.length}, commonPrefixChars=${commonPrefix})`,

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -1519,9 +1519,10 @@ export class ChatGptBrowserWorker {
       await page.keyboard.insertText(text.slice(offset, end));
       throwIfChatGptPromptAborted(abortSignal);
       if (end < text.length) {
-        // Keep the native selection produced by Input.insertText. Replacing it with a DOM Range
-        // after each commit can move Lexical's logical caret into the middle of the active block.
+        // Lexical can rebuild the active block after an exact commit and move the native
+        // selection. Re-anchor only after the verified prefix is stable, before the next input.
         await this.waitForPromptChunkAttached(page, text.slice(0, end).trimStart(), baseline, abortSignal);
+        await this.reanchorPromptCaret(page, abortSignal);
       }
       offset = end;
     }

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -302,6 +302,10 @@ export function composeChatGptPromptReadback(parts: readonly ChatGptPromptReadba
     .trimStart();
 }
 
+function throwIfChatGptPromptAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw new DOMException("ChatGPT prompt attachment aborted", "AbortError");
+}
+
 interface ChatGptPromptSubmissionBaseline {
   initialUserTurnCount: number;
   initialAssistantTurnCount: number;
@@ -1245,8 +1249,10 @@ export class ChatGptBrowserWorker {
     };
   }
 
-  private async waitForPromptComposerSettle(): Promise<void> {
+  private async waitForPromptComposerSettle(abortSignal?: AbortSignal): Promise<void> {
+    throwIfChatGptPromptAborted(abortSignal);
     await new Promise(resolveSleep => setTimeout(resolveSleep, CHATGPT_PROMPT_VERIFICATION_POLL_MS));
+    throwIfChatGptPromptAborted(abortSignal);
   }
 
   private async exactPromptSnapshot(
@@ -1254,11 +1260,14 @@ export class ChatGptBrowserWorker {
     prompt: string,
     baseline: ChatGptPromptSubmissionBaseline = { initialUserTurnCount: 0, initialAssistantTurnCount: 0 },
     timeoutMs = CHATGPT_PROMPT_FINAL_VERIFY_TIMEOUT_MS,
+    abortSignal?: AbortSignal,
   ): Promise<string> {
     const deadline = Date.now() + timeoutMs;
     let observed = "";
     for (;;) {
+      throwIfChatGptPromptAborted(abortSignal);
       const snapshot = await this.promptAttachmentSnapshot(page, baseline);
+      throwIfChatGptPromptAborted(abortSignal);
       observed = snapshot.text;
       if (snapshot.submissionEvidence) {
         throw new Error(
@@ -1267,7 +1276,7 @@ export class ChatGptBrowserWorker {
       }
       if (observed === prompt) return observed;
       if (Date.now() >= deadline) return observed;
-      await this.waitForPromptComposerSettle();
+      await this.waitForPromptComposerSettle(abortSignal);
     }
   }
 
@@ -1275,8 +1284,15 @@ export class ChatGptBrowserWorker {
     page: Page,
     prompt: string,
     baseline: ChatGptPromptSubmissionBaseline = { initialUserTurnCount: 0, initialAssistantTurnCount: 0 },
+    abortSignal?: AbortSignal,
   ): Promise<void> {
-    const observed = await this.exactPromptSnapshot(page, prompt, baseline, CHATGPT_PROMPT_FINAL_VERIFY_TIMEOUT_MS);
+    const observed = await this.exactPromptSnapshot(
+      page,
+      prompt,
+      baseline,
+      CHATGPT_PROMPT_FINAL_VERIFY_TIMEOUT_MS,
+      abortSignal,
+    );
     if (observed === prompt) return;
     const commonPrefix = promptCommonPrefixChars(prompt, observed);
     throw new Error(
@@ -1401,8 +1417,11 @@ export class ChatGptBrowserWorker {
     prompt: string,
     localTools: boolean,
     captureDiagnostic?: (checkpoint: string) => Promise<void>,
+    abortSignal?: AbortSignal,
   ): Promise<void> {
+    throwIfChatGptPromptAborted(abortSignal);
     const submissionBaseline = await this.promptSubmissionBaseline(page);
+    throwIfChatGptPromptAborted(abortSignal);
     if (!localTools) {
       const composer = await this.activeComposer(page);
       // Playwright's multiline fill maps through an input action that ChatGPT's Lexical editor can
@@ -1410,17 +1429,19 @@ export class ChatGptBrowserWorker {
       // then transport the complete text in one CDP Input.insertText command.
       await composer.fill("");
       await composer.focus();
-      await this.insertPromptText(page, prompt, submissionBaseline);
-      await this.assertPromptAttached(page, prompt, submissionBaseline);
+      await this.insertPromptText(page, prompt, submissionBaseline, abortSignal);
+      await this.assertPromptAttached(page, prompt, submissionBaseline, abortSignal);
       return;
     }
     await this.selectConnector(page, captureDiagnostic);
-    await this.reanchorPromptCaret(page);
-    await this.insertPromptText(page, ` ${prompt}`, submissionBaseline);
-    await this.assertPromptAttached(page, prompt, submissionBaseline);
+    throwIfChatGptPromptAborted(abortSignal);
+    await this.reanchorPromptCaret(page, abortSignal);
+    await this.insertPromptText(page, ` ${prompt}`, submissionBaseline, abortSignal);
+    await this.assertPromptAttached(page, prompt, submissionBaseline, abortSignal);
   }
 
-  private async reanchorPromptCaret(page: Page): Promise<void> {
+  private async reanchorPromptCaret(page: Page, abortSignal?: AbortSignal): Promise<void> {
+    throwIfChatGptPromptAborted(abortSignal);
     const composer = await this.activeComposer(page);
     await composer.focus();
     const anchored = await composer.evaluate(element => {
@@ -1480,6 +1501,7 @@ export class ChatGptBrowserWorker {
         && selection.anchorNode !== null
         && lastEditableBlock.contains(selection.anchorNode);
     }, undefined, { timeout: 20_000 });
+    throwIfChatGptPromptAborted(abortSignal);
     if (!anchored) {
       throw new Error("ChatGPT composer could not re-anchor the prompt caret at the document end");
     }
@@ -1489,14 +1511,17 @@ export class ChatGptBrowserWorker {
     page: Page,
     text: string,
     baseline: ChatGptPromptSubmissionBaseline = { initialUserTurnCount: 0, initialAssistantTurnCount: 0 },
+    abortSignal?: AbortSignal,
   ): Promise<void> {
     for (let offset = 0; offset < text.length;) {
+      throwIfChatGptPromptAborted(abortSignal);
       const end = promptInsertChunkEnd(text, offset);
       await page.keyboard.insertText(text.slice(offset, end));
+      throwIfChatGptPromptAborted(abortSignal);
       if (end < text.length) {
         // Keep the native selection produced by Input.insertText. Replacing it with a DOM Range
         // after each commit can move Lexical's logical caret into the middle of the active block.
-        await this.waitForPromptChunkAttached(page, text.slice(0, end).trimStart(), baseline);
+        await this.waitForPromptChunkAttached(page, text.slice(0, end).trimStart(), baseline, abortSignal);
       }
       offset = end;
     }
@@ -1506,8 +1531,15 @@ export class ChatGptBrowserWorker {
     page: Page,
     expected: string,
     baseline: ChatGptPromptSubmissionBaseline = { initialUserTurnCount: 0, initialAssistantTurnCount: 0 },
+    abortSignal?: AbortSignal,
   ): Promise<void> {
-    const observed = await this.exactPromptSnapshot(page, expected, baseline, CHATGPT_PROMPT_INTERMEDIATE_VERIFY_TIMEOUT_MS);
+    const observed = await this.exactPromptSnapshot(
+      page,
+      expected,
+      baseline,
+      CHATGPT_PROMPT_INTERMEDIATE_VERIFY_TIMEOUT_MS,
+      abortSignal,
+    );
     if (observed === expected) return;
     const commonPrefix = promptCommonPrefixChars(expected, observed);
     throw new Error(
@@ -1970,8 +2002,14 @@ export class ChatGptBrowserWorker {
         )
       ));
       await diagnostics.capture(page, "effort-selection-complete");
-      await this.runStage(turn.traceId, "prompt_attachment", browserStageTimeouts.promptAttachment, () => (
-        this.attachPrompt(page, prepared.text, mode.localTools, checkpoint => diagnostics.capture(page, checkpoint))
+      await this.runStage(turn.traceId, "prompt_attachment", browserStageTimeouts.promptAttachment, (stageSignal) => (
+        this.attachPrompt(
+          page,
+          prepared.text,
+          mode.localTools,
+          checkpoint => diagnostics.capture(page, checkpoint),
+          stageSignal,
+        )
       ));
       await diagnostics.capture(page, "prompt-attachment-complete");
       await this.runStage(turn.traceId, "file_attachment", browserStageTimeouts.fileAttachment, () => (

--- a/src/chatgpt-session.ts
+++ b/src/chatgpt-session.ts
@@ -25,11 +25,13 @@ export const CHATGPT_ASSISTANT_TURN_SELECTOR = [
   '[data-testid^="conversation-turn-"][data-turn="assistant"]',
   '[data-testid^="conversation-turn-"][data-message-author-role="assistant"]',
   '[data-testid^="conversation-turn-"]:has([data-message-author-role="assistant"])',
+  'body:not(:has([data-testid^="conversation-turn-"])) [data-message-author-role="assistant"]',
 ].join(", ");
 export const CHATGPT_USER_TURN_SELECTOR = [
   '[data-testid^="conversation-turn-"][data-turn="user"]',
   '[data-testid^="conversation-turn-"][data-message-author-role="user"]',
   '[data-testid^="conversation-turn-"]:has([data-message-author-role="user"])',
+  'body:not(:has([data-testid^="conversation-turn-"])) [data-message-author-role="user"]',
 ].join(", ");
 
 export interface ChatGptEffortSliderState {

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -1,15 +1,15 @@
 import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import type { Page } from "playwright-core";
-import { CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_PROMPT_INSERT_CHUNK_CHARS, ChatGptBrowserWorker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_TABS, assertChatGptWebInputWithinLimits, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptSubmissionEvidence, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert } from "../src/adapters/chatgpt-web/browser-worker";
+import { CHATGPT_PROMPT_INSERT_CHUNK_CHARS, ChatGptBrowserWorker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_TABS, assertChatGptWebInputWithinLimits, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptSubmissionEvidence, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert } from "../src/adapters/chatgpt-web/browser-worker";
 import { CHATGPT_CONNECTOR_NAME, defaultChromeExecutable } from "../src/config";
 import { parseChatGptEffortSliderState } from "../src/chatgpt-session";
 
 test("Codex context uses the owned CDP composer transport, never the operating-system clipboard", () => {
   const workerSource = readFileSync(new URL("../src/adapters/chatgpt-web/browser-worker.ts", import.meta.url), "utf8");
   expect(workerSource).toContain('composer.fill("")');
-  expect(workerSource).toContain("this.insertPromptText(page, prompt)");
-  expect(workerSource).toContain("this.insertPromptText(page, ` ${prompt}`)");
+  expect(workerSource).toContain("this.insertPromptText(page, prompt, submissionBaseline)");
+  expect(workerSource).toContain("this.insertPromptText(page, ` ${prompt}`, submissionBaseline)");
   expect(workerSource).not.toMatch(/\bclipboard\b|pbcopy|pbpaste/i);
 });
 
@@ -201,7 +201,7 @@ test("active composer resolution waits for exactly one visible editor", async ()
   expect(await activeComposer.call({}, page, 500)).toBe(composer);
 });
 
-test("large read-only context is inserted as contiguous bounded edits before exact verification", async () => {
+test("large read-only context is inserted as contiguous low-load edits before exact verification", async () => {
   const prompt = `Act as the model backend for the Codex task encoded below.\n${"x".repeat(819_343)}`;
   const calls: Array<[string, string?]> = [];
   let asserted = "";
@@ -224,15 +224,18 @@ test("large read-only context is inserted as contiguous bounded edits before exa
 
   await attachPrompt.call({
     activeComposer: async () => composer,
+    promptSubmissionBaseline: async () => ({ initialUserTurnCount: 0, initialAssistantTurnCount: 0 }),
     insertPromptText,
     waitForPromptChunkAttached: async (_page: unknown, expected: string) => {
       calls.push(["chunkCommitted", String(expected.length)]);
     },
+    reanchorPromptCaret: async () => {},
     assertPromptAttached: async (_page: unknown, value: string) => { asserted = value; },
   }, page, prompt, false);
 
   const inserted = calls.filter(call => call[0] === "insertText").map(call => call[1] ?? "");
   const fullChunkCount = Math.floor((prompt.length - 1) / CHATGPT_PROMPT_INSERT_CHUNK_CHARS);
+  expect(CHATGPT_PROMPT_INSERT_CHUNK_CHARS).toBeLessThanOrEqual(16_000);
   expect(calls.slice(0, 2)).toEqual([["fill", ""], ["focus"]]);
   expect(inserted.every(chunk => chunk.length <= CHATGPT_PROMPT_INSERT_CHUNK_CHARS)).toBeTrue();
   expect(inserted.length).toBe(Math.ceil(prompt.length / CHATGPT_PROMPT_INSERT_CHUNK_CHARS));
@@ -245,6 +248,227 @@ test("large read-only context is inserted as contiguous bounded edits before exa
   );
   expect(calls.filter(call => call[0] === "press")).toEqual([]);
   expect(asserted).toBe(prompt);
+});
+
+test("multi-chunk prompt insertion re-anchors the caret after each committed prefix", async () => {
+  const prompt = "a".repeat(CHATGPT_PROMPT_INSERT_CHUNK_CHARS)
+    + "b".repeat(CHATGPT_PROMPT_INSERT_CHUNK_CHARS)
+    + "c";
+  const calls: Array<[string, string?]> = [];
+  let attached = "";
+  let caret = 0;
+  const page = {
+    keyboard: {
+      insertText: async (value: string) => {
+        attached = `${attached.slice(0, caret)}${value}${attached.slice(caret)}`;
+        caret += value.length;
+        calls.push(["insertText", String(value.length)]);
+      },
+    },
+  };
+  const insertPromptText = (ChatGptBrowserWorker.prototype as unknown as {
+    insertPromptText(page: unknown, text: string): Promise<void>;
+  }).insertPromptText;
+
+  await insertPromptText.call({
+    waitForPromptChunkAttached: async (_page: unknown, expected: string) => {
+      expect(attached).toBe(expected);
+      calls.push(["chunkCommitted", String(expected.length)]);
+    },
+    reanchorPromptCaret: async () => {
+      // The editor may rebuild the active Lexical block after a committed chunk. Re-anchor
+      // to the verified prefix end before the next native insertion.
+      caret = attached.length;
+      calls.push(["reanchor"]);
+    },
+  }, page, prompt);
+
+  expect(attached).toBe(prompt);
+  expect(calls).toEqual([
+    ["insertText", String(CHATGPT_PROMPT_INSERT_CHUNK_CHARS)],
+    ["chunkCommitted", String(CHATGPT_PROMPT_INSERT_CHUNK_CHARS)],
+    ["reanchor"],
+    ["insertText", String(CHATGPT_PROMPT_INSERT_CHUNK_CHARS)],
+    ["chunkCommitted", String(CHATGPT_PROMPT_INSERT_CHUNK_CHARS * 2)],
+    ["reanchor"],
+    ["insertText", "1"],
+  ]);
+});
+
+test("caret re-anchor fails closed when the live selection cannot be verified", async () => {
+  const reanchorPromptCaret = (ChatGptBrowserWorker.prototype as unknown as {
+    reanchorPromptCaret(page: unknown): Promise<void>;
+  }).reanchorPromptCaret;
+  let evaluateOptions: unknown;
+  const composer = {
+    focus: async () => {},
+    evaluate: async (_fn: unknown, _arg: unknown, options: unknown) => {
+      evaluateOptions = options;
+      return false;
+    },
+  };
+
+  await expect(reanchorPromptCaret.call({
+    activeComposer: async () => composer,
+  }, {})).rejects.toThrow("could not re-anchor the prompt caret");
+  expect(evaluateOptions).toEqual({ timeout: 20_000 });
+});
+
+test("caret re-anchor uses the live Selection API and excludes connector-only nodes", () => {
+  const workerSource = readFileSync(new URL("../src/adapters/chatgpt-web/browser-worker.ts", import.meta.url), "utf8");
+  const reanchorSource = workerSource.slice(
+    workerSource.indexOf("private async reanchorPromptCaret"),
+    workerSource.indexOf("private async insertPromptText"),
+  );
+  expect(reanchorSource).toContain("window.getSelection()");
+  expect(reanchorSource).toContain("document.createRange()");
+  expect(reanchorSource).toContain("selection.addRange(range)");
+  expect(reanchorSource).toContain('node.tagName === "P"');
+  expect(reanchorSource).toContain("range.setStartBefore(cursorTarget)");
+  expect(reanchorSource).toContain("[data-id^=\"plugin:\"][data-keyword]");
+  expect(reanchorSource).toContain("[data-inline-selection-pill-cursor-target]");
+  expect(reanchorSource).not.toContain("CHATGPT_COMPOSER_DOCUMENT_END_KEY");
+});
+
+test("long prompt insertion prefers a nearby text boundary over an unstable Unicode tail", async () => {
+  const prompt = `${"x".repeat(CHATGPT_PROMPT_INSERT_CHUNK_CHARS - 10)} ${"y".repeat(7)}☹️tail`;
+  const inserted: string[] = [];
+  const page = {
+    keyboard: {
+      insertText: async (value: string) => { inserted.push(value); },
+    },
+  };
+  const insertPromptText = (ChatGptBrowserWorker.prototype as unknown as {
+    insertPromptText(page: unknown, text: string): Promise<void>;
+  }).insertPromptText;
+
+  await insertPromptText.call({
+    waitForPromptChunkAttached: async () => {},
+    reanchorPromptCaret: async () => {},
+  }, page, prompt);
+
+  expect(inserted.join("")).toBe(prompt);
+  expect(inserted[0]?.length).toBe(CHATGPT_PROMPT_INSERT_CHUNK_CHARS - 10);
+  expect(inserted[0]?.endsWith("x")).toBeTrue();
+  expect(inserted[1]?.startsWith(" ")).toBeTrue();
+});
+
+test("long prompt insertion never divides a UTF-16 surrogate pair", async () => {
+  const prompt = `${"x".repeat(CHATGPT_PROMPT_INSERT_CHUNK_CHARS - 1)}😀tail`;
+  const inserted: string[] = [];
+  const page = {
+    keyboard: {
+      insertText: async (value: string) => { inserted.push(value); },
+    },
+  };
+  const insertPromptText = (ChatGptBrowserWorker.prototype as unknown as {
+    insertPromptText(page: unknown, text: string): Promise<void>;
+  }).insertPromptText;
+
+  await insertPromptText.call({
+    waitForPromptChunkAttached: async () => {},
+    reanchorPromptCaret: async () => {},
+  }, page, prompt);
+
+  expect(inserted.join("")).toBe(prompt);
+  expect(inserted[0]?.length).toBe(CHATGPT_PROMPT_INSERT_CHUNK_CHARS - 1);
+  for (const chunk of inserted) {
+    const lastCodeUnit = chunk.charCodeAt(chunk.length - 1);
+    expect(lastCodeUnit < 0xd800 || lastCodeUnit > 0xdbff).toBeTrue();
+  }
+});
+
+test("intermediate prompt verification never accepts a stable equal-length boundary rewrite", async () => {
+  const expected = "x".repeat(CHATGPT_PROMPT_INSERT_CHUNK_CHARS);
+  const normalized = `${expected.slice(0, -2)}yz`;
+  let observations = 0;
+  const waitForPromptChunkAttached = (ChatGptBrowserWorker.prototype as unknown as {
+    waitForPromptChunkAttached(page: unknown, value: string): Promise<void>;
+  }).waitForPromptChunkAttached;
+  const exactPromptSnapshot = (ChatGptBrowserWorker.prototype as unknown as {
+    exactPromptSnapshot(page: unknown, value: string): Promise<string>;
+  }).exactPromptSnapshot;
+
+  await expect(waitForPromptChunkAttached.call({
+    exactPromptSnapshot,
+    waitForPromptComposerSettle: async () => {},
+    promptAttachmentSnapshot: async () => {
+      observations += 1;
+      return { text: normalized };
+    },
+  }, {}, expected)).rejects.toThrow("commonPrefixChars=");
+
+  expect(observations).toBeLessThanOrEqual(5);
+});
+
+test("prompt verification stops immediately when ChatGPT submits during insertion", async () => {
+  const waitForPromptChunkAttached = (ChatGptBrowserWorker.prototype as unknown as {
+    waitForPromptChunkAttached(page: unknown, value: string): Promise<void>;
+  }).waitForPromptChunkAttached;
+  const exactPromptSnapshot = (ChatGptBrowserWorker.prototype as unknown as {
+    exactPromptSnapshot(page: unknown, value: string): Promise<string>;
+  }).exactPromptSnapshot;
+  let observations = 0;
+
+  await expect(waitForPromptChunkAttached.call({
+    exactPromptSnapshot,
+    waitForPromptComposerSettle: async () => {},
+    promptAttachmentSnapshot: async () => {
+      observations += 1;
+      return { text: "expected prompt", submissionEvidence: "generation_running" };
+    },
+  }, {}, "expected prompt")).rejects.toThrow("submitted before prompt verification completed");
+
+  expect(observations).toBe(1);
+});
+
+test("final prompt verification still requires an exact snapshot", async () => {
+  const expected = "x".repeat(CHATGPT_PROMPT_INSERT_CHUNK_CHARS);
+  const normalized = `${expected.slice(0, -2)}yz`;
+  let observations = 0;
+  const assertPromptAttached = (ChatGptBrowserWorker.prototype as unknown as {
+    assertPromptAttached(page: unknown, value: string): Promise<void>;
+  }).assertPromptAttached;
+  const exactPromptSnapshot = (ChatGptBrowserWorker.prototype as unknown as {
+    exactPromptSnapshot(page: unknown, value: string): Promise<string>;
+  }).exactPromptSnapshot;
+
+  await assertPromptAttached.call({
+    exactPromptSnapshot,
+    waitForPromptComposerSettle: async () => {},
+    promptAttachmentSnapshot: async () => {
+      observations += 1;
+      return { text: observations < 4 ? normalized : expected };
+    },
+  }, {}, expected);
+
+  expect(observations).toBe(4);
+});
+
+test("prompt attachment verification uses the existing-turn baseline", async () => {
+  const promptAttachmentSnapshot = (ChatGptBrowserWorker.prototype as unknown as {
+    promptAttachmentSnapshot(
+      page: unknown,
+      baseline: { initialUserTurnCount: number; initialAssistantTurnCount: number },
+    ): Promise<{ text: string; submissionEvidence?: string }>;
+  }).promptAttachmentSnapshot;
+  const counts = [3, 4, 0];
+  const page = {
+    locator: () => {
+      const count = counts.shift() ?? 0;
+      return {
+        count: async () => count,
+        filter: () => ({ count: async () => 0 }),
+      };
+    },
+  };
+
+  const snapshot = await promptAttachmentSnapshot.call({
+    attachedPromptText: async () => "expected prompt",
+  }, page, { initialUserTurnCount: 3, initialAssistantTurnCount: 4 });
+
+  expect(snapshot.text).toBe("expected prompt");
+  expect(snapshot.submissionEvidence).toBeUndefined();
 });
 
 test("connector selection re-resolves the active composer after ChatGPT replaces it", async () => {
@@ -449,6 +673,7 @@ test("tool-capable prompts use the shared Playwright connector selection before 
   let activeComposerCalls = 0;
   await attachPrompt.call({
     config: { appName: "Codex Native2" },
+    promptSubmissionBaseline: async () => ({ initialUserTurnCount: 0, initialAssistantTurnCount: 0 }),
     selectConnector,
     insertPromptText,
     connectorIsSelected: async () => selected,
@@ -457,6 +682,7 @@ test("tool-capable prompts use the shared Playwright connector selection before 
       activeComposerCalls += 1;
       return selected ? selectedComposer : initialComposer;
     },
+    reanchorPromptCaret: async () => { calls.push(["reanchor"]); },
     assertPromptAttached: async () => { calls.push(["assertPrompt"]); },
   }, page, "context", true);
 
@@ -468,8 +694,7 @@ test("tool-capable prompts use the shared Playwright connector selection before 
     ["connectorMenu"],
     ["selectConnector"],
     ["selectedConnector"],
-    ["selectedFocus"],
-    ["press", CHATGPT_COMPOSER_DOCUMENT_END_KEY],
+    ["reanchor"],
     ["insertText", " context"],
     ["assertPrompt"],
   ]);
@@ -920,6 +1145,19 @@ test("browser diagnostics redact context envelopes and capability values", () =>
   expect(diagnostic).not.toContain("private context");
   expect(diagnostic).not.toContain("12345678901234567890");
   expect(diagnostic).toContain("<codex_context_json>[redacted]</codex_context_json>");
+});
+
+test("browser failure diagnostics record composer structure and selection without prompt content", () => {
+  const workerSource = readFileSync(new URL("../src/adapters/chatgpt-web/browser-worker.ts", import.meta.url), "utf8");
+  expect(workerSource).toContain("childTextChars");
+  expect(workerSource).toContain("anchorPath");
+  expect(workerSource).toContain("focusPath");
+  expect(workerSource).not.toContain("childTexts:");
+  const promptReadback = workerSource.slice(
+    workerSource.indexOf("private async attachedPromptText"),
+    workerSource.indexOf("private async promptAttachmentSnapshot"),
+  );
+  expect(promptReadback).not.toContain("cloneNode(true)");
 });
 
 test("browser stage diagnostics use safe bounded artifact names", () => {

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -289,6 +289,34 @@ test("multi-chunk prompt insertion preserves the native caret after each committ
   ]);
 });
 
+test("prompt insertion stops after a stage abort before another native edit", async () => {
+  const prompt = "x".repeat(CHATGPT_PROMPT_INSERT_CHUNK_CHARS * 2 + 1);
+  const controller = new AbortController();
+  const inserted: string[] = [];
+  const page = {
+    keyboard: {
+      insertText: async (value: string) => {
+        inserted.push(value);
+        controller.abort();
+      },
+    },
+  };
+  const insertPromptText = (ChatGptBrowserWorker.prototype as unknown as {
+    insertPromptText(
+      page: unknown,
+      text: string,
+      baseline: { initialUserTurnCount: number; initialAssistantTurnCount: number },
+      abortSignal?: AbortSignal,
+    ): Promise<void>;
+  }).insertPromptText;
+
+  await expect(insertPromptText.call({
+    waitForPromptChunkAttached: async () => {},
+  }, page, prompt, { initialUserTurnCount: 0, initialAssistantTurnCount: 0 }, controller.signal))
+    .rejects.toThrow("aborted");
+  expect(inserted).toHaveLength(1);
+});
+
 test("composer readback removes ignored root nodes before adding block separators", () => {
   expect(composeChatGptPromptReadback([
     { text: "prefix", ignored: false },

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -250,7 +250,7 @@ test("large read-only context is inserted as contiguous low-load edits before ex
   expect(asserted).toBe(prompt);
 });
 
-test("multi-chunk prompt insertion preserves the native caret after each committed prefix", async () => {
+test("multi-chunk prompt insertion re-anchors the DOM caret after each committed prefix", async () => {
   const prompt = "a".repeat(CHATGPT_PROMPT_INSERT_CHUNK_CHARS)
     + "b".repeat(CHATGPT_PROMPT_INSERT_CHUNK_CHARS)
     + "c";
@@ -279,12 +279,14 @@ test("multi-chunk prompt insertion preserves the native caret after each committ
   }, page, prompt);
 
   expect(attached).toBe(prompt);
-  expect(calls.filter(call => call[0] === "reanchor")).toHaveLength(0);
+  expect(calls.filter(call => call[0] === "reanchor")).toHaveLength(2);
   expect(calls).toEqual([
     ["insertText", String(CHATGPT_PROMPT_INSERT_CHUNK_CHARS)],
     ["chunkCommitted", String(CHATGPT_PROMPT_INSERT_CHUNK_CHARS)],
+    ["reanchor"],
     ["insertText", String(CHATGPT_PROMPT_INSERT_CHUNK_CHARS)],
     ["chunkCommitted", String(CHATGPT_PROMPT_INSERT_CHUNK_CHARS * 2)],
+    ["reanchor"],
     ["insertText", "1"],
   ]);
 });

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -257,6 +257,7 @@ test("multi-chunk prompt insertion re-anchors the DOM caret after each committed
   const calls: Array<[string, string?]> = [];
   let attached = "";
   let caret = 0;
+  const simulatedCaretDrift = 13;
   const page = {
     keyboard: {
       insertText: async (value: string) => {
@@ -273,9 +274,13 @@ test("multi-chunk prompt insertion re-anchors the DOM caret after each committed
   await insertPromptText.call({
     waitForPromptChunkAttached: async (_page: unknown, expected: string) => {
       expect(attached).toBe(expected);
+      caret = Math.max(0, attached.length - simulatedCaretDrift);
       calls.push(["chunkCommitted", String(expected.length)]);
     },
-    reanchorPromptCaret: async () => { calls.push(["reanchor"]); },
+    reanchorPromptCaret: async () => {
+      caret = attached.length;
+      calls.push(["reanchor"]);
+    },
   }, page, prompt);
 
   expect(attached).toBe(prompt);

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import type { Page } from "playwright-core";
-import { CHATGPT_PROMPT_INSERT_CHUNK_CHARS, ChatGptBrowserWorker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_TABS, assertChatGptWebInputWithinLimits, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptSubmissionEvidence, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert } from "../src/adapters/chatgpt-web/browser-worker";
+import { CHATGPT_PROMPT_INSERT_CHUNK_CHARS, ChatGptBrowserWorker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_TABS, assertChatGptWebInputWithinLimits, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptSubmissionEvidence, composeChatGptPromptReadback, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert } from "../src/adapters/chatgpt-web/browser-worker";
 import { CHATGPT_CONNECTOR_NAME, defaultChromeExecutable } from "../src/config";
 import { parseChatGptEffortSliderState } from "../src/chatgpt-session";
 
@@ -250,7 +250,7 @@ test("large read-only context is inserted as contiguous low-load edits before ex
   expect(asserted).toBe(prompt);
 });
 
-test("multi-chunk prompt insertion re-anchors the caret after each committed prefix", async () => {
+test("multi-chunk prompt insertion preserves the native caret after each committed prefix", async () => {
   const prompt = "a".repeat(CHATGPT_PROMPT_INSERT_CHUNK_CHARS)
     + "b".repeat(CHATGPT_PROMPT_INSERT_CHUNK_CHARS)
     + "c";
@@ -275,24 +275,31 @@ test("multi-chunk prompt insertion re-anchors the caret after each committed pre
       expect(attached).toBe(expected);
       calls.push(["chunkCommitted", String(expected.length)]);
     },
-    reanchorPromptCaret: async () => {
-      // The editor may rebuild the active Lexical block after a committed chunk. Re-anchor
-      // to the verified prefix end before the next native insertion.
-      caret = attached.length;
-      calls.push(["reanchor"]);
-    },
+    reanchorPromptCaret: async () => { calls.push(["reanchor"]); },
   }, page, prompt);
 
   expect(attached).toBe(prompt);
+  expect(calls.filter(call => call[0] === "reanchor")).toHaveLength(0);
   expect(calls).toEqual([
     ["insertText", String(CHATGPT_PROMPT_INSERT_CHUNK_CHARS)],
     ["chunkCommitted", String(CHATGPT_PROMPT_INSERT_CHUNK_CHARS)],
-    ["reanchor"],
     ["insertText", String(CHATGPT_PROMPT_INSERT_CHUNK_CHARS)],
     ["chunkCommitted", String(CHATGPT_PROMPT_INSERT_CHUNK_CHARS * 2)],
-    ["reanchor"],
     ["insertText", "1"],
   ]);
+});
+
+test("composer readback removes ignored root nodes before adding block separators", () => {
+  expect(composeChatGptPromptReadback([
+    { text: "prefix", ignored: false },
+    { text: "Codex Native2", ignored: true },
+    { text: "suffix", ignored: false },
+  ])).toBe("prefix\nsuffix");
+  expect(composeChatGptPromptReadback([
+    { text: "first", ignored: false },
+    { text: "", ignored: false },
+    { text: "third", ignored: false },
+  ])).toBe("first\n\nthird");
 });
 
 test("caret re-anchor fails closed when the live selection cannot be verified", async () => {
@@ -381,24 +388,57 @@ test("long prompt insertion never divides a UTF-16 surrogate pair", async () => 
 test("intermediate prompt verification never accepts a stable equal-length boundary rewrite", async () => {
   const expected = "x".repeat(CHATGPT_PROMPT_INSERT_CHUNK_CHARS);
   const normalized = `${expected.slice(0, -2)}yz`;
-  let observations = 0;
   const waitForPromptChunkAttached = (ChatGptBrowserWorker.prototype as unknown as {
     waitForPromptChunkAttached(page: unknown, value: string): Promise<void>;
   }).waitForPromptChunkAttached;
-  const exactPromptSnapshot = (ChatGptBrowserWorker.prototype as unknown as {
-    exactPromptSnapshot(page: unknown, value: string): Promise<string>;
-  }).exactPromptSnapshot;
 
   await expect(waitForPromptChunkAttached.call({
-    exactPromptSnapshot,
+    exactPromptSnapshot: async () => normalized,
+  }, {}, expected)).rejects.toThrow("commonPrefixChars=");
+});
+
+test("prompt verification allows a delayed Lexical commit beyond five observations", async () => {
+  const expected = "expected prompt";
+  let observations = 0;
+  const exactPromptSnapshot = (ChatGptBrowserWorker.prototype as unknown as {
+    exactPromptSnapshot(
+      page: unknown,
+      value: string,
+      baseline: { initialUserTurnCount: number; initialAssistantTurnCount: number },
+      timeoutMs?: number,
+    ): Promise<string>;
+  }).exactPromptSnapshot;
+
+  const observed = await exactPromptSnapshot.call({
     waitForPromptComposerSettle: async () => {},
     promptAttachmentSnapshot: async () => {
       observations += 1;
-      return { text: normalized };
+      return { text: observations < 6 ? "pending" : expected };
     },
-  }, {}, expected)).rejects.toThrow("commonPrefixChars=");
+  }, {}, expected, { initialUserTurnCount: 0, initialAssistantTurnCount: 0 }, 5_000);
 
-  expect(observations).toBeLessThanOrEqual(5);
+  expect(observed).toBe(expected);
+  expect(observations).toBe(6);
+});
+
+test("intermediate and final prompt verification retain separate UI deadlines", async () => {
+  const expected = "expected prompt";
+  const timeouts: number[] = [];
+  const exactPromptSnapshot = async (...args: unknown[]) => {
+    timeouts.push(Number(args[3]));
+    return expected;
+  };
+  const waitForPromptChunkAttached = (ChatGptBrowserWorker.prototype as unknown as {
+    waitForPromptChunkAttached(page: unknown, value: string): Promise<void>;
+  }).waitForPromptChunkAttached;
+  const assertPromptAttached = (ChatGptBrowserWorker.prototype as unknown as {
+    assertPromptAttached(page: unknown, value: string): Promise<void>;
+  }).assertPromptAttached;
+
+  await waitForPromptChunkAttached.call({ exactPromptSnapshot }, {}, expected);
+  await assertPromptAttached.call({ exactPromptSnapshot }, {}, expected);
+
+  expect(timeouts).toEqual([20_000, 10_000]);
 });
 
 test("prompt verification stops immediately when ChatGPT submits during insertion", async () => {

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -8,8 +8,8 @@ import { parseChatGptEffortSliderState } from "../src/chatgpt-session";
 test("Codex context uses the owned CDP composer transport, never the operating-system clipboard", () => {
   const workerSource = readFileSync(new URL("../src/adapters/chatgpt-web/browser-worker.ts", import.meta.url), "utf8");
   expect(workerSource).toContain('composer.fill("")');
-  expect(workerSource).toContain("this.insertPromptText(page, prompt, submissionBaseline)");
-  expect(workerSource).toContain("this.insertPromptText(page, ` ${prompt}`, submissionBaseline)");
+  expect(workerSource).toContain("this.insertPromptText(page, prompt, submissionBaseline, abortSignal)");
+  expect(workerSource).toContain("this.insertPromptText(page, ` ${prompt}`, submissionBaseline, abortSignal)");
   expect(workerSource).not.toMatch(/\bclipboard\b|pbcopy|pbpaste/i);
 });
 

--- a/tests/chatgpt-session.test.ts
+++ b/tests/chatgpt-session.test.ts
@@ -19,6 +19,33 @@ test("turn selectors support role nodes without conversation-turn test ids", () 
     .toContain('body:not(:has([data-testid^="conversation-turn-"])) [data-message-author-role="user"]');
 });
 
+test("role-based turn fallback matches the observed no-test-id DOM fixture only", () => {
+  const fixtureHtml = `
+    <main>
+      <article data-message-author-role="user">existing user</article>
+      <article data-message-author-role="assistant">existing assistant</article>
+      <div data-message-author-role="status">not a turn</div>
+    </main>
+  `;
+  const roleCount = (role: "user" | "assistant"): number => (
+    [...fixtureHtml.matchAll(new RegExp(`data-message-author-role="${role}"`, "g"))].length
+  );
+  const hasConversationTurnTestId = /data-testid="conversation-turn-/.test(fixtureHtml);
+
+  expect(hasConversationTurnTestId).toBeFalse();
+  expect(roleCount("user")).toBe(1);
+  expect(roleCount("assistant")).toBe(1);
+  expect(CHATGPT_USER_TURN_SELECTOR).toContain(
+    'body:not(:has([data-testid^="conversation-turn-"])) [data-message-author-role="user"]',
+  );
+  expect(CHATGPT_ASSISTANT_TURN_SELECTOR).toContain(
+    'body:not(:has([data-testid^="conversation-turn-"])) [data-message-author-role="assistant"]',
+  );
+
+  const idBearingFixture = '<article data-testid="conversation-turn-1" data-message-author-role="user"></article>';
+  expect(/data-testid="conversation-turn-/.test(idBearingFixture)).toBeTrue();
+});
+
 test("a complete authenticated composer with no effort selector is Luna-only", async () => {
   const effortButton = {
     last() { return this; },

--- a/tests/chatgpt-session.test.ts
+++ b/tests/chatgpt-session.test.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "bun:test";
 import {
+  CHATGPT_ASSISTANT_TURN_SELECTOR,
   CHATGPT_EFFORT_CONTROL_SELECTOR,
+  CHATGPT_USER_TURN_SELECTOR,
   detectChatGptAccountCapabilities,
 } from "../src/chatgpt-session";
 
@@ -8,6 +10,13 @@ test("the effort selector identifies the model slider instead of any composer me
   expect(CHATGPT_EFFORT_CONTROL_SELECTOR).toContain('[data-animated-slider-trigger="true"]');
   expect(CHATGPT_EFFORT_CONTROL_SELECTOR).toContain('[data-testid="model-switcher-dropdown-button"]');
   expect(CHATGPT_EFFORT_CONTROL_SELECTOR).not.toBe('button[aria-haspopup="menu"]');
+});
+
+test("turn selectors support role nodes without conversation-turn test ids", () => {
+  expect(CHATGPT_ASSISTANT_TURN_SELECTOR)
+    .toContain('body:not(:has([data-testid^="conversation-turn-"])) [data-message-author-role="assistant"]');
+  expect(CHATGPT_USER_TURN_SELECTOR)
+    .toContain('body:not(:has([data-testid^="conversation-turn-"])) [data-message-author-role="user"]');
 });
 
 test("a complete authenticated composer with no effort selector is Luna-only", async () => {


### PR DESCRIPTION
## Summary

Long inline prompts can fail closed when ChatGPT's composer readback differs near a chunk boundary. This PR hardens the transport so altered context is never sent and repairs the Lexical caret transition between verified chunks.

## Scope and invariants

- Scope is limited to the ChatGPT Web browser adapter, prompt/compaction transport, and its regression tests.
- Model selection, reasoning-level selection, Full/Browser-only tool boundaries, Pro read-only behavior, and the official MCP tunnel contract are unchanged.
- No generic provider or unrelated product surface is introduced.
- No selector fallback can choose another model or claim a successful prompt.

## Observed DOM evidence

The live composer and connector UI used by the fix are identified by these observed selectors:

- Composer: `[contenteditable="true"][data-lexical-editor="true"]`
- Connector pill: `[data-id^="plugin:"][data-keyword]`
- Inline cursor target: `[data-inline-selection-pill-cursor-target]`
- Conversation turns when ChatGPT omits conversation-turn test ids: `[data-message-author-role="user|assistant"]`, guarded by `body:not(:has([data-testid^="conversation-turn-"]))`

Representative pre-fix diagnostics contained 16 top-level `<p>` blocks and equal/near-equal length rewrites:

```text
expectedChars=31997, actualChars=31995, commonPrefixChars=15570
selectionPath=[15,1,0], selectionOffset=16425

expectedChars=31929, actualChars=31929, commonPrefixChars=15982
selectionPath=[15,2], selectionOffset=10188
```

Diagnostics record structural node names/lengths and selection paths/offsets only; prompt contents, cookies, tokens, and absolute paths are not recorded.

## Changes

- Bound native composer edits to at most 16,000 UTF-16 code units.
- Prefer nearby whitespace and avoid splitting grapheme boundaries when choosing chunk ends.
- Verify exact normalized composer readback after every intermediate chunk and before send; stable equal-length rewrites are rejected.
- Re-resolve the active composer after connector selection.
- Re-anchor the live DOM Selection/Range after each successfully verified intermediate chunk, inside the final editable paragraph and excluding connector-pill/cursor-target nodes. Whole-document `Control+End` is not used as the chunk anchor.
- Filter connector-pill and inline cursor-target root nodes before adding block separators, while preserving empty paragraphs.
- Restore deadline-based verification (20 seconds for intermediate chunks, 10 seconds for the final prompt).
- Propagate prompt-stage abort signals so a timeout cannot start another native edit.
- Baseline existing user/assistant turns so reused Temporary Chat pages do not look like early submission.
- Keep the turn-role fallback narrowly guarded for pages without conversation-turn test ids; it does not broaden the composer or model selectors.

## Reproducible regression fixtures

`tests/browser-worker-contract.test.ts` includes focused fixtures for:

- `multi-chunk prompt insertion re-anchors the DOM caret after each committed prefix` — deliberately moves the simulated caret 13 UTF-16 units backward after each verified chunk; only the re-anchor callback restores the insertion point to the attached-text end.
- `composer readback removes ignored root nodes before adding block separators`
- `caret re-anchor uses the live Selection API and excludes connector-only nodes`
- `intermediate prompt verification never accepts a stable equal-length boundary rewrite`
- `prompt insertion stops after a stage abort before another native edit`
- `tests/chatgpt-session.test.ts` includes a DOM-shaped fixture for role-based turn fallback when conversation-turn test ids are absent.

## Verification

- `bun install --frozen-lockfile` (repository root): passed; no dependency changes.
- `bun install --frozen-lockfile` (launcher/): passed; no dependency changes.
- `bun run verify` on `8713c8e`: passed (version sync, audit with no vulnerabilities, root tests, launcher tests, typecheck, native launcher build, runtime bundle generation, and release smoke).
- Full `bun test` on `8713c8e`: 500 passed, 1 skipped, 0 failed (501 total).
- Targeted browser-worker/session tests on `8713c8e`: 71 passed, 0 failed.
- Root and launcher typechecks: passed.
- Runtime and launcher builds: passed.
- `git diff --check`: passed.
- A Windows packaged-build run completed automatic compaction after the per-chunk re-anchor. This is one live run, not a cross-platform E2E matrix.

## Safety and remaining validation gap

No cookies, browser state, tunnel ids, API keys, Codex history, absolute user paths, or generated logs are part of the diff. Terms and trademark references remain factual; the PR does not claim quota or rate-limit bypass.

The generated installer was packaged but was not executed by this development session, and `smoke:package` was not run. Cross-platform live ChatGPT/Lexical coverage remains a maintainer/CI concern. Bun runtime/version and first-launch Windows EPERM changes remain outside this PR.

Related to #103

Fixes #105 — long-prompt composer integrity and automatic-compaction failures.
