### PR TITLE
Fix macOS login reuse and embedded authentication

### DIFF
--- a/launcher/electron/browser-host.cjs
+++ b/launcher/electron/browser-host.cjs
@@ -1330,12 +1330,29 @@ class BrowserHost {
       this.setState({ status: "signed-out", message: "Sign in to ChatGPT", authenticated: false, url });
       return this.snapshot();
     }
-    const probe = (contents) => contents.executeJavaScript(`(() => {
+    const probe = (contents) => contents.executeJavaScript(`(async () => {
       const composer = ${visibleElementScript(COMPOSER_SELECTOR)};
-      return { composer: Boolean(composer), readyState: document.readyState };
-    })()`, true).catch(() => ({ composer: false, readyState: "unknown" }));
+      let sessionAuthenticated = false;
+      try {
+        const response = await fetch("/api/auth/session", {
+          cache: "no-store",
+          credentials: "include",
+        });
+        if (response.ok) {
+          const session = await response.json();
+          sessionAuthenticated = Boolean(
+            session
+            && typeof session === "object"
+            && !Array.isArray(session)
+            && session.user
+            && typeof session.user === "object"
+          );
+        }
+      } catch {}
+      return { composer: Boolean(composer), sessionAuthenticated, readyState: document.readyState };
+    })()`, true).catch(() => ({ composer: false, sessionAuthenticated: false, readyState: "unknown" }));
     const result = await probe(this.view.webContents);
-    if (result.composer) {
+    if (result.composer && result.sessionAuthenticated) {
       const wasAuthenticated = this.state.authenticated;
       const availability = this.activeTraceId
         ? { status: "running", message: "ChatGPT is working" }

--- a/launcher/electron/browser-host.cjs
+++ b/launcher/electron/browser-host.cjs
@@ -83,6 +83,21 @@ function visibleElementScript(selector) {
   })`;
 }
 
+function chromeCompatibleUserAgent(value) {
+  if (typeof value !== "string" || !value) {
+    throw new Error("Electron session returned an invalid user agent");
+  }
+  return value
+    .replace(/\sElectron\/[^\s]+/g, "")
+    .replace(/\sCodexWebGPT\/[^\s]+/g, "");
+}
+
+function applyChromeCompatibleUserAgent(contents) {
+  const userAgent = chromeCompatibleUserAgent(contents.session.getUserAgent());
+  contents.session.setUserAgent(userAgent);
+  contents.setUserAgent(userAgent);
+}
+
 function normalizeBounds(bounds) {
   const read = (value) => Number.isFinite(value) ? Math.max(0, Math.round(value)) : 0;
   return {
@@ -119,6 +134,11 @@ function isTemporaryChatUrl(value) {
   return parsed.origin === CHATGPT_ORIGIN
     && parsed.pathname === "/"
     && parsed.searchParams.get("temporary-chat") === "true";
+}
+
+function isSupersededSystemBrowserImportNavigation(error) {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("ERR_FAILED (-2)") && message.includes(TEMPORARY_CHAT_URL);
 }
 
 function isChatGptBackendUrl(value) {
@@ -327,6 +347,10 @@ class BrowserHost {
         backgroundThrottling: true,
       },
     });
+    // ChatGPT redirects an otherwise valid imported session to /auth/login when Chromium's
+    // user agent includes Electron's product token. Keep Chromium's real version and platform,
+    // but remove only the compatibility-breaking application tokens from every owned view.
+    applyChromeCompatibleUserAgent(this.view.webContents);
     window.contentView.addChildView(this.view);
     this.view.setBounds(this.bounds);
     this.view.setVisible(false);
@@ -395,6 +419,7 @@ class BrowserHost {
         backgroundThrottling: false,
       },
     });
+    applyChromeCompatibleUserAgent(view.webContents);
     const tab = {
       id,
       surfaceId,
@@ -590,6 +615,11 @@ class BrowserHost {
 
   routeAuthenticationToSystemBrowser(url) {
     if (!allowedAuthUrl(url)) return false;
+    // The verified system-browser transfer can legitimately traverse ChatGPT's auth endpoints
+    // while the imported cookies establish the Electron session. Blocking that redirect starts
+    // another login operation and aborts the in-flight load with ERR_FAILED (-2). Keep ordinary
+    // embedded authentication fail-closed, but allow this bounded, already-verified import path.
+    if (this.systemBrowserLoginImportActive === true) return false;
     void this.openLogin({ force: true }).catch((error) => {
       this.logger.error("browser.system_login_failed", {
         message: error instanceof Error ? error.message : String(error),
@@ -1166,6 +1196,16 @@ class BrowserHost {
     if (failure) throw failure;
   }
 
+  async loadImportedTemporaryChat(contents) {
+    try {
+      await contents.loadURL(TEMPORARY_CHAT_URL);
+    } catch (error) {
+      if (!isSupersededSystemBrowserImportNavigation(error)) throw error;
+      this.logger.warn("browser.system_login_navigation_superseded");
+    }
+    return await this.waitForAuthenticated(60_000);
+  }
+
   async installSystemBrowserLogin(transfer) {
     if (!transfer || typeof transfer !== "object" || typeof transfer.cleanup !== "function") {
       throw new Error("System-browser login returned an invalid transfer handle");
@@ -1184,13 +1224,14 @@ class BrowserHost {
     const contents = this.view?.webContents;
     if (!primaryError) {
       try {
+        this.systemBrowserLoginImportActive = true;
         if (!contents || contents.isDestroyed()) throw new Error("Owned ChatGPT browser session is unavailable");
         sessionMutated = true;
         await this.clearOwnedChatGptSession();
         for (const cookie of state.cookies) await contents.session.cookies.set(cookie);
         contents.session.flushStorageData();
         await contents.session.cookies.flushStore();
-        await contents.loadURL(TEMPORARY_CHAT_URL);
+        browser = await this.loadImportedTemporaryChat(contents);
         if (state.localStorage.length > 0) {
           const entries = javaScriptLiteral(state.localStorage);
           await contents.executeJavaScript(`(() => {
@@ -1199,9 +1240,8 @@ class BrowserHost {
             }
             for (const entry of ${entries}) localStorage.setItem(entry.name, entry.value);
           })()`, true);
-          await contents.loadURL(TEMPORARY_CHAT_URL);
+          browser = await this.loadImportedTemporaryChat(contents);
         }
-        browser = await this.waitForAuthenticated(60_000);
         if (browser?.authenticated !== true) {
           throw new Error("Imported ChatGPT session did not produce an authenticated Electron composer");
         }
@@ -1211,6 +1251,8 @@ class BrowserHost {
         this.logger.info("browser.system_login_imported");
       } catch (error) {
         primaryError = error;
+      } finally {
+        this.systemBrowserLoginImportActive = false;
       }
     }
 
@@ -1477,8 +1519,10 @@ class BrowserHost {
 
 module.exports = {
   allowedAuthUrl,
+  applyChromeCompatibleUserAgent,
   BrowserHost,
   CHATGPT_VIEWPORT_CSS,
+  chromeCompatibleUserAgent,
   IDLE_BROWSER_URL,
   isChatGptCloudflareChallengeResponse,
   isTemporaryChatUrl,

--- a/launcher/tests/browser-host.test.cjs
+++ b/launcher/tests/browser-host.test.cjs
@@ -11,12 +11,45 @@ const {
 } = require("../electron/browser-state.cjs");
 const {
   allowedAuthUrl,
+  applyChromeCompatibleUserAgent,
   BrowserHost,
   CHATGPT_VIEWPORT_CSS,
+  chromeCompatibleUserAgent,
   isChatGptCloudflareChallengeResponse,
   isTemporaryChatUrl,
   validateChatGptStorageState,
 } = require("../electron/browser-host.cjs");
+
+test("ChatGPT browser user agent removes only application product tokens", () => {
+  const electronUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) CodexWebGPT/2.1.8 Chrome/146.0.7680.216 Electron/41.7.1 Safari/537.36";
+
+  assert.equal(
+    chromeCompatibleUserAgent(electronUserAgent),
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.7680.216 Safari/537.36",
+  );
+  assert.equal(
+    chromeCompatibleUserAgent("Mozilla/5.0 Chrome/146.0.7680.216 Safari/537.36"),
+    "Mozilla/5.0 Chrome/146.0.7680.216 Safari/537.36",
+  );
+  assert.throws(() => chromeCompatibleUserAgent(""), /invalid user agent/);
+});
+
+test("ChatGPT browser applies its compatible identity to the session and current contents", () => {
+  const calls = [];
+  const raw = "Mozilla/5.0 CodexWebGPT/2.1.8 Chrome/146.0.7680.216 Electron/41.7.1 Safari/537.36";
+  const contents = {
+    session: {
+      getUserAgent: () => raw,
+      setUserAgent: (value) => calls.push(["session", value]),
+    },
+    setUserAgent: (value) => calls.push(["contents", value]),
+  };
+
+  applyChromeCompatibleUserAgent(contents);
+
+  const expected = "Mozilla/5.0 Chrome/146.0.7680.216 Safari/537.36";
+  assert.deepEqual(calls, [["session", expected], ["contents", expected]]);
+});
 
 test("only an explicit Cloudflare challenge on a ChatGPT backend response triggers recovery", () => {
   assert.equal(isChatGptCloudflareChallengeResponse({
@@ -287,6 +320,25 @@ test("authentication routing is explicit and never opens provider auth as a gene
   );
   await Promise.resolve();
   assert.equal(logins, 1);
+});
+
+test("verified system-browser import may finish an auth redirect without starting another login", async () => {
+  let logins = 0;
+  const fixture = {
+    systemBrowserLoginImportActive: true,
+    openLogin: async () => { logins += 1; },
+    logger: { error() {} },
+  };
+
+  assert.equal(
+    BrowserHost.prototype.routeAuthenticationToSystemBrowser.call(
+      fixture,
+      "https://chatgpt.com/auth/login",
+    ),
+    false,
+  );
+  await Promise.resolve();
+  assert.equal(logins, 0);
 });
 
 test("an auth redirect forces system-browser login even when cached state says authenticated", async () => {
@@ -565,6 +617,52 @@ test("system-browser login proves the Electron composer and cleans transfer stat
   assert.ok(calls.indexOf("verify-electron") > calls.findIndex((call) => Array.isArray(call) && call[0] === "cookie"));
   assert.ok(calls.indexOf("cleanup") > calls.indexOf("verify-electron"));
   assert.equal(calls.at(-1), "cleanup");
+});
+
+test("system-browser import accepts ERR_FAILED only after the Electron composer proves authentication", async () => {
+  const calls = [];
+  const fixture = {
+    logger: { warn: (event) => calls.push(["warn", event]) },
+    waitForAuthenticated: async (timeoutMs) => {
+      calls.push(["verify", timeoutMs]);
+      return { authenticated: true };
+    },
+  };
+  const contents = {
+    loadURL: async () => {
+      throw new Error("ERR_FAILED (-2) loading 'https://chatgpt.com/?temporary-chat=true'");
+    },
+  };
+
+  const result = await BrowserHost.prototype.loadImportedTemporaryChat.call(fixture, contents);
+
+  assert.equal(result.authenticated, true);
+  assert.deepEqual(calls, [
+    ["warn", "browser.system_login_navigation_superseded"],
+    ["verify", 60_000],
+  ]);
+});
+
+test("system-browser import preserves unrelated navigation failures", async () => {
+  let verified = false;
+  const fixture = {
+    logger: { warn() {} },
+    waitForAuthenticated: async () => {
+      verified = true;
+      return { authenticated: true };
+    },
+  };
+  const contents = {
+    loadURL: async () => {
+      throw new Error("ERR_CONNECTION_RESET (-101) loading 'https://chatgpt.com/?temporary-chat=true'");
+    },
+  };
+
+  await assert.rejects(
+    BrowserHost.prototype.loadImportedTemporaryChat.call(fixture, contents),
+    /ERR_CONNECTION_RESET/,
+  );
+  assert.equal(verified, false);
 });
 
 test("failed Electron session import clears partial state and cleans the transfer", async () => {

--- a/launcher/tests/browser-host.test.cjs
+++ b/launcher/tests/browser-host.test.cjs
@@ -452,6 +452,62 @@ test("logout clears only the owned ChatGPT session and returns to the sign-in su
   assert.ok(calls.some(([name]) => name === "show"));
 });
 
+test("a guest composer does not prove launcher authentication", async () => {
+  const calls = [];
+  const fixture = {
+    state: { authenticated: true },
+    activeTraceId: null,
+    manualOperation: null,
+    view: {
+      webContents: {
+        isDestroyed: () => false,
+        getURL: () => "https://chatgpt.com/?temporary-chat=true",
+        executeJavaScript: async script => {
+          calls.push(["script", script]);
+          return { composer: true, sessionAuthenticated: false, readyState: "complete" };
+        },
+      },
+    },
+    setState(patch) { this.state = { ...this.state, ...patch }; },
+    snapshot() { return { ...this.state }; },
+    logger: { info() {} },
+  };
+
+  const result = await BrowserHost.prototype.probeAuthentication.call(fixture);
+
+  assert.equal(result.authenticated, false);
+  assert.equal(result.status, "signed-out");
+  assert.match(calls[0][1], /\/api\/auth\/session/);
+  assert.match(calls[0][1], /session\.user/);
+});
+
+test("launcher authentication requires both a real session and composer", async () => {
+  const fixture = {
+    state: { authenticated: false },
+    activeTraceId: null,
+    manualOperation: null,
+    view: {
+      webContents: {
+        isDestroyed: () => false,
+        getURL: () => "https://chatgpt.com/?temporary-chat=true",
+        executeJavaScript: async () => ({
+          composer: true,
+          sessionAuthenticated: true,
+          readyState: "complete",
+        }),
+      },
+    },
+    setState(patch) { this.state = { ...this.state, ...patch }; },
+    snapshot() { return { ...this.state }; },
+    logger: { info() {} },
+  };
+
+  const result = await BrowserHost.prototype.probeAuthentication.call(fixture);
+
+  assert.equal(result.authenticated, true);
+  assert.equal(result.status, "ready");
+});
+
 test("launcher shutdown persists ChatGPT DOM storage and cookies before browser destruction", async () => {
   const calls = [];
   const fixture = {

--- a/src/browser-login.ts
+++ b/src/browser-login.ts
@@ -1,7 +1,8 @@
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { createServer } from "node:net";
-import { dirname, join, win32 } from "node:path";
+import { homedir } from "node:os";
+import { basename, dirname, join, win32 } from "node:path";
 import {
   chromium,
   type Browser,
@@ -54,6 +55,67 @@ const LOGIN_BROWSER_START_TIMEOUT_MS = 30_000;
 const LOGIN_COMPLETION_TIMEOUT_MS = 10 * 60_000;
 const LOGIN_POLL_INTERVAL_MS = 100;
 const MAX_DEVTOOLS_VERSION_BYTES = 64 * 1024;
+
+function sqliteString(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+export function seedMacChromeLoginProfile(
+  profileDir: string,
+  options: {
+    platform?: NodeJS.Platform;
+    chromeUserDataDir?: string;
+    sqliteExecutable?: string;
+  } = {},
+): boolean {
+  if ((options.platform ?? process.platform) !== "darwin") return false;
+  const chromeUserDataDir = options.chromeUserDataDir
+    ?? join(homedir(), "Library", "Application Support", "Google", "Chrome");
+  const sqliteExecutable = options.sqliteExecutable ?? "/usr/bin/sqlite3";
+  if (!existsSync(sqliteExecutable)) return false;
+
+  let lastUsed: unknown;
+  try {
+    const localState = JSON.parse(readFileSync(join(chromeUserDataDir, "Local State"), "utf8")) as {
+      profile?: { last_used?: unknown };
+    };
+    lastUsed = localState.profile?.last_used;
+  } catch {
+    return false;
+  }
+  if (typeof lastUsed !== "string" || !/^(?:Default|Profile [1-9]\d*)$/.test(lastUsed)) return false;
+
+  const sourceCookies = join(chromeUserDataDir, lastUsed, "Cookies");
+  if (!existsSync(sourceCookies)) return false;
+  const targetProfile = join(profileDir, "Default");
+  const targetCookies = join(targetProfile, "Cookies");
+  mkdirSync(targetProfile, { recursive: true, mode: 0o700 });
+  rmSync(targetCookies, { force: true });
+
+  const backup = spawnSync(sqliteExecutable, [
+    sourceCookies,
+    `.backup ${sqliteString(targetCookies)}`,
+  ], { encoding: "utf8", timeout: 10_000 });
+  if (backup.error || backup.status !== 0 || !existsSync(targetCookies)) {
+    rmSync(targetCookies, { force: true });
+    return false;
+  }
+  const filter = spawnSync(sqliteExecutable, [
+    targetCookies,
+    [
+      "DELETE FROM cookies WHERE NOT (",
+      "host_key = 'chatgpt.com' OR host_key LIKE '%.chatgpt.com' OR ",
+      "host_key = 'openai.com' OR host_key LIKE '%.openai.com'",
+      "); VACUUM;",
+    ].join(""),
+  ], { encoding: "utf8", timeout: 10_000 });
+  if (filter.error || filter.status !== 0) {
+    rmSync(targetCookies, { force: true });
+    return false;
+  }
+  try { chmodSync(targetCookies, 0o600); } catch {}
+  return true;
+}
 
 function delay(ms: number): Promise<void> {
   return new Promise(resolveDelay => setTimeout(resolveDelay, ms));
@@ -332,16 +394,20 @@ export async function loginToChatGpt(
   const profileDir = join(dirname(config.storageStatePath), "login-profile");
   rmSync(profileDir, { recursive: true, force: true });
   mkdirSync(profileDir, { recursive: true, mode: 0o700 });
+  const reusedChromeSession = basename(config.chromeExecutablePath) === "Google Chrome"
+    && seedMacChromeLoginProfile(profileDir);
   // Chrome treats port 0 as an automation signal and exposes navigator.webdriver=true. Reserve a
   // normal loopback port so provider/passkey sign-in stays on Chrome's ordinary browser surface.
   const devToolsPort = await reserveLoopbackPort();
-  process.stdout.write(
-    "A dedicated system Chrome/Chromium window is open. Sign in to ChatGPT and leave it open; transfer continues automatically when the Temporary Chat composer is visible.\n",
-  );
+  process.stdout.write(reusedChromeSession
+    ? "A dedicated Chrome window is reusing the current profile's allowlisted ChatGPT session; transfer continues automatically after verification.\n"
+    : "A dedicated system Chrome/Chromium window is open. Sign in to ChatGPT and leave it open; transfer continues automatically after the authenticated Temporary Chat is verified.\n");
   const loginBrowser = spawn(config.chromeExecutablePath, [
     `--user-data-dir=${profileDir}`,
+    "--profile-directory=Default",
     "--new-window",
     "--disable-background-mode",
+    "--disable-extensions",
     "--remote-debugging-address=127.0.0.1",
     `--remote-debugging-port=${devToolsPort}`,
     "--no-first-run",

--- a/src/chatgpt-session.ts
+++ b/src/chatgpt-session.ts
@@ -41,12 +41,13 @@ export interface ChatGptEffortSliderState {
 export interface ChatGptAuthenticationSurfaceEvidence {
   url: string;
   visibleComposerCount: number;
+  sessionAuthenticated: boolean;
 }
 
 export function chatGptAuthenticationSurfaceReady(
   evidence: ChatGptAuthenticationSurfaceEvidence,
 ): boolean {
-  if (evidence.visibleComposerCount !== 1) return false;
+  if (evidence.visibleComposerCount !== 1 || !evidence.sessionAuthenticated) return false;
   try {
     const actual = new URL(evidence.url);
     const expected = new URL(CHATGPT_TEMPORARY_CHAT_URL);
@@ -59,7 +60,7 @@ export function chatGptAuthenticationSurfaceReady(
 }
 
 export async function isAuthenticatedTemporaryChatPage(page: Page): Promise<boolean> {
-  const evidence = await page.evaluate(({ composerSelector }) => {
+  const evidence = await page.evaluate(async ({ composerSelector }) => {
     const visible = (element: Element): boolean => {
       const style = getComputedStyle(element);
       const bounds = element.getBoundingClientRect();
@@ -70,9 +71,27 @@ export async function isAuthenticatedTemporaryChatPage(page: Page): Promise<bool
         && style.visibility !== "hidden"
         && style.opacity !== "0";
     };
+    let sessionAuthenticated = false;
+    try {
+      const response = await fetch("/api/auth/session", {
+        cache: "no-store",
+        credentials: "include",
+      });
+      if (response.ok) {
+        const session = await response.json();
+        sessionAuthenticated = Boolean(
+          session
+          && typeof session === "object"
+          && !Array.isArray(session)
+          && session.user
+          && typeof session.user === "object",
+        );
+      }
+    } catch {}
     return {
       url: location.href,
       visibleComposerCount: [...document.querySelectorAll(composerSelector)].filter(visible).length,
+      sessionAuthenticated,
     };
   }, { composerSelector: CHATGPT_COMPOSER_SELECTOR }).catch(() => undefined);
   return evidence ? chatGptAuthenticationSurfaceReady(evidence) : false;

--- a/tests/browser-login.test.ts
+++ b/tests/browser-login.test.ts
@@ -1,8 +1,14 @@
 import { expect, test } from "bun:test";
-import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { browserLoginStateExists, loginToChatGpt, loginVerificationMarkerPath } from "../src/browser-login";
+import {
+  browserLoginStateExists,
+  loginToChatGpt,
+  loginVerificationMarkerPath,
+  seedMacChromeLoginProfile,
+} from "../src/browser-login";
 import { CHATGPT_TEMPORARY_CHAT_URL } from "../src/chatgpt-session";
 import { defaultConfig } from "../src/config";
 
@@ -40,6 +46,8 @@ test("login uses one normal Chrome on a non-automation loopback port and never l
     const firstLaunch = launches[0] ?? "";
     expect(firstLaunch).toContain("--new-window");
     expect(firstLaunch).toContain("--user-data-dir=");
+    expect(firstLaunch).toContain("--profile-directory=Default");
+    expect(firstLaunch).toContain("--disable-extensions");
     expect(firstLaunch).toContain("--remote-debugging-address=127.0.0.1");
     const portMatch = firstLaunch.match(/--remote-debugging-port=(\d+)/);
     expect(portMatch).not.toBeNull();
@@ -63,6 +71,41 @@ test("login uses one normal Chrome on a non-automation loopback port and never l
   } finally {
     if (previousLog === undefined) delete process.env.CODEX_LOGIN_ARG_LOG;
     else process.env.CODEX_LOGIN_ARG_LOG = previousLog;
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("macOS login seeds only allowlisted ChatGPT/OpenAI cookies from Chrome's current profile", () => {
+  if (process.platform !== "darwin" || !existsSync("/usr/bin/sqlite3")) return;
+  const root = mkdtempSync(join(tmpdir(), "codex-chatgpt-web-login-seed-"));
+  const chromeRoot = join(root, "Chrome");
+  const sourceProfile = join(chromeRoot, "Profile 1");
+  const targetProfile = join(root, "login-profile");
+  mkdirSync(sourceProfile, { recursive: true });
+  writeFileSync(
+    join(chromeRoot, "Local State"),
+    `${JSON.stringify({ profile: { last_used: "Profile 1" } })}\n`,
+  );
+  const sourceCookies = join(sourceProfile, "Cookies");
+  const create = spawnSync("/usr/bin/sqlite3", [sourceCookies, [
+    "CREATE TABLE cookies(host_key TEXT);",
+    "INSERT INTO cookies VALUES ('.chatgpt.com'), ('auth.openai.com'), ('.google.com'), ('example.com');",
+  ].join("")]);
+  expect(create.status).toBe(0);
+  try {
+    expect(seedMacChromeLoginProfile(targetProfile, { chromeUserDataDir: chromeRoot })).toBe(true);
+    const targetCookies = join(targetProfile, "Default", "Cookies");
+    expect(existsSync(targetCookies)).toBe(true);
+    const read = spawnSync("/usr/bin/sqlite3", [
+      targetCookies,
+      "SELECT host_key FROM cookies ORDER BY host_key;",
+    ], { encoding: "utf8" });
+    expect(read.status).toBe(0);
+    expect(read.stdout.trim().split("\n")).toEqual([".chatgpt.com", "auth.openai.com"]);
+    expect(existsSync(join(targetProfile, "Default", "Login Data"))).toBe(false);
+    expect(existsSync(join(targetProfile, "Default", "History"))).toBe(false);
+    expect(existsSync(join(targetProfile, "Default", "Preferences"))).toBe(false);
+  } finally {
     rmSync(root, { recursive: true, force: true });
   }
 });

--- a/tests/chatgpt-session.test.ts
+++ b/tests/chatgpt-session.test.ts
@@ -20,22 +20,32 @@ test("login requires one atomic Temporary Chat composer observation", async () =
   expect(chatGptAuthenticationSurfaceReady({
     url: "https://chatgpt.com/auth/login",
     visibleComposerCount: 1,
+    sessionAuthenticated: true,
   })).toBe(false);
   expect(chatGptAuthenticationSurfaceReady({
     url: "https://chatgpt.com/?temporary-chat=true",
     visibleComposerCount: 0,
+    sessionAuthenticated: true,
   })).toBe(false);
   expect(chatGptAuthenticationSurfaceReady({
     url: "https://chatgpt.com/?temporary-chat=true",
     visibleComposerCount: 2,
+    sessionAuthenticated: true,
   })).toBe(false);
   expect(chatGptAuthenticationSurfaceReady({
     url: "https://example.com/?temporary-chat=true",
     visibleComposerCount: 1,
+    sessionAuthenticated: true,
   })).toBe(false);
   expect(chatGptAuthenticationSurfaceReady({
     url: "https://chatgpt.com/?temporary-chat=true",
     visibleComposerCount: 1,
+    sessionAuthenticated: false,
+  })).toBe(false);
+  expect(chatGptAuthenticationSurfaceReady({
+    url: "https://chatgpt.com/?temporary-chat=true",
+    visibleComposerCount: 1,
+    sessionAuthenticated: true,
   })).toBe(true);
 
   let evaluations = 0;
@@ -48,6 +58,7 @@ test("login requires one atomic Temporary Chat composer observation", async () =
       return {
         url: "https://chatgpt.com/?temporary-chat=true",
         visibleComposerCount: 1,
+        sessionAuthenticated: true,
       };
     },
   };
@@ -57,6 +68,8 @@ test("login requires one atomic Temporary Chat composer observation", async () =
   expect(callbackSource).toContain("document.querySelectorAll(composerSelector)");
   expect(callbackSource).toContain("bounds.width > 0");
   expect(callbackSource).toContain("bounds.height > 0");
+  expect(callbackSource).toContain('/api/auth/session');
+  expect(callbackSource).toContain("session.user");
 
   const navigatingPage = {
     evaluate: async () => { throw new Error("Execution context was destroyed"); },


### PR DESCRIPTION
## Summary

Fixes the macOS login loop and app exit/error path when the user is already signed in to ChatGPT in Chrome.

Related to #108.

## Root causes

- ChatGPT authentication rejected the Electron/product-marked user agent during imported-session redirects.
- The login check treated the signed-out guest composer as authenticated.
- The private login profile ignored the current Chrome profile's existing ChatGPT session.
- A verified auth redirect could recursively start another login operation and supersede the in-flight navigation.

## Changes

- Use a Chrome-compatible user agent for managed ChatGPT pages.
- Require `/api/auth/session` user evidence plus a visible composer.
- On macOS, detect Chrome's current profile and seed a disposable login profile with allowlisted ChatGPT/OpenAI cookies.
- Exclude passwords, history, extensions, and Chrome preferences.
- Keep the verified import redirect inside the bounded handoff.
- Clear the Electron-owned ChatGPT session before installing transferred state.
- Delete disposable browser state after capture.

## Verification

- Core tests: 312 passed, 0 failed.
- Launcher tests: 185 passed, 0 failed.
- Core typecheck passed.
- Launcher typecheck passed.
- Renderer production build passed.
- `git diff --check` passed.
- Packaged and installed macOS arm64 v2.1.8.
- Live proof on macOS returned `/api/auth/session` status 200 with `authenticated: true`.
- Live user agent contained Chrome only. It excluded Electron and Codex Web GPT markers.
- The installed app remained open and reused the existing Easton Chrome session without another login.

## Security

The temporary Chrome profile contains only allowlisted `chatgpt.com` and `openai.com` cookie rows. It uses owner-only permissions and is deleted after capture. No password database, browsing history, extension data, or Chrome preferences are copied.