### PR TITLE
fix: preserve full harness tool surface

### DIFF
--- a/src/model-catalog.ts
+++ b/src/model-catalog.ts
@@ -93,10 +93,9 @@ export function buildChatGptWebModel(
     // provider cannot decrypt that cross-backend payload, so every routed Web model must stay on
     // the native V1 surface where `message` and `fork_context` remain ordinary Codex context.
     multi_agent_version: "v1",
-    // Keep every routed Web model inside Codex's native code-mode and subagent model registry.
-    // Pro's lack of local computer tools is enforced by the adapter runtime; `requiresPro` is only
-    // an account-entitlement gate and must not make the model disappear from native orchestration.
-    tool_mode: config.mode === "full" ? template.tool_mode : null,
+    // Code mode collapses the outer registry into an exec gateway; routed models need the regular
+    // Responses tool surface so MCP namespaces, deferred tool_search, and custom tools reach us.
+    tool_mode: null,
     upgrade: null,
     default_reasoning_level: route.codexEffort,
     supported_reasoning_levels: [reasoningLevel(template, route.codexEffort, route.displayName)],

--- a/tests/model-catalog.test.ts
+++ b/tests/model-catalog.test.ts
@@ -65,7 +65,7 @@ describe("native /models augmentation", () => {
       expect(model).toMatchObject({
         slug: route.slug,
         display_name: route.displayName,
-        tool_mode: "code_mode_only",
+        tool_mode: null,
         default_reasoning_level: route.codexEffort,
         supported_reasoning_levels: [{ effort: route.codexEffort, description: route.displayName }],
         multi_agent_version: "v1",
@@ -221,7 +221,7 @@ describe("native /models augmentation", () => {
       .filter(model => String(model.slug).startsWith("chatgpt-web/"));
     expect(web.length).toBe(3);
     expect(web.every(model => model.shell_type === "shell_command")).toBe(true);
-    expect(web.every(model => model.tool_mode === "code_mode_only")).toBe(true);
+    expect(web.every(model => model.tool_mode === null)).toBe(true);
   });
 
   test("uses a ChatGPT-visible template even when it is not available to API-key auth", () => {


### PR DESCRIPTION
## Summary

Restores the regular Codex Responses tool surface for routed ChatGPT Web models in Full Harness mode.

Related to #73.

## Root cause

Full-mode routed rows inherited the native template's `tool_mode: "code_mode_only"`. For a Desktop turn, Codex applied that model metadata before creating the `/v1/responses` request, collapsing the outer registry before the bridge could parse or broker it.

The bridge therefore received only the code-mode helper surface rather than the active outer registry. This is earlier than parser, turn broker, or inventory search logic, so those layers cannot reconstruct the missing tools safely.

## Change

Publish routed ChatGPT Web rows with `tool_mode: null`.

This keeps the native template requirement for selecting a tool-capable source row, while letting Full Harness use the normal Responses surface for MCP namespaces, deferred `tool_search`, and custom outer tools. It does not hard-code MCP servers or rebuild a registry.

The existing V1 subagent-registry regression coverage remains unchanged.

## Evidence

A Desktop Full Harness turn previously exposed an inventory of 2 helper tools. With this catalog behavior, a later bounded acceptance exposed 16 entries, loaded Context7 through `tool_search`, and successfully invoked its library lookup tool.

## Testing

- `bun test tests/model-catalog.test.ts` — 11 passed
- root test suite — 311 passed
- root typecheck — passed
- launcher test suite — 160 passed
- launcher typecheck and production build — passed
- `git diff --check` — passed

`bun audit` did not complete in this environment, so `bun run verify` could not finish; this is recorded rather than treated as passing.

## Limit

An arbitrary `pwd` command remained blocked by the connector's existing open-world/destructive safety policy. That is not an inventory regression and is intentionally outside this change.