### PR TITLE
fix: support ChatGPT tool approval cards

### DIFF
--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -168,7 +168,7 @@ export async function resolveChatGptToolConfirmation(
   timeoutMs = CHATGPT_TOOL_CONFIRMATION_TIMEOUT_MS,
   onVisible?: () => Promise<void>,
 ): Promise<boolean> {
-  const dialog = page.locator('[role="dialog"]')
+  const dialog = page.locator('[role="dialog"], [data-testid="tool-approval-card"]')
     .filter({ hasText: `Allow ChatGPT to use ${appName}?` })
     .last();
   if (!await dialog.isVisible().catch(() => false)) return false;

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -1057,7 +1057,10 @@ test("unrelated ChatGPT alerts are not terminal", async () => {
   expect(fixture.pressed).toEqual([]);
 });
 
-function toolConfirmationPage(options: { disappearAfterReads?: number } = {}): {
+function toolConfirmationPage(options: {
+  disappearAfterReads?: number;
+  surface?: "dialog" | "card";
+} = {}): {
   page: Page;
   pressed: string[];
 } {
@@ -1089,8 +1092,20 @@ function toolConfirmationPage(options: { disappearAfterReads?: number } = {}): {
       expect(visible).toBeFalse();
     },
   };
+  const surfaceSelector = options.surface === "card"
+    ? '[data-testid="tool-approval-card"]'
+    : '[role="dialog"]';
+  const hiddenDialog = {
+    filter: () => hiddenDialog,
+    last: () => hiddenDialog,
+    isVisible: async () => false,
+  };
   return {
-    page: { locator: () => dialog } as unknown as Page,
+    page: {
+      locator: (selector: string) => selector.includes(surfaceSelector)
+        ? dialog
+        : hiddenDialog,
+    } as unknown as Page,
     pressed,
   };
 }
@@ -1111,6 +1126,13 @@ test("an unanswered ChatGPT connector approval is denied instead of aborting the
 
 test("explicit connector auto-approval still selects Allow once", async () => {
   const fixture = toolConfirmationPage();
+
+  expect(await resolveChatGptToolConfirmation(fixture.page, "Codex Native", true)).toBeTrue();
+  expect(fixture.pressed).toEqual(["Allow once:Enter"]);
+});
+
+test("auto-approval recognizes the observed non-dialog approval card", async () => {
+  const fixture = toolConfirmationPage({ surface: "card" });
 
   expect(await resolveChatGptToolConfirmation(fixture.page, "Codex Native", true)).toBeTrue();
   expect(fixture.pressed).toEqual(["Allow once:Enter"]);


### PR DESCRIPTION
## Summary

ChatGPT can render a connector confirmation as `div[data-testid="tool-approval-card"]` rather than an element with `role="dialog"`.

Recognize that exact approval-card surface in addition to the legacy dialog while retaining the existing confirmation text filter.

## Observed DOM evidence

A stalled connector confirmation exposed a `div` with:

- `role: null`
- `data-testid: "tool-approval-card"`

The same confirmation flow did not provide a dialog role, so the previous `[role="dialog"]` locator could not recognize the prompt.

## Behavior

- Legacy dialog confirmations remain supported.
- Manual confirmation still waits for user action and denies on timeout.
- Explicit auto-approval still selects only **Allow once**.
- Unmatched UI still fails closed; this does not broaden model or connector selection.

## Tests

- Added a card-only DOM-shaped fixture. It is invisible to the legacy dialog selector, reproducing the regression.
- `bun test tests/browser-worker-contract.test.ts --test-name-pattern 'approval'` — 4 passed
- `bun test tests/browser-worker-contract.test.ts` — 57 passed
- `bun run verify` — passed
- `git diff --check` — passed
