### PR TITLE
fix(browser): tolerate Lexical NBSP prompt readback

### DIFF
--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -748,6 +748,58 @@ export class ChatGptBrowserWorker {
 
   private constructor(private readonly config: ResolvedBrowserConfig) {}
 
+  /**
+   * Lexical/contenteditable may preserve runs of ASCII spaces by exposing some of them as NBSP
+   * through DOM textContent. Treat that DOM-only representation as equivalent only when the
+   * expected U+0020 belongs to a multi-space run. Single spaces, tabs, newlines, intentional
+   * expected NBSP characters, and every other mutation remain exact and fail closed.
+   */
+  private promptCodeUnitEquivalent(
+    expected: string,
+    observed: string,
+    index: number,
+  ): boolean {
+    const expectedUnit = expected[index];
+    const observedUnit = observed[index];
+
+    if (expectedUnit === observedUnit) return true;
+    if (expectedUnit !== " " || observedUnit !== "\u00A0") return false;
+
+    return expected[index - 1] === " " || expected[index + 1] === " ";
+  }
+
+  private promptTextEquivalent(
+    expected: string,
+    observed: string,
+  ): boolean {
+    if (expected.length !== observed.length) return false;
+
+    for (let index = 0; index < expected.length; index += 1) {
+      if (!this.promptCodeUnitEquivalent(expected, observed, index)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private promptEquivalentPrefixLength(
+    expected: string,
+    observed: string,
+  ): number {
+    const length = Math.min(expected.length, observed.length);
+
+    let index = 0;
+    while (
+      index < length
+      && this.promptCodeUnitEquivalent(expected, observed, index)
+    ) {
+      index += 1;
+    }
+
+    return index;
+  }
+
   run(turn: BrowserTurn): Promise<string> {
     if (this.activeRuns.has(turn.traceId)) {
       return Promise.reject(new Error(`Duplicate ChatGPT web browser turn: ${turn.traceId}`));
@@ -1166,12 +1218,11 @@ export class ChatGptBrowserWorker {
       throwIfPromptAttachmentAborted(abortSignal);
       observed = await this.attachedPromptText(page);
       throwIfPromptAttachmentAborted(abortSignal);
-      if (observed === prompt) return;
+      if (this.promptTextEquivalent(prompt, observed)) return;
       await new Promise(resolveSleep => setTimeout(resolveSleep, 50));
     }
     throwIfPromptAttachmentAborted(abortSignal);
-    let commonPrefix = 0;
-    while (commonPrefix < prompt.length && prompt[commonPrefix] === observed[commonPrefix]) commonPrefix += 1;
+    const commonPrefix = this.promptEquivalentPrefixLength(prompt, observed);
     throw new Error(
       `ChatGPT composer did not preserve the complete prompt (expectedChars=${prompt.length}, actualChars=${observed.length}, commonPrefixChars=${commonPrefix})`,
     );
@@ -1432,12 +1483,11 @@ export class ChatGptBrowserWorker {
       throwIfPromptAttachmentAborted(abortSignal);
       observed = await this.attachedPromptText(page);
       throwIfPromptAttachmentAborted(abortSignal);
-      if (observed === expected) return;
+      if (this.promptTextEquivalent(expected, observed)) return;
       await new Promise(resolveSleep => setTimeout(resolveSleep, 100));
     } while (Date.now() < deadline);
     throwIfPromptAttachmentAborted(abortSignal);
-    let commonPrefix = 0;
-    while (commonPrefix < expected.length && expected[commonPrefix] === observed[commonPrefix]) commonPrefix += 1;
+    const commonPrefix = this.promptEquivalentPrefixLength(expected, observed);
     throw new Error(
       `ChatGPT composer did not commit a complete prompt insertion chunk`
       + ` (expectedChars=${expected.length}, actualChars=${observed.length}, commonPrefixChars=${commonPrefix})`,

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -173,6 +173,62 @@ test("active composer resolution waits for exactly one visible editor", async ()
   expect(await activeComposer.call({}, page, 500)).toBe(composer);
 });
 
+test("prompt verification accepts Lexical NBSP preservation without weakening other mismatches", async () => {
+  // This reproduces a live macOS compaction failure where a 16k prompt prefix retained the same
+  // UTF-16 length but Lexical exposed alternating NBSP/ASCII spaces inside a long indentation run.
+  const expected = `prefix C\\n${" ".repeat(24)}suffix`;
+  const observed = `prefix C\\n${"\u00A0 ".repeat(12)}suffix`;
+
+  expect(observed.length).toBe(expected.length);
+  expect(observed).not.toBe(expected);
+
+  const worker = Object.assign(Object.create(ChatGptBrowserWorker.prototype), {
+    attachedPromptText: async () => observed,
+  }) as ChatGptBrowserWorker;
+
+  const promptTextEquivalent = (ChatGptBrowserWorker.prototype as unknown as {
+    promptTextEquivalent(expected: string, observed: string): boolean;
+  }).promptTextEquivalent;
+
+  expect(promptTextEquivalent.call(worker, expected, observed)).toBeTrue();
+
+  // The allowance is intentionally directional and restricted to repeated ASCII-space runs.
+  expect(promptTextEquivalent.call(worker, "a  b", "a\u00A0 b")).toBeTrue();
+  expect(promptTextEquivalent.call(worker, "a b", "a\u00A0b")).toBeFalse();
+  expect(promptTextEquivalent.call(worker, "a\u00A0b", "a b")).toBeFalse();
+
+  // Other whitespace and same-length text mutations must remain fail closed.
+  expect(promptTextEquivalent.call(worker, "a b", "a\tb")).toBeFalse();
+  expect(promptTextEquivalent.call(worker, "a\nb", "a b")).toBeFalse();
+  expect(promptTextEquivalent.call(worker, "abc", "abd")).toBeFalse();
+  expect(promptTextEquivalent.call(worker, "abc", "ab")).toBeFalse();
+
+  const waitForPromptChunkAttached = (ChatGptBrowserWorker.prototype as unknown as {
+    waitForPromptChunkAttached(
+      page: Page,
+      expected: string,
+      abortSignal?: AbortSignal,
+    ): Promise<void>;
+  }).waitForPromptChunkAttached;
+
+  const assertPromptAttached = (ChatGptBrowserWorker.prototype as unknown as {
+    assertPromptAttached(
+      page: Page,
+      prompt: string,
+      abortSignal?: AbortSignal,
+    ): Promise<void>;
+  }).assertPromptAttached;
+
+  // Exercise both verification stages so this is not only a unit test of the comparator.
+  await expect(
+    waitForPromptChunkAttached.call(worker, {} as Page, expected),
+  ).resolves.toBeUndefined();
+
+  await expect(
+    assertPromptAttached.call(worker, {} as Page, expected),
+  ).resolves.toBeUndefined();
+});
+
 test("large read-only context is inserted as contiguous bounded edits before exact verification", async () => {
   const prompt = `Act as the model backend for the Codex task encoded below.\n${"x".repeat(819_343)}`;
   const calls: Array<[string, string?]> = [];


### PR DESCRIPTION
## Summary

This fixes one reproducible prompt verification failure during long prompt insertion and automatic compaction.

ChatGPT's Lexical editor can expose some ASCII spaces (`U+0020`) as non-breaking spaces (`U+00A0`) in `textContent` when they are part of a repeated-space run. The inserted prompt is still the same length and the visible text is unchanged, but the adapter currently compares the DOM readback with the expected prompt using exact UTF-16 equality.

That makes a DOM representation detail look like prompt corruption, so the adapter aborts before submission.

This patch accepts that one observed Lexical transformation while keeping the rest of prompt verification strict.

## What I observed

A real automatic compaction failure on macOS produced:

```text
ChatGPT composer did not commit a complete prompt insertion chunk
(expectedChars=16000, actualChars=16000, commonPrefixChars=15818)
```

I added temporary local diagnostics around the first mismatch. The expected prompt contained a run of ASCII spaces:

```text
... U+0043 U+005C U+006E
U+0020 U+0020 U+0020 U+0020 U+0020 ...
```

The DOM readback contained the same-length run with alternating NBSP and ASCII spaces:

```text
... U+0043 U+005C U+006E
U+00A0 U+0020 U+00A0 U+0020 U+00A0 ...
```

The surrounding text was unchanged.

NFC and NFD normalization did not make the strings equal. That is expected because `U+00A0` is not canonically equivalent to `U+0020`.

The temporary diagnostics are not part of this PR.

## Fix

Prompt verification now treats observed `U+00A0` as equivalent to expected `U+0020` only when the expected space belongs to a run of at least two ASCII spaces.

The same comparison is used for:

- intermediate chunk verification
- final prompt verification
- common-prefix calculation used in failure diagnostics

The rule is directional and narrow.

Accepted:

```text
expected: "a  b"
observed: "a<NBSP> b"
```

Rejected:

```text
expected: "a b"
observed: "a<NBSP>b"
```

Also rejected:

```text
expected: "a<NBSP>b"
observed: "a b"
```

Tabs, newlines, missing characters, reordered text, length changes, and normal text mutations still fail verification.

The patch does not modify the prompt before insertion and does not normalize whitespace globally.

## Why only repeated spaces

The failure I captured happened inside a long indentation run. That matches how `contenteditable` editors may preserve consecutive spaces in DOM text.

Treating every ASCII space and NBSP as interchangeable would hide changes that the verifier should catch. Limiting the exception to repeated expected ASCII spaces covers the observed Lexical behavior without weakening normal single-space checks or intentional NBSP content.

## Tests

The regression test reproduces the captured failure with equal-length strings and alternating `U+00A0` / `U+0020` inside a repeated-space run.

It also checks that:

- intermediate chunk verification accepts the Lexical representation
- final prompt verification accepts the same representation
- a single-space `U+0020 -> U+00A0` change is rejected
- `U+00A0 -> U+0020` is rejected
- tab and newline changes are rejected
- text mutations are rejected
- length mismatches are rejected

Validation:

```text
bun install --frozen-lockfile
(cd launcher && bun install --frozen-lockfile)
bun run typecheck
bun test tests/browser-worker-contract.test.ts
bun run verify
```

## Related issues

This is related to:

- #105
- #122
- #125

It fixes the same-length `U+0020 -> U+00A0` prompt readback failure described above.

It does not fix separate failures where the composer is cleared or replaced, such as `expectedChars=16000, actualChars=0`. It also does not address manual-submit continuation reconciliation from #122.
