### PR TITLE
fix(browser): handle NBSP at prompt chunk boundary

### DIFF
--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -758,6 +758,7 @@ export class ChatGptBrowserWorker {
     expected: string,
     observed: string,
     index: number,
+    nextExpectedUnit?: string,
   ): boolean {
     const expectedUnit = expected[index];
     const observedUnit = observed[index];
@@ -765,17 +766,20 @@ export class ChatGptBrowserWorker {
     if (expectedUnit === observedUnit) return true;
     if (expectedUnit !== " " || observedUnit !== "\u00A0") return false;
 
-    return expected[index - 1] === " " || expected[index + 1] === " ";
+    return expected[index - 1] === " "
+      || expected[index + 1] === " "
+      || (index === expected.length - 1 && nextExpectedUnit === " ");
   }
 
   private promptTextEquivalent(
     expected: string,
     observed: string,
+    nextExpectedUnit?: string,
   ): boolean {
     if (expected.length !== observed.length) return false;
 
     for (let index = 0; index < expected.length; index += 1) {
-      if (!this.promptCodeUnitEquivalent(expected, observed, index)) {
+      if (!this.promptCodeUnitEquivalent(expected, observed, index, nextExpectedUnit)) {
         return false;
       }
     }
@@ -786,13 +790,14 @@ export class ChatGptBrowserWorker {
   private promptEquivalentPrefixLength(
     expected: string,
     observed: string,
+    nextExpectedUnit?: string,
   ): number {
     const length = Math.min(expected.length, observed.length);
 
     let index = 0;
     while (
       index < length
-      && this.promptCodeUnitEquivalent(expected, observed, index)
+      && this.promptCodeUnitEquivalent(expected, observed, index, nextExpectedUnit)
     ) {
       index += 1;
     }
@@ -1465,7 +1470,7 @@ export class ChatGptBrowserWorker {
         // Lexical can rebuild the active block after an exact commit and move its native selection.
         // Re-anchor only after the verified prefix is stable, before the next irreversible edit.
         const expectedPrefix = text.slice(0, end).trimStart();
-        await this.waitForPromptChunkAttached(page, expectedPrefix, abortSignal);
+        await this.waitForPromptChunkAttached(page, expectedPrefix, abortSignal, text[end]);
         await this.reanchorPromptCaret(page, abortSignal);
       }
       offset = end;
@@ -1476,6 +1481,7 @@ export class ChatGptBrowserWorker {
     page: Page,
     expected: string,
     abortSignal?: AbortSignal,
+    nextExpectedUnit?: string,
   ): Promise<void> {
     const deadline = Date.now() + 20_000;
     let observed = "";
@@ -1483,11 +1489,11 @@ export class ChatGptBrowserWorker {
       throwIfPromptAttachmentAborted(abortSignal);
       observed = await this.attachedPromptText(page);
       throwIfPromptAttachmentAborted(abortSignal);
-      if (this.promptTextEquivalent(expected, observed)) return;
+      if (this.promptTextEquivalent(expected, observed, nextExpectedUnit)) return;
       await new Promise(resolveSleep => setTimeout(resolveSleep, 100));
     } while (Date.now() < deadline);
     throwIfPromptAttachmentAborted(abortSignal);
-    const commonPrefix = this.promptEquivalentPrefixLength(expected, observed);
+    const commonPrefix = this.promptEquivalentPrefixLength(expected, observed, nextExpectedUnit);
     throw new Error(
       `ChatGPT composer did not commit a complete prompt insertion chunk`
       + ` (expectedChars=${expected.length}, actualChars=${observed.length}, commonPrefixChars=${commonPrefix})`,

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -187,7 +187,7 @@ test("prompt verification accepts Lexical NBSP preservation without weakening ot
   }) as ChatGptBrowserWorker;
 
   const promptTextEquivalent = (ChatGptBrowserWorker.prototype as unknown as {
-    promptTextEquivalent(expected: string, observed: string): boolean;
+    promptTextEquivalent(expected: string, observed: string, nextExpectedUnit?: string): boolean;
   }).promptTextEquivalent;
 
   expect(promptTextEquivalent.call(worker, expected, observed)).toBeTrue();
@@ -196,6 +196,8 @@ test("prompt verification accepts Lexical NBSP preservation without weakening ot
   expect(promptTextEquivalent.call(worker, "a  b", "a\u00A0 b")).toBeTrue();
   expect(promptTextEquivalent.call(worker, "a b", "a\u00A0b")).toBeFalse();
   expect(promptTextEquivalent.call(worker, "a\u00A0b", "a b")).toBeFalse();
+  expect(promptTextEquivalent.call(worker, "a ", "a\u00A0", " ")).toBeTrue();
+  expect(promptTextEquivalent.call(worker, "a ", "a\u00A0", "x")).toBeFalse();
 
   // Other whitespace and same-length text mutations must remain fail closed.
   expect(promptTextEquivalent.call(worker, "a b", "a\tb")).toBeFalse();
@@ -315,6 +317,42 @@ test("multi-chunk prompt insertion repairs a drifted Lexical caret after each ex
     ["reanchor"],
     ["insertText", "457"],
   ]);
+});
+
+test("multi-chunk prompt insertion accepts Lexical NBSP when a space run crosses the chunk boundary", async () => {
+  const prompt = "a".repeat(CHATGPT_PROMPT_INSERT_CHUNK_CHARS - 1)
+    + "  tail";
+  const inserted: string[] = [];
+  let attached = "";
+  let reanchorCount = 0;
+  const page = {
+    keyboard: {
+      insertText: async (value: string) => {
+        inserted.push(value);
+        attached += value;
+      },
+    },
+  };
+  const worker = Object.assign(Object.create(ChatGptBrowserWorker.prototype), {
+    attachedPromptText: async () => attached.length === CHATGPT_PROMPT_INSERT_CHUNK_CHARS
+      ? `${attached.slice(0, -1)}\u00A0`
+      : attached,
+    reanchorPromptCaret: async () => {
+      reanchorCount += 1;
+    },
+  }) as ChatGptBrowserWorker;
+  const insertPromptText = (ChatGptBrowserWorker.prototype as unknown as {
+    insertPromptText(page: unknown, text: string): Promise<void>;
+  }).insertPromptText;
+
+  await insertPromptText.call(worker, page, prompt);
+
+  expect(inserted).toEqual([
+    prompt.slice(0, CHATGPT_PROMPT_INSERT_CHUNK_CHARS),
+    prompt.slice(CHATGPT_PROMPT_INSERT_CHUNK_CHARS),
+  ]);
+  expect(attached).toBe(prompt);
+  expect(reanchorCount).toBe(1);
 });
 
 test("prompt insertion never sends the six-figure native edit that rewrites the first 100k prefix", async () => {


### PR DESCRIPTION
Follow-up to #130.

## Summary

Fixes a remaining Lexical NBSP edge case where a multi-space sequence crosses a prompt insertion chunk boundary.

## Problem

Prompt insertion is split into bounded **16,000-character chunks**.

A remaining edge case occurs when a chunk boundary falls between two ASCII spaces in the same multi-space run.

For example, given a prompt with **15,999 characters followed by two spaces**:

```text
aaaaaaaa...aaaaaaaa  tail
                      ^^
```

the prompt is split into:

```text
Chunk 1: <15,999 chars><space>
Chunk 2: <space>tail
```

After inserting Chunk 1, the expected intermediate prefix ends with an ASCII space:

```text
Expected:
...aaaa<space>
```

However, Lexical may expose that trailing space through `textContent` as an NBSP:

```text
Observed:
...aaaa<NBSP>
```

PR #130 allows **ASCII space → NBSP equivalence** when the space belongs to a multi-space run.

At this intermediate verification point, however, the comparator only sees Chunk 1. It cannot see that Chunk 2 begins with another ASCII space.

As a result, the trailing space appears to be an isolated single space. The NBSP readback is therefore rejected, causing prompt insertion to stall:

```text
insert chunk 1
    ↓
verify committed prefix
    ↓
ASCII space vs NBSP mismatch
    ↓
verification timeout
    ↓
chunk 2 is never inserted
```

The full prompt contains enough context to determine that the trailing space is part of a multi-space run. That context was simply unavailable during intermediate prefix verification.

## Fix

Pass the **next expected code unit from the full prompt** into intermediate chunk verification.

This provides the comparator with enough lookahead to recognize a multi-space run that crosses a chunk boundary.

ASCII space → NBSP equivalence is allowed at the boundary **only when the next expected character is also an ASCII space**.

This preserves the existing fail-closed behavior for:

* isolated single spaces,
* unrelated whitespace changes, and
* other unexpected NBSP substitutions.

Final full-prompt verification remains unchanged.

## Tests

Added regression coverage verifying that:

* NBSP readback is accepted when a multi-space run crosses a chunk boundary.
* NBSP remains rejected when the following expected character is not a space.
* After successful verification, prompt insertion continues with caret re-anchoring and insertion of the next chunk.