### PR TITLE
fix(browser): recover effort slider after popover rerender

### DIFF
--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -43,6 +43,7 @@ import {
   CHATGPT_USER_TURN_SELECTOR,
   detectChatGptAccountCapabilities,
   parseChatGptEffortSliderState,
+  visibleChatGptEffortSliderSnapshot,
 } from "../../chatgpt-session";
 import { loginVerificationMarkerPath } from "../../browser-login";
 import {
@@ -1026,10 +1027,30 @@ export class ChatGptBrowserWorker {
       waitAbort.abort();
     }
     if (ready === "slider") {
+      const readEffortSliderSnapshot = async () => {
+        const snapshotDeadline = Date.now() + 5_000;
+        let snapshot = await visibleChatGptEffortSliderSnapshot(page);
+        while (!snapshot && Date.now() < snapshotDeadline) {
+          const visible = await effortMenu.isVisible().catch(() => false);
+          const expanded = await currentEffort.getAttribute("aria-expanded").catch(() => null);
+          if (!visible && expanded !== "true") {
+            await throwIfChatGptRateLimitDialog(page);
+            await currentEffort.press("Enter");
+          }
+          await new Promise(resolveSleep => setTimeout(resolveSleep, 50));
+          snapshot = await visibleChatGptEffortSliderSnapshot(page);
+        }
+        if (snapshot) return snapshot;
+        throw new ChatGptWebAdapterError(
+          "ChatGPT effort slider disappeared before its ARIA state could be read",
+          { status: 502, errorType: "server_error", code: "upstream_server_error", retryable: false },
+        );
+      };
+      let sliderSnapshot = await readEffortSliderSnapshot();
       let sliderState = parseChatGptEffortSliderState(
-        await effortSlider.getAttribute("aria-valuemin"),
-        await effortSlider.getAttribute("aria-valuemax"),
-        await effortSlider.getAttribute("aria-valuenow"),
+        sliderSnapshot.rawMin,
+        sliderSnapshot.rawMax,
+        sliderSnapshot.rawValue,
       );
       if (!sliderState) {
         throw new ChatGptWebAdapterError(
@@ -1054,10 +1075,11 @@ export class ChatGptBrowserWorker {
         await sliderControl.press(key);
         const changeDeadline = Date.now() + 5_000;
         do {
+          sliderSnapshot = await readEffortSliderSnapshot();
           sliderState = parseChatGptEffortSliderState(
-            await effortSlider.getAttribute("aria-valuemin"),
-            await effortSlider.getAttribute("aria-valuemax"),
-            await effortSlider.getAttribute("aria-valuenow"),
+            sliderSnapshot.rawMin,
+            sliderSnapshot.rawMax,
+            sliderSnapshot.rawValue,
           );
           if (!sliderState) throw new Error("ChatGPT effort slider lost its semantic ARIA state");
           if (sliderState.value !== previousValue) break;

--- a/src/chatgpt-session.ts
+++ b/src/chatgpt-session.ts
@@ -38,6 +38,12 @@ export interface ChatGptEffortSliderState {
   value: number;
 }
 
+export interface ChatGptEffortSliderSnapshot {
+  rawMin: string | null;
+  rawMax: string | null;
+  rawValue: string | null;
+}
+
 function safeIntegerAttribute(value: string | null): number | undefined {
   if (value === null || !/^-?\d+$/.test(value)) return undefined;
   const parsed = Number(value);
@@ -57,6 +63,30 @@ export function parseChatGptEffortSliderState(
   if (optionCount < 1 || optionCount > CHATGPT_EFFORT_SLIDER_MAX_OPTIONS) return undefined;
   if (value < min || value > max) return undefined;
   return { min, max, value };
+}
+
+/**
+ * Read the visible slider attributes in one browser evaluation. ChatGPT can
+ * replace or close the effort popover immediately after Playwright observes it
+ * as visible, so separate locator attribute reads can otherwise wait on a
+ * locator that no longer resolves.
+ */
+export async function visibleChatGptEffortSliderSnapshot(
+  page: Page,
+): Promise<ChatGptEffortSliderSnapshot | undefined> {
+  return await page.evaluate((selector) => {
+    const sliders = Array.from(document.querySelectorAll<HTMLElement>(selector));
+    const slider = sliders.filter((element) => {
+      const style = window.getComputedStyle(element);
+      return style.visibility !== "hidden" && element.getClientRects().length > 0;
+    }).at(-1);
+    if (!slider) return undefined;
+    return {
+      rawMin: slider.getAttribute("aria-valuemin"),
+      rawMax: slider.getAttribute("aria-valuemax"),
+      rawValue: slider.getAttribute("aria-valuenow"),
+    };
+  }, CHATGPT_EFFORT_SLIDER_SELECTOR);
 }
 
 async function anyVisible(locator: Locator): Promise<boolean> {

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -923,11 +923,85 @@ test("effort selection uses structural menu and slider indices instead of locali
   expect(sessionSource).not.toContain("data-radix-collection-item");
   expect(workerSource).toContain('getAttribute("aria-checked")');
   expect(workerSource).toContain('getAttribute("aria-expanded")');
-  expect(workerSource).toContain('getAttribute("aria-valuenow")');
+  expect(sessionSource).toContain('getAttribute("aria-valuenow")');
   expect(workerSource).toContain("sliderControl.press(key)");
   expect(workerSource).not.toContain("currentLabel === targetLabel");
   expect(workerSource).not.toContain("chatGptEffortLabelsMatch");
   expect(workerSource).not.toMatch(/getByRole\("button", \{\s*name: "(?:Instant|Medium|High|Extra High|Pro)"/);
+});
+
+test("effort selection reopens a slider popover that closes before its ARIA snapshot", async () => {
+  let effortButtonPresses = 0;
+  let snapshotReads = 0;
+  const neverVisible = (signal?: AbortSignal) => new Promise<void>((_resolve, reject) => {
+    signal?.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+  });
+  const hiddenDialog = {
+    filter() { return this; },
+    last() { return this; },
+    isVisible: async () => false,
+    waitFor: async ({ signal }: { signal?: AbortSignal }) => await neverVisible(signal),
+  };
+  const currentEffort = {
+    last() { return this; },
+    waitFor: async () => undefined,
+    getAttribute: async () => "false",
+    press: async () => { effortButtonPresses += 1; },
+  };
+  const sliderControl = { press: async () => undefined };
+  const effortSlider = {
+    filter() { return this; },
+    last() { return this; },
+    waitFor: async () => undefined,
+    locator: () => sliderControl,
+  };
+  const effortChoice = {
+    waitFor: async ({ signal }: { signal?: AbortSignal }) => await neverVisible(signal),
+  };
+  const effortChoices = {
+    nth: () => effortChoice,
+    count: async () => 0,
+  };
+  const effortMenu = {
+    last() { return this; },
+    isVisible: async () => false,
+    locator: () => effortChoices,
+  };
+  const composerForm = { locator: () => currentEffort };
+  const composer = { locator: () => composerForm };
+  const page = {
+    locator: (selector: string) => {
+      if (selector.includes("composer-intelligence-picker-content")) return effortMenu;
+      if (selector.includes("data-model-reasoning-effort-slider")) return effortSlider;
+      return hiddenDialog;
+    },
+    evaluate: async () => {
+      snapshotReads += 1;
+      return snapshotReads === 1
+        ? undefined
+        : { rawMin: "0", rawMax: "4", rawValue: "2" };
+    },
+    keyboard: { press: async () => undefined },
+  };
+  const selectModelAndEffort = (ChatGptBrowserWorker.prototype as unknown as {
+    selectModelAndEffort(
+      page: unknown,
+      modelId: string,
+      reasoning: string,
+      capabilities: { localToolsEnabled: boolean; solAvailable: boolean; proAvailable: boolean },
+    ): Promise<{ displayLabel: string; uiEffortIndex: number | null }>;
+  }).selectModelAndEffort;
+
+  const mode = await selectModelAndEffort.call({
+    activeComposer: async () => composer,
+  }, page, CHATGPT_WEB_MODEL_ID, "high", {
+    localToolsEnabled: false,
+    solAvailable: true,
+    proAvailable: true,
+  });
+  expect(mode).toMatchObject({ uiEffortIndex: 2 });
+  expect(snapshotReads).toBe(2);
+  expect(effortButtonPresses).toBe(2);
 });
 
 test("effort slider ARIA state fails closed on malformed and unsupported ranges", () => {


### PR DESCRIPTION
## Summary

- capture the visible effort slider's ARIA range atomically in the browser document
- reopen the effort menu for a bounded retry when ChatGPT replaces or closes the popover
- reuse the same recovery path after keyboard slider movement
- cover the visible-then-disappearing popover lifecycle with a regression test

## Why

ChatGPT can replace or close the effort popover immediately after Playwright observes the slider as visible. The existing locator is filtered to visible elements, so three later `getAttribute` calls can wait 30 seconds on a locator that no longer resolves. This makes launcher smoke tests and normal model selection intermittently fail even though the selector itself is still correct.

The new browser-document snapshot reads all three ARIA attributes in one evaluation. If the popover disappeared first, model selection reopens it for up to five seconds and then fails closed with a structured upstream error.

## Scope boundary

This PR fixes effort-popover selection only. Later Sub2API and BYOK Chat canaries exposed a separate intermittent failure after submission: ChatGPT can remove the active assistant response DOM before the bridge observes terminal completion, producing `ChatGPT response DOM disappeared while the browser turn was active`. That response-lifecycle problem needs a separate regression and follow-up change; it is not evidence that this effort-selector fix failed.


## Verification

- `bun run verify`
  - 315 runtime tests passed
  - 160 launcher tests passed
  - audit, typechecks, launcher build, runtime bundle, notices, and release smoke passed
- live authenticated launcher smoke with the menu initially closed returned `CODEX WEB GPT READY` at High effort

