### PR TITLE
fix(browser): stabilize replaced and mutable response turns

### DIFF
--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -84,6 +84,7 @@ export const CHATGPT_EMPTY_RESPONSE_GRACE_MS = 10_000;
 export const CHATGPT_COMPLETION_ACTION_GRACE_MS = 60_000;
 export const CHATGPT_COMPLETION_SETTLE_MS = 2_000;
 export const CHATGPT_TOOL_CONFIRMATION_TIMEOUT_MS = 60_000;
+const CHATGPT_CONVERSATION_TURN_SELECTOR = '[data-testid^="conversation-turn-"]';
 const CHATGPT_SMOKE_TEXT = "Reply with exactly: CODEX WEB GPT READY";
 const CHATGPT_SMOKE_EXPECTED = "CODEX WEB GPT READY";
 /**
@@ -336,6 +337,28 @@ export function chatGptSubmissionEvidence(state: {
   if (state.userTurnCount > state.initialUserTurnCount) return "user_turn";
   if (state.assistantTurnCount > state.initialAssistantTurnCount) return "assistant_turn";
   if (state.generationRunning) return "generation_running";
+  return undefined;
+}
+
+export interface ChatGptConversationTurnDescriptor {
+  testId: string | null;
+  isUser: boolean;
+  hasResponseEvidence: boolean;
+}
+
+export function chatGptCurrentResponseTurnIndex(
+  turns: readonly ChatGptConversationTurnDescriptor[],
+  initialTurnIds: readonly string[],
+): number | undefined {
+  const initial = new Set(initialTurnIds);
+  const currentUserIndex = turns.findLastIndex(turn => turn.isUser);
+  for (let index = turns.length - 1; index > currentUserIndex; index -= 1) {
+    const turn = turns[index]!;
+    if (turn.testId
+      && !turn.isUser
+      && turn.hasResponseEvidence
+      && !initial.has(turn.testId)) return index;
+  }
   return undefined;
 }
 
@@ -1164,7 +1187,8 @@ export class ChatGptBrowserWorker {
     page: Page,
     userTurns: Locator,
     responseTurns: Locator,
-    responseTurn: Locator,
+    conversationTurns: Locator,
+    initialConversationTurnIds: readonly string[],
     initialUserTurnCount: number,
     initialResponseTurnCount: number,
     signal?: AbortSignal,
@@ -1174,7 +1198,11 @@ export class ChatGptBrowserWorker {
     for (;;) {
       if (signal?.aborted) throw new DOMException("ChatGPT web turn aborted", "AbortError");
       await throwIfChatGptSessionFailureAlert(page);
-      await throwIfChatGptTerminalErrorAlert(responseTurn);
+      const responseTurn = await this.currentResponseTurn(
+        conversationTurns,
+        initialConversationTurnIds,
+      );
+      if (responseTurn) await throwIfChatGptTerminalErrorAlert(responseTurn);
       const [userTurnCount, assistantTurnCount, visibleStopButtonCount] = await Promise.all([
         userTurns.count(),
         responseTurns.count(),
@@ -1190,6 +1218,32 @@ export class ChatGptBrowserWorker {
       if (evidence) return evidence;
       await new Promise(resolveSleep => setTimeout(resolveSleep, 50));
     }
+  }
+
+  private async currentResponseTurn(
+    conversationTurns: Locator,
+    initialConversationTurnIds: readonly string[],
+  ): Promise<Locator | undefined> {
+    const turns = await conversationTurns.evaluateAll((elements, completionActionSelector) => (
+      elements.map(element => ({
+        testId: element.getAttribute("data-testid"),
+        isUser: element.matches('[data-turn="user"], [data-message-author-role="user"]')
+          || element.querySelector('[data-message-author-role="user"]') !== null,
+        hasResponseEvidence: element.matches('[data-turn="assistant"], [data-message-author-role="assistant"]')
+          || element.querySelector([
+            '[data-message-author-role="assistant"]',
+            "[data-streaming-response-status]",
+            ".markdown",
+            '[role="alert"]',
+            '[role="status"]',
+            '[aria-busy="true"]',
+            completionActionSelector,
+          ].join(", ")) !== null,
+      }))
+    ), CHATGPT_COMPLETION_ACTION_SELECTOR);
+    const index = chatGptCurrentResponseTurnIndex(turns, initialConversationTurnIds);
+    const testId = index === undefined ? undefined : turns[index]?.testId;
+    return testId ? conversationTurns.page().getByTestId(testId) : undefined;
   }
 
   private async attachedPromptText(page: Page): Promise<string> {
@@ -1765,8 +1819,8 @@ export class ChatGptBrowserWorker {
     return snapshot;
   }
 
-  private async stalledTurnDiagnostic(page: Page, responseTurn: Locator): Promise<string> {
-    const responseState = await responseTurn.count()
+  private async stalledTurnDiagnostic(page: Page, responseTurn?: Locator): Promise<string> {
+    const responseState = responseTurn && await responseTurn.count()
       ? await responseTurn.evaluate(element => {
         const root = element as HTMLElement;
         const descriptors = [...root.querySelectorAll<HTMLElement>("[role], [data-testid], button, [aria-label]")]
@@ -1997,9 +2051,14 @@ export class ChatGptBrowserWorker {
         this.attachFiles(page, prepared)
       ));
       await diagnostics.capture(page, "file-attachment-complete");
+      const conversationTurns = page.locator(CHATGPT_CONVERSATION_TURN_SELECTOR);
+      const initialConversationTurnIds = await conversationTurns.evaluateAll(elements => (
+        elements
+          .map(element => element.getAttribute("data-testid"))
+          .filter((testId): testId is string => Boolean(testId))
+      ));
       const responseTurns = page.locator(CHATGPT_ASSISTANT_TURN_SELECTOR);
       const initialResponseTurnCount = await responseTurns.count();
-      const responseTurn = responseTurns.nth(initialResponseTurnCount);
       const userTurns = page.locator(CHATGPT_USER_TURN_SELECTOR);
       const initialUserTurnCount = await userTurns.count();
       await this.runStage(turn.traceId, "send", browserStageTimeouts.send, async (stageSignal) => {
@@ -2019,7 +2078,8 @@ export class ChatGptBrowserWorker {
           page,
           userTurns,
           responseTurns,
-          responseTurn,
+          conversationTurns,
+          initialConversationTurnIds,
           initialUserTurnCount,
           initialResponseTurnCount,
           stageSignal,
@@ -2063,7 +2123,11 @@ export class ChatGptBrowserWorker {
         }
 
         await throwIfChatGptSessionFailureAlert(page);
-        await throwIfChatGptTerminalErrorAlert(responseTurn);
+        const responseTurn = await this.currentResponseTurn(
+          conversationTurns,
+          initialConversationTurnIds,
+        );
+        if (responseTurn) await throwIfChatGptTerminalErrorAlert(responseTurn);
 
         if (mode.localTools && await resolveChatGptToolConfirmation(
           page,
@@ -2077,7 +2141,9 @@ export class ChatGptBrowserWorker {
           continue;
         }
 
-        const snapshot = await this.responseDomSnapshot(responseTurn);
+        const snapshot = responseTurn
+          ? await this.responseDomSnapshot(responseTurn)
+          : absentResponseDomSnapshot();
         const stop = page.locator(CHATGPT_STOP_BUTTON_SELECTOR).last();
         const running = await stop.isVisible().catch(() => false);
         if (running) sawRunning = true;

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -2095,7 +2095,7 @@ export class ChatGptBrowserWorker {
       let capturedResponse = false;
       const sentAt = Date.now();
       const visibleTrace = new ChatGptVisibleTraceTracker();
-      const markdownBuffer = new ChatGptMarkdownBuffer();
+      const markdownBuffer = new ChatGptMarkdownBuffer(markdown => markdown, 750, false);
       const checkpointStream = turn.captureLunaCheckpoint
         ? new ChatGptLunaCheckpointStream()
         : undefined;

--- a/src/adapters/chatgpt-web/markdown.ts
+++ b/src/adapters/chatgpt-web/markdown.ts
@@ -78,6 +78,7 @@ export class ChatGptMarkdownBuffer {
   constructor(
     private readonly transform: (markdown: string) => string = markdown => markdown,
     private readonly stabilityMs = 750,
+    private readonly incremental = true,
   ) {
     if (!Number.isFinite(stabilityMs) || stabilityMs < 0) {
       throw new Error("ChatGPT Markdown stability window must be a non-negative finite number");
@@ -109,6 +110,12 @@ export class ChatGptMarkdownBuffer {
     for (const index of this.candidates.keys()) {
       if (index >= segments.length) this.candidates.delete(index);
     }
+
+    // ChatGPT can revise blocks long after they looked complete, especially after a browser-native
+    // search or Python artifact finishes. Responses deltas are append-only, so the browser worker
+    // defers final-answer text until response-scoped completion is proven. The incremental mode
+    // remains available for isolated serializer tests and consumers with an immutable source.
+    if (!this.incremental) return "";
 
     let delta = "";
     while (this.committed.length < segments.length) {

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import type { Page } from "playwright-core";
-import { CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_PROMPT_INSERT_CHUNK_CHARS, ChatGptBrowserWorker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_TABS, assertChatGptWebInputWithinLimits, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptSubmissionEvidence, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert } from "../src/adapters/chatgpt-web/browser-worker";
+import { CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_PROMPT_INSERT_CHUNK_CHARS, ChatGptBrowserWorker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_TABS, assertChatGptWebInputWithinLimits, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptCurrentResponseTurnIndex, chatGptSubmissionEvidence, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert } from "../src/adapters/chatgpt-web/browser-worker";
 import { CHATGPT_WEB_MODEL_ID } from "../src/adapters/chatgpt-web/model";
 import { compileChatGptWebPrompt } from "../src/adapters/chatgpt-web/prompt";
 import { CHATGPT_CONNECTOR_NAME, defaultChromeExecutable, legacyChatGptConnectorMigrationMessage } from "../src/config";
@@ -1085,7 +1085,8 @@ test("submission acceptance stops when its stage is aborted", async () => {
       page: Page,
       userTurns: unknown,
       responseTurns: unknown,
-      responseTurn: unknown,
+      conversationTurns: unknown,
+      initialConversationTurnIds: readonly string[],
       initialUserTurnCount: number,
       initialResponseTurnCount: number,
       signal: AbortSignal,
@@ -1100,6 +1101,7 @@ test("submission acceptance stops when its stage is aborted", async () => {
     {},
     {},
     {},
+    [],
     0,
     0,
     controller.signal,
@@ -1574,6 +1576,69 @@ test("browser send accepts only conclusive ChatGPT submission evidence", () => {
   expect(chatGptSubmissionEvidence({ ...idle, userTurnCount: 2 })).toBe("user_turn");
   expect(chatGptSubmissionEvidence({ ...idle, assistantTurnCount: 3 })).toBe("assistant_turn");
   expect(chatGptSubmissionEvidence({ ...idle, generationRunning: true })).toBe("generation_running");
+});
+
+test("current response identity follows a removed provisional turn to its replacement", () => {
+  const initialTurnIds = ["conversation-turn-old-user", "conversation-turn-old-assistant"];
+  const oldTurns = [
+    { testId: initialTurnIds[0]!, isUser: true, hasResponseEvidence: false },
+    { testId: initialTurnIds[1]!, isUser: false, hasResponseEvidence: true },
+  ];
+  const currentUser = {
+    testId: "conversation-turn-current-user",
+    isUser: true,
+    hasResponseEvidence: false,
+  };
+  const provisional = {
+    testId: "conversation-turn-provisional",
+    isUser: false,
+    hasResponseEvidence: true,
+  };
+
+  expect(chatGptCurrentResponseTurnIndex(
+    [...oldTurns, currentUser, provisional],
+    initialTurnIds,
+  )).toBe(3);
+  expect(chatGptCurrentResponseTurnIndex(
+    [...oldTurns, currentUser],
+    initialTurnIds,
+  )).toBeUndefined();
+  expect(chatGptCurrentResponseTurnIndex(
+    [oldTurns[0]!, {
+      testId: "conversation-turn-old-assistant-replaced",
+      isUser: false,
+      hasResponseEvidence: true,
+    }, currentUser],
+    initialTurnIds,
+  )).toBeUndefined();
+  expect(chatGptCurrentResponseTurnIndex(
+    [...oldTurns, currentUser, {
+      testId: "conversation-turn-generic-wrapper",
+      isUser: false,
+      hasResponseEvidence: false,
+    }],
+    initialTurnIds,
+  )).toBeUndefined();
+  for (const unowned of [
+    { testId: null, isUser: false, hasResponseEvidence: true },
+    { testId: initialTurnIds[1]!, isUser: false, hasResponseEvidence: true },
+    { testId: "conversation-turn-current-user-replacement", isUser: true, hasResponseEvidence: true },
+  ]) {
+    expect(chatGptCurrentResponseTurnIndex(
+      [...oldTurns, currentUser, unowned],
+      initialTurnIds,
+    )).toBeUndefined();
+  }
+
+  const replacement = {
+    testId: "conversation-turn-replacement",
+    isUser: false,
+    hasResponseEvidence: true,
+  };
+  expect(chatGptCurrentResponseTurnIndex(
+    [...oldTurns, currentUser, replacement],
+    initialTurnIds,
+  )).toBe(3);
 });
 
 test("visible reasoning keeps the browser turn healthy before final assistant markdown exists", () => {

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -1424,6 +1424,7 @@ test("response DOM separates streaming commentary from the final Markdown answer
   expect(workerSource).toContain("const renderedRoots = allMarkdownRoots.filter");
   expect(workerSource).toContain('fullHtml: renderedRoots.map(candidate => candidate.innerHTML).join("")');
   expect(workerSource).toContain("const markdownSegments = renderedRoots.flatMap");
+  expect(workerSource).toContain("new ChatGptMarkdownBuffer(markdown => markdown, 750, false)");
   expect(workerSource).toContain('key: `${rootIndex}:${childIndex}:${tag}:${itemIndex}`');
   expect(workerSource).toContain("streamable: childIsComplete || itemIndex < listItems.length - 1");
   expect(workerSource).toContain("markdownBuffer.observe(snapshot.markdownSegments)");

--- a/tests/chatgpt-web-harness.test.ts
+++ b/tests/chatgpt-web-harness.test.ts
@@ -1207,6 +1207,30 @@ describe("ChatGPT outer-native harness v4", () => {
     ], 200)).toThrow("completed text block");
   });
 
+  test("defers mutable final-answer blocks until browser completion", () => {
+    const buffer = new ChatGptMarkdownBuffer(markdown => markdown, 100, false);
+    const initial = [{
+      key: "artifact",
+      html: "<p>draft artifact</p>",
+      text: "draft artifact",
+      streamable: true,
+    }];
+    expect(buffer.observe(initial, 0)).toBe("");
+    expect(buffer.observe(initial, 100)).toBe("");
+
+    const completed = [{
+      key: "artifact",
+      html: "<p>completed artifact</p>",
+      text: "completed artifact",
+      streamable: true,
+    }];
+    expect(buffer.observe(completed, 200)).toBe("");
+    expect(buffer.finish()).toEqual({
+      delta: "completed artifact",
+      markdown: "completed artifact",
+    });
+  });
+
   test("drops decorative HTML images without removing textual links", () => {
     const markdown = chatGptHtmlToMarkdown([
       '<p>Source card: <a href="https://github.com/example/repo"><img alt="GitHub" src="data:image/png;base64,AAAA"></a></p>',


### PR DESCRIPTION
## Summary

- re-resolve the active ChatGPT response from conversation-turn identity when the provisional assistant node is replaced
- reject pre-send, user, and generic wrappers until they expose response-specific DOM evidence
- defer append-only final-answer deltas until response-scoped completion and a stable final DOM snapshot are proven
- preserve live reasoning, commentary, heartbeats, tool rounds, cancellation, and five-tab isolation

## Root causes

### Replaced response turns

Failed turns showed one short provisional assistant response followed by loss of the assistant-semantic match while the browser turn remained active. Playwright locators re-evaluate correctly when a replacement stays inside the selector; the unstable boundary was selector membership and index ownership during ChatGPT's conversation-turn replacement.

The worker now snapshots pre-send turn IDs and dynamically selects only a new, non-user turn after the current user boundary. A replacement must expose assistant, status, alert, busy, Markdown, or response-scoped completion evidence before it is considered present.

### Mutable streamed blocks

ChatGPT can revise apparently completed text blocks long after the previous 750 ms commit window, especially after browser-native web search or Python artifact work. Responses text deltas cannot retract content, so committing those blocks early caused the bridge to disconnect when ChatGPT changed them later.

The worker now buffers final-answer Markdown through generation and emits it only after the existing response-scoped copy action and stable completed DOM are proven. Reasoning, commentary, heartbeats, and tool events continue streaming during the turn.

This remains separate from #133, which was scoped to effort-popover rerenders.

## Verification

- focused browser lifecycle suites: 107 passed
- full `bun run verify`: 316 runtime tests and 160 launcher tests passed
- dependency audit, TypeScript checks, production builds, relocatable runtime smoke, and real system-Chrome launch passed
- complex Extra High artifact canary completed with 23,809 Markdown characters and no response-DOM or mutation failure
- streamed High artifact canary: one `response.created`, one `response.completed`, zero `response.failed`, four final text deltas, and one `[DONE]`

## Test plan

- [x] provisional response is selected
- [x] removal yields no stale response
- [x] replacement response is rebound
- [x] pre-send, user, missing-ID, and response-evidence-free turns are rejected
- [x] mutable completed blocks remain replaceable until browser completion
- [x] final Markdown still reproduces the completed answer exactly
- [x] cancellation and five-tab isolation contracts remain green
