### PR TITLE
Respect native model context window override

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -102,8 +102,9 @@ auto-compaction reserve. Usage is counted with the GPT-5 tokenizer plus fixed pl
 reserves, rather than inferred from character length. The ChatGPT composer also has an independent
 inline-size boundary: usage accounting asks Codex to compact before that boundary, and a prompt
 that still exceeds the proven hard ceiling fails explicitly before any browser turn opens.
-Top-level `model_context_window` and `model_auto_compact_token_limit` overrides are applied only to
-the proxied native Codex rows; routed ChatGPT Web models retain their measured adapter-owned limits.
+Top-level `model_context_window` raises only the proxied native rows' advertised maximum, allowing
+Codex to apply its own configured context override without clamping. Routed ChatGPT Web models
+retain their measured adapter-owned limits.
 
 Routed compaction v1/v2 runs as a dedicated read-only browser summarization turn with no broker or
 local tools, then returns the native replacement-history shape expected by Codex. A prompt-level

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -102,6 +102,8 @@ auto-compaction reserve. Usage is counted with the GPT-5 tokenizer plus fixed pl
 reserves, rather than inferred from character length. The ChatGPT composer also has an independent
 inline-size boundary: usage accounting asks Codex to compact before that boundary, and a prompt
 that still exceeds the proven hard ceiling fails explicitly before any browser turn opens.
+Top-level `model_context_window` and `model_auto_compact_token_limit` overrides are applied only to
+the proxied native Codex rows; routed ChatGPT Web models retain their measured adapter-owned limits.
 
 Routed compaction v1/v2 runs as a dedicated read-only browser summarization turn with no broker or
 local tools, then returns the native replacement-history shape expected by Codex. A prompt-level

--- a/src/codex-integration-document.ts
+++ b/src/codex-integration-document.ts
@@ -78,7 +78,7 @@ export function findTopLevelAssignment(lines: string[], key: string): PreviousAs
   return matches[0] ?? { present: false };
 }
 
-function findTopLevelPositiveInteger(lines: string[], key: string): number | undefined {
+function findTopLevelInteger(lines: string[], key: string): number | undefined {
   const regex = assignmentRegex(key);
   const matches: string[] = [];
   for (let index = 0; index < firstTableIndex(lines); index += 1) {
@@ -90,9 +90,17 @@ function findTopLevelPositiveInteger(lines: string[], key: string): number | und
   if (matches.length > 1) throw new Error(`Codex config contains duplicate top-level ${key} assignments`);
   if (matches.length === 0) return undefined;
   const normalized = matches[0]!.replaceAll("_", "");
-  if (!/^\d+$/.test(normalized)) throw new Error(`${key} in Codex config must be a positive integer`);
+  if (!/^-?\d+$/.test(normalized)) throw new Error(`${key} in Codex config must be an integer`);
   const value = Number(normalized);
-  if (!Number.isSafeInteger(value) || value <= 0) throw new Error(`${key} in Codex config must be a positive integer`);
+  if (!Number.isSafeInteger(value)) throw new Error(`${key} in Codex config must be an integer`);
+  return value;
+}
+
+function findTopLevelPositiveInteger(lines: string[], key: string): number | undefined {
+  const value = findTopLevelInteger(lines, key);
+  if (value !== undefined && value <= 0) {
+    throw new Error(`${key} in Codex config must be a positive integer`);
+  }
   return value;
 }
 
@@ -102,9 +110,15 @@ export function readCodexModelContextOverride(): CodexModelContextOverride | und
   const text = readFileSync(path, "utf8");
   const lines = splitLines(text);
   const contextWindow = findTopLevelPositiveInteger(lines, "model_context_window");
-  if (contextWindow === undefined) return undefined;
-  const model = findTopLevelAssignment(lines, "model").value;
-  return model ? { model, contextWindow } : undefined;
+  const autoCompactTokenLimit = findTopLevelInteger(
+    lines,
+    "model_auto_compact_token_limit",
+  );
+  if (contextWindow === undefined && autoCompactTokenLimit === undefined) return undefined;
+  return {
+    ...(contextWindow === undefined ? {} : { contextWindow }),
+    ...(autoCompactTokenLimit === undefined ? {} : { autoCompactTokenLimit }),
+  };
 }
 
 export function assignments(lines: string[]): Record<ManagedAssignmentKey, PreviousAssignment> {

--- a/src/codex-integration-document.ts
+++ b/src/codex-integration-document.ts
@@ -78,7 +78,7 @@ export function findTopLevelAssignment(lines: string[], key: string): PreviousAs
   return matches[0] ?? { present: false };
 }
 
-function findTopLevelInteger(lines: string[], key: string): number | undefined {
+function findTopLevelPositiveInteger(lines: string[], key: string): number | undefined {
   const regex = assignmentRegex(key);
   const matches: string[] = [];
   for (let index = 0; index < firstTableIndex(lines); index += 1) {
@@ -90,17 +90,9 @@ function findTopLevelInteger(lines: string[], key: string): number | undefined {
   if (matches.length > 1) throw new Error(`Codex config contains duplicate top-level ${key} assignments`);
   if (matches.length === 0) return undefined;
   const normalized = matches[0]!.replaceAll("_", "");
-  if (!/^-?\d+$/.test(normalized)) throw new Error(`${key} in Codex config must be an integer`);
+  if (!/^\d+$/.test(normalized)) throw new Error(`${key} in Codex config must be a positive integer`);
   const value = Number(normalized);
-  if (!Number.isSafeInteger(value)) throw new Error(`${key} in Codex config must be an integer`);
-  return value;
-}
-
-function findTopLevelPositiveInteger(lines: string[], key: string): number | undefined {
-  const value = findTopLevelInteger(lines, key);
-  if (value !== undefined && value <= 0) {
-    throw new Error(`${key} in Codex config must be a positive integer`);
-  }
+  if (!Number.isSafeInteger(value) || value <= 0) throw new Error(`${key} in Codex config must be a positive integer`);
   return value;
 }
 
@@ -110,15 +102,7 @@ export function readCodexModelContextOverride(): CodexModelContextOverride | und
   const text = readFileSync(path, "utf8");
   const lines = splitLines(text);
   const contextWindow = findTopLevelPositiveInteger(lines, "model_context_window");
-  const autoCompactTokenLimit = findTopLevelInteger(
-    lines,
-    "model_auto_compact_token_limit",
-  );
-  if (contextWindow === undefined && autoCompactTokenLimit === undefined) return undefined;
-  return {
-    ...(contextWindow === undefined ? {} : { contextWindow }),
-    ...(autoCompactTokenLimit === undefined ? {} : { autoCompactTokenLimit }),
-  };
+  return contextWindow === undefined ? undefined : { contextWindow };
 }
 
 export function assignments(lines: string[]): Record<ManagedAssignmentKey, PreviousAssignment> {

--- a/src/codex-integration-shared.ts
+++ b/src/codex-integration-shared.ts
@@ -151,8 +151,7 @@ export interface SetCodexIntegrationActiveResult {
 }
 
 export interface CodexModelContextOverride {
-  contextWindow?: number;
-  autoCompactTokenLimit?: number;
+  contextWindow: number;
 }
 
 export function getCodexHome(): string {

--- a/src/codex-integration-shared.ts
+++ b/src/codex-integration-shared.ts
@@ -151,8 +151,8 @@ export interface SetCodexIntegrationActiveResult {
 }
 
 export interface CodexModelContextOverride {
-  model: string;
-  contextWindow: number;
+  contextWindow?: number;
+  autoCompactTokenLimit?: number;
 }
 
 export function getCodexHome(): string {

--- a/src/model-catalog.ts
+++ b/src/model-catalog.ts
@@ -135,26 +135,20 @@ export function augmentNativeModelCatalog(
   }
   const template = selectNativeTemplate(nativeModels, config);
   if (contextOverride) {
-    // These are top-level Codex settings, not per-model ones. Apply them to every native row so
-    // switching native models cannot silently restore the smaller catalog defaults. Routed Web
-    // rows retain their adapter-owned measured limits below.
+    // model_context_window is a single top-level Codex setting, not a per-model one. Apply its
+    // advertised maximum to every native row so switching native models cannot silently clamp the
+    // effective override. Codex itself applies context_window and auto-compaction configuration.
     for (const candidate of nativeModels) {
       const modelSlug = slug(candidate);
       if (!modelSlug) continue;
       const model = object(candidate, `native ${modelSlug} model`);
-      if (contextOverride.contextWindow !== undefined) {
-        const current = model.max_context_window;
-        if (current !== undefined && current !== null
-          && (typeof current !== "number" || !Number.isSafeInteger(current) || current <= 0)) {
-          throw new Error(`Native ${modelSlug} max_context_window must be a positive integer`);
-        }
-        if (current === undefined || current === null || current < contextOverride.contextWindow) {
-          model.max_context_window = contextOverride.contextWindow;
-        }
-        model.context_window = contextOverride.contextWindow;
+      const current = model.max_context_window;
+      if (current !== undefined && current !== null
+        && (typeof current !== "number" || !Number.isSafeInteger(current) || current <= 0)) {
+        throw new Error(`Native ${modelSlug} max_context_window must be a positive integer`);
       }
-      if (contextOverride.autoCompactTokenLimit !== undefined) {
-        model.auto_compact_token_limit = contextOverride.autoCompactTokenLimit;
+      if (current === undefined || current === null || current < contextOverride.contextWindow) {
+        model.max_context_window = contextOverride.contextWindow;
       }
     }
   }

--- a/src/model-catalog.ts
+++ b/src/model-catalog.ts
@@ -135,20 +135,26 @@ export function augmentNativeModelCatalog(
   }
   const template = selectNativeTemplate(nativeModels, config);
   if (contextOverride) {
-    // model_context_window is a single top-level Codex setting, not a per-model one. Binding it to
-    // the model named in the config makes it vanish the moment that line names a ChatGPT Web slug,
-    // leaving the model actually in use clamped to the catalog's smaller window.
+    // These are top-level Codex settings, not per-model ones. Apply them to every native row so
+    // switching native models cannot silently restore the smaller catalog defaults. Routed Web
+    // rows retain their adapter-owned measured limits below.
     for (const candidate of nativeModels) {
       const modelSlug = slug(candidate);
       if (!modelSlug) continue;
       const model = object(candidate, `native ${modelSlug} model`);
-      const current = model.max_context_window;
-      if (current !== undefined && current !== null
-        && (typeof current !== "number" || !Number.isSafeInteger(current) || current <= 0)) {
-        throw new Error(`Native ${modelSlug} max_context_window must be a positive integer`);
+      if (contextOverride.contextWindow !== undefined) {
+        const current = model.max_context_window;
+        if (current !== undefined && current !== null
+          && (typeof current !== "number" || !Number.isSafeInteger(current) || current <= 0)) {
+          throw new Error(`Native ${modelSlug} max_context_window must be a positive integer`);
+        }
+        if (current === undefined || current === null || current < contextOverride.contextWindow) {
+          model.max_context_window = contextOverride.contextWindow;
+        }
+        model.context_window = contextOverride.contextWindow;
       }
-      if (current === undefined || current === null || current < contextOverride.contextWindow) {
-        model.max_context_window = contextOverride.contextWindow;
+      if (contextOverride.autoCompactTokenLimit !== undefined) {
+        model.auto_compact_token_limit = contextOverride.autoCompactTokenLimit;
       }
     }
   }

--- a/tests/codex-integration.test.ts
+++ b/tests/codex-integration.test.ts
@@ -42,7 +42,7 @@ describe("reversible native Codex route integration", () => {
     expect(getCodexHome()).toBe(join(homedir(), "custom-codex-home"));
   });
 
-  test("reads explicit native context and compaction overrides from Codex config", () => {
+  test("reads an explicit native context override without requiring a selected model", () => {
     const { codexHome } = fixture();
     writeFileSync(
       join(codexHome, "config.toml"),
@@ -55,31 +55,6 @@ describe("reversible native Codex route integration", () => {
 
     expect(readCodexModelContextOverride()).toEqual({
       contextWindow: 1_000_000,
-      autoCompactTokenLimit: 900_000,
-    });
-  });
-
-  test("reads an explicit native compaction override independently", () => {
-    const { codexHome } = fixture();
-    writeFileSync(
-      join(codexHome, "config.toml"),
-      "model_auto_compact_token_limit = 456_789\n",
-    );
-
-    expect(readCodexModelContextOverride()).toEqual({
-      autoCompactTokenLimit: 456_789,
-    });
-  });
-
-  test("preserves a zero native compaction threshold accepted by Codex", () => {
-    const { codexHome } = fixture();
-    writeFileSync(
-      join(codexHome, "config.toml"),
-      "model_auto_compact_token_limit = 0\n",
-    );
-
-    expect(readCodexModelContextOverride()).toEqual({
-      autoCompactTokenLimit: 0,
     });
   });
 

--- a/tests/codex-integration.test.ts
+++ b/tests/codex-integration.test.ts
@@ -42,16 +42,44 @@ describe("reversible native Codex route integration", () => {
     expect(getCodexHome()).toBe(join(homedir(), "custom-codex-home"));
   });
 
-  test("reads the selected model's explicit context override from Codex config", () => {
+  test("reads explicit native context and compaction overrides from Codex config", () => {
     const { codexHome } = fixture();
     writeFileSync(
       join(codexHome, "config.toml"),
-      'model = "gpt-5.6-sol"\nmodel_context_window = 371_851 # explicit override\n',
+      [
+        "model_context_window = 1_000_000 # explicit override",
+        "model_auto_compact_token_limit = 900_000",
+        "",
+      ].join("\n"),
     );
 
     expect(readCodexModelContextOverride()).toEqual({
-      model: "gpt-5.6-sol",
-      contextWindow: 371_851,
+      contextWindow: 1_000_000,
+      autoCompactTokenLimit: 900_000,
+    });
+  });
+
+  test("reads an explicit native compaction override independently", () => {
+    const { codexHome } = fixture();
+    writeFileSync(
+      join(codexHome, "config.toml"),
+      "model_auto_compact_token_limit = 456_789\n",
+    );
+
+    expect(readCodexModelContextOverride()).toEqual({
+      autoCompactTokenLimit: 456_789,
+    });
+  });
+
+  test("preserves a zero native compaction threshold accepted by Codex", () => {
+    const { codexHome } = fixture();
+    writeFileSync(
+      join(codexHome, "config.toml"),
+      "model_auto_compact_token_limit = 0\n",
+    );
+
+    expect(readCodexModelContextOverride()).toEqual({
+      autoCompactTokenLimit: 0,
     });
   });
 

--- a/tests/model-catalog.test.ts
+++ b/tests/model-catalog.test.ts
@@ -158,26 +158,40 @@ describe("native /models augmentation", () => {
     });
   });
 
-  test("honors an explicit Codex context override without replacing or reordering native models", () => {
+  test("honors explicit Codex context and compaction overrides only for native models", () => {
     const native = source();
     const nativeSnapshot = structuredClone(native);
     const config = defaultConfig("full");
-    // model_context_window is one top-level Codex setting, so it must not depend on which model
-    // the config's `model` line happens to name - that line can hold a ChatGPT Web slug.
     const result = augmentNativeModelCatalog(native, config, {
-      model: "chatgpt-web/medium",
       contextWindow: 371_851,
+      autoCompactTokenLimit: 333_333,
     });
     const models = result.models as Array<Record<string, unknown>>;
     const originalModels = nativeSnapshot.models as Array<Record<string, unknown>>;
 
     expect(native).toEqual(nativeSnapshot);
     expect(models.slice(0, 3)).toEqual([
-      { ...originalModels[0], max_context_window: 371_851 },
-      { ...originalModels[1], max_context_window: 371_851, multi_agent_version: "v1" },
-      { ...originalModels[2], max_context_window: 371_851, multi_agent_version: "v1" },
+      {
+        ...originalModels[0],
+        context_window: 371_851,
+        max_context_window: 371_851,
+        auto_compact_token_limit: 333_333,
+      },
+      {
+        ...originalModels[1],
+        context_window: 371_851,
+        max_context_window: 371_851,
+        auto_compact_token_limit: 333_333,
+        multi_agent_version: "v1",
+      },
+      {
+        ...originalModels[2],
+        context_window: 371_851,
+        max_context_window: 371_851,
+        auto_compact_token_limit: 333_333,
+        multi_agent_version: "v1",
+      },
     ]);
-    expect(models[1]!.context_window).toBe(300_000);
     for (const [index, model] of models.slice(3).entries()) {
       const route = CHATGPT_WEB_MODEL_ROUTES[index]!;
       const limits = resolveChatGptWebContextLimits(
@@ -197,11 +211,39 @@ describe("native /models augmentation", () => {
     const models = native.models as Array<Record<string, unknown>>;
     models[0]!.max_context_window = 1_000_000;
     const result = augmentNativeModelCatalog(native, defaultConfig("full"), {
-      model: "gpt-5.6-sol",
       contextWindow: 371_851,
     });
 
-    expect((result.models as Array<Record<string, unknown>>)[0]!.max_context_window).toBe(1_000_000);
+    const overridden = (result.models as Array<Record<string, unknown>>)[0]!;
+    expect(overridden.context_window).toBe(371_851);
+    expect(overridden.max_context_window).toBe(1_000_000);
+  });
+
+  test("applies a native compaction override without changing native context windows", () => {
+    const native = source();
+    const nativeSnapshot = structuredClone(native);
+    const config = defaultConfig("full");
+    const models = augmentNativeModelCatalog(native, config, {
+      autoCompactTokenLimit: 222_222,
+    }).models as Array<Record<string, unknown>>;
+    const originalModels = nativeSnapshot.models as Array<Record<string, unknown>>;
+
+    expect(native).toEqual(nativeSnapshot);
+    expect(models.slice(0, 3)).toEqual([
+      { ...originalModels[0], auto_compact_token_limit: 222_222 },
+      { ...originalModels[1], auto_compact_token_limit: 222_222, multi_agent_version: "v1" },
+      { ...originalModels[2], auto_compact_token_limit: 222_222, multi_agent_version: "v1" },
+    ]);
+    for (const [index, model] of models.slice(3).entries()) {
+      const route = CHATGPT_WEB_MODEL_ROUTES[index]!;
+      const limits = resolveChatGptWebContextLimits(
+        route.backendModel,
+        route.adapterEffort,
+        config,
+      );
+      expect(model.context_window).toBe(limits.contextWindow);
+      expect(model.auto_compact_token_limit).toBe(limits.autoCompactTokenLimit);
+    }
   });
 
   test("uses an available compatible official model when an account exposes a smaller catalog", () => {

--- a/tests/model-catalog.test.ts
+++ b/tests/model-catalog.test.ts
@@ -158,40 +158,24 @@ describe("native /models augmentation", () => {
     });
   });
 
-  test("honors explicit Codex context and compaction overrides only for native models", () => {
+  test("raises only native maximum windows for an explicit Codex context override", () => {
     const native = source();
     const nativeSnapshot = structuredClone(native);
     const config = defaultConfig("full");
     const result = augmentNativeModelCatalog(native, config, {
       contextWindow: 371_851,
-      autoCompactTokenLimit: 333_333,
     });
     const models = result.models as Array<Record<string, unknown>>;
     const originalModels = nativeSnapshot.models as Array<Record<string, unknown>>;
 
     expect(native).toEqual(nativeSnapshot);
     expect(models.slice(0, 3)).toEqual([
-      {
-        ...originalModels[0],
-        context_window: 371_851,
-        max_context_window: 371_851,
-        auto_compact_token_limit: 333_333,
-      },
-      {
-        ...originalModels[1],
-        context_window: 371_851,
-        max_context_window: 371_851,
-        auto_compact_token_limit: 333_333,
-        multi_agent_version: "v1",
-      },
-      {
-        ...originalModels[2],
-        context_window: 371_851,
-        max_context_window: 371_851,
-        auto_compact_token_limit: 333_333,
-        multi_agent_version: "v1",
-      },
+      { ...originalModels[0], max_context_window: 371_851 },
+      { ...originalModels[1], max_context_window: 371_851, multi_agent_version: "v1" },
+      { ...originalModels[2], max_context_window: 371_851, multi_agent_version: "v1" },
     ]);
+    expect(models[1]!.context_window).toBe(300_000);
+    expect(models[1]!.auto_compact_token_limit).toBe(270_000);
     for (const [index, model] of models.slice(3).entries()) {
       const route = CHATGPT_WEB_MODEL_ROUTES[index]!;
       const limits = resolveChatGptWebContextLimits(
@@ -209,41 +193,15 @@ describe("native /models augmentation", () => {
   test("never lowers a native window that already exceeds the Codex context override", () => {
     const native = source();
     const models = native.models as Array<Record<string, unknown>>;
-    models[0]!.max_context_window = 1_000_000;
+    models[1]!.max_context_window = 1_000_000;
     const result = augmentNativeModelCatalog(native, defaultConfig("full"), {
       contextWindow: 371_851,
     });
 
-    const overridden = (result.models as Array<Record<string, unknown>>)[0]!;
-    expect(overridden.context_window).toBe(371_851);
+    const overridden = (result.models as Array<Record<string, unknown>>)[1]!;
+    expect(overridden.context_window).toBe(300_000);
     expect(overridden.max_context_window).toBe(1_000_000);
-  });
-
-  test("applies a native compaction override without changing native context windows", () => {
-    const native = source();
-    const nativeSnapshot = structuredClone(native);
-    const config = defaultConfig("full");
-    const models = augmentNativeModelCatalog(native, config, {
-      autoCompactTokenLimit: 222_222,
-    }).models as Array<Record<string, unknown>>;
-    const originalModels = nativeSnapshot.models as Array<Record<string, unknown>>;
-
-    expect(native).toEqual(nativeSnapshot);
-    expect(models.slice(0, 3)).toEqual([
-      { ...originalModels[0], auto_compact_token_limit: 222_222 },
-      { ...originalModels[1], auto_compact_token_limit: 222_222, multi_agent_version: "v1" },
-      { ...originalModels[2], auto_compact_token_limit: 222_222, multi_agent_version: "v1" },
-    ]);
-    for (const [index, model] of models.slice(3).entries()) {
-      const route = CHATGPT_WEB_MODEL_ROUTES[index]!;
-      const limits = resolveChatGptWebContextLimits(
-        route.backendModel,
-        route.adapterEffort,
-        config,
-      );
-      expect(model.context_window).toBe(limits.contextWindow);
-      expect(model.auto_compact_token_limit).toBe(limits.autoCompactTokenLimit);
-    }
+    expect(overridden.auto_compact_token_limit).toBe(270_000);
   });
 
   test("uses an available compatible official model when an account exposes a smaller catalog", () => {

--- a/tests/server-models.test.ts
+++ b/tests/server-models.test.ts
@@ -25,7 +25,7 @@ test("proxies official /models auth and query, then appends the fixed ChatGPT We
         tool_mode: "code_mode_only",
       }],
     }, { headers: { etag: "native-etag" } });
-  }, () => ({ model: "gpt-5.6-sol", contextWindow: 371_851 }));
+  }, () => ({ contextWindow: 371_851, autoCompactTokenLimit: 333_333 }));
 
   expect(upstream!.url).toBe("https://chatgpt.com/backend-api/codex/models?client_version=1.2.3");
   expect(upstream!.method).toBe("GET");
@@ -52,7 +52,9 @@ test("proxies official /models auth and query, then appends the fixed ChatGPT We
     "chatgpt-web/extra-high",
     "chatgpt-web/pro",
   ]);
+  expect(body.models[0]!.context_window).toBe(371_851);
   expect(body.models[0]!.max_context_window).toBe(371_851);
+  expect(body.models[0]!.auto_compact_token_limit).toBe(333_333);
   expect(body.models[0]!.multi_agent_version).toBe("v1");
   for (const [index, model] of body.models.slice(1).entries()) {
     const route = CHATGPT_WEB_MODEL_ROUTES[index]!;

--- a/tests/server-models.test.ts
+++ b/tests/server-models.test.ts
@@ -23,9 +23,12 @@ test("proxies official /models auth and query, then appends the fixed ChatGPT We
         supported_in_api: true,
         supported_reasoning_levels: [],
         tool_mode: "code_mode_only",
+        context_window: 300_000,
+        max_context_window: 320_000,
+        auto_compact_token_limit: 270_000,
       }],
     }, { headers: { etag: "native-etag" } });
-  }, () => ({ contextWindow: 371_851, autoCompactTokenLimit: 333_333 }));
+  }, () => ({ contextWindow: 371_851 }));
 
   expect(upstream!.url).toBe("https://chatgpt.com/backend-api/codex/models?client_version=1.2.3");
   expect(upstream!.method).toBe("GET");
@@ -52,9 +55,9 @@ test("proxies official /models auth and query, then appends the fixed ChatGPT We
     "chatgpt-web/extra-high",
     "chatgpt-web/pro",
   ]);
-  expect(body.models[0]!.context_window).toBe(371_851);
+  expect(body.models[0]!.context_window).toBe(300_000);
   expect(body.models[0]!.max_context_window).toBe(371_851);
-  expect(body.models[0]!.auto_compact_token_limit).toBe(333_333);
+  expect(body.models[0]!.auto_compact_token_limit).toBe(270_000);
   expect(body.models[0]!.multi_agent_version).toBe("v1");
   for (const [index, model] of body.models.slice(1).entries()) {
     const route = CHATGPT_WEB_MODEL_ROUTES[index]!;


### PR DESCRIPTION
## Summary

- read the top-level `model_context_window` setting without requiring a top-level `model = ...` assignment
- raise only native `max_context_window` values that would otherwise clamp Codex's own context override
- leave native `context_window` and `auto_compact_token_limit` metadata unchanged
- keep routed ChatGPT Web model limits adapter-owned and unchanged

## Testing

- `bun run verify`

Fixes #139