### PR TITLE
Use @codex when selecting the ChatGPT connector

### DIFF
--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -1373,7 +1373,7 @@ export class ChatGptBrowserWorker {
       await composer.fill("");
       await composer.focus();
       await settleChatGptUi();
-      await composer.pressSequentially("@c", { delay: 25 });
+      await composer.pressSequentially("@codex", { delay: 25 });
       if (!firstMenuCaptured) {
         firstMenuCaptured = true;
         await captureDiagnostic?.("connector-mention-triggered");

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -661,7 +661,7 @@ test("connector selection re-resolves the active composer after ChatGPT replaces
     ["fill", ""],
     ["fill", ""],
     ["focus"],
-    ["pressSequentially", "@c"],
+    ["pressSequentially", "@codex"],
     ["waitForResult"],
     ["press"],
     ["waitForSelectedConnector"],
@@ -739,7 +739,7 @@ test("connector selection retriggers the complete mention after a fresh-page hyd
     fill: async () => { calls.push("clear"); },
     focus: async () => { calls.push("focus"); },
     pressSequentially: async (value: string) => {
-      expect(value).toBe("@c");
+      expect(value).toBe("@codex");
       calls.push("type");
     },
   };
@@ -997,7 +997,7 @@ test("tool-capable prompts use the shared Playwright connector selection before 
     ["fill", ""],
     ["fill", ""],
     ["focus"],
-    ["type", "@c"],
+    ["type", "@codex"],
     ["connectorMenu"],
     ["selectConnector"],
     ["selectedConnector"],


### PR DESCRIPTION
## Summary
ChatGPT connector selection types `@c` into the composer to open the mention menu. On accounts with many connectors whose names start with `C`, that prefix is too short and `Codex Native2` never appears in the filtered list.

When the exact `Codex Native2` row is missing, the browser worker does not stop. It keeps clearing the composer and typing `@c` again until the 20-second mention deadline, then fails. The turn looks stuck on connector selection even though the connector exists.

This changes the mention to `@codex`. The connector identity stays `Codex Native2`; this does not add custom names.

`@codex` is still a short, space-free prefix, so it avoids the earlier instability of typing the full `@Codex Native2` mention.

## Testing
- `bun test tests/browser-worker-contract.test.ts`
- `bun run typecheck`