### PR TITLE
feat: add authenticated external Responses API

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,37 @@ rows, but changing them cannot silently change the selected browser model. In Fu
 available effort receives the same turn-bound MCP capability. Pro has no separate restriction or
 reduced tool contract.
 
+## External Responses API
+
+An optional second listener exposes the available `chatgpt-web/*` routes to OpenAI Responses API
+clients. It is disabled by default, uses a separate bearer token, and never exposes native model
+passthrough, health, lifecycle, search, or compaction routes.
+
+Enable it during setup. Omitting `--external-api-token` generates and prints a 256-bit token:
+
+```bash
+codex-chatgpt-web setup --browser-only --external-api --external-api-host 127.0.0.1
+```
+
+Then point an OpenAI client at the external listener:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://127.0.0.1:17842/v1", api_key="YOUR_EXTERNAL_API_TOKEN")
+response = client.responses.create(model="chatgpt-web/high", input="Explain this API briefly.")
+print(response.output_text)
+```
+
+`GET /v1/models`, streaming Responses calls, `previous_response_id`, and standard function tools
+are supported. Function tools require Full harness setup; calls are returned to the API client for
+execution and run under a synthetic read-only environment with no local workspace authority.
+
+Keep the listener on `127.0.0.1` for local agents. To bind a LAN, VPN, or container-facing IP, use
+`--external-api-host`; plain HTTP does not protect the bearer token in transit, so non-loopback
+deployments require a trusted private network or a TLS reverse proxy. Disable it with
+`--no-external-api` and restart the owning launcher/service after changing setup.
+
 ## Full harness
 
 Full mode connects ChatGPT's tool calls back to the current Codex task through the official
@@ -197,7 +228,7 @@ codex-chatgpt-web subagents native
 
 ## Limitations and security
 
-- This is unofficial browser automation, not an OpenAI API. ChatGPT UI changes can break selectors;
+- This is unofficial browser automation, not the official OpenAI API. ChatGPT UI changes can break selectors;
   drift fails explicitly instead of silently switching model or transport.
 - ChatGPT's account-specific composer ceilings are smaller than some underlying model windows.
   The measured boundaries and requirements for a larger deterministic transport are tracked in

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -64,6 +64,20 @@ request and long-lived browser/tool loop are idle, flush response state, and sto
 token does not turn loopback into a hostile-local-process security boundary; it prevents accidental
 or unauthenticated lifecycle control through ordinary requests.
 
+### External API callers
+
+The optional external listener is a separate opt-in trust boundary with its own random bearer
+token. It exposes only `GET /v1/models` and `POST /v1/responses`, accepts only `chatgpt-web/*`
+routes, strips the bearer credential before internal dispatch, and rejects native passthrough and
+native `additional_tools` payloads. Caller-supplied turn metadata and workspace authority are
+replaced with server-owned identity and a synthetic read-only environment.
+
+Requests without function tools are forced into browser-only mode even when the installed runtime
+uses Full harness. Standard function tools require Full harness because the connector transports
+the model's call back to the Responses client; the gateway never executes a caller tool itself.
+External response IDs carry only random thread/turn identity and are accepted for continuation only
+when they were issued in the external ID format.
+
 ### Browser/UI drift
 
 ChatGPT DOM and labels are not a stable API. Selectors are narrow and completion requires stable
@@ -91,7 +105,10 @@ response; the bridge does not fabricate or install a Codex history checkpoint.
 
 ## Network exposure
 
-- Responses and health listeners bind to `127.0.0.1` only.
+- The native Responses and health listener binds to `127.0.0.1` only.
+- The external Responses listener is disabled by default. Its default bind is `127.0.0.1`; a user
+  may explicitly select another local IP. Bearer authentication does not encrypt plain HTTP, so a
+  non-loopback bind requires a trusted private network or TLS termination.
 - Full mode uses OpenAI's outbound HTTPS Secure MCP Tunnel; it opens no public listener or inbound
   firewall rule.
 - The embedded browser connects to ChatGPT, the selected identity provider during explicit sign-in,
@@ -102,3 +119,4 @@ response; the bridge does not fabricate or install a Codex history checkpoint.
 - Defending against a compromised local OS user or compromised Codex/Electron binary.
 - Bypassing ChatGPT plan, workspace, usage, action-control, or model restrictions.
 - Making consumer browser automation equivalent to a supported OpenAI API contract.
+- Providing multi-tenant isolation, billing, or internet-facing TLS termination.

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -825,6 +825,7 @@ export function buildResponseJSON(
   events: AdapterEvent[],
   modelId: string,
   options?: {
+    responseId?: string;
     hideThinkingSummary?: boolean;
     toolNsMap?: Map<string, { namespace: string; name: string }>;
     freeformToolNames?: Set<string>;
@@ -834,7 +835,7 @@ export function buildResponseJSON(
     onProviderState?: (state: CodexProviderContinuationState) => void;
   },
 ): Record<string, unknown> {
-  const responseId = `resp_${uuid()}`;
+  const responseId = options?.responseId ?? `resp_${uuid()}`;
   const output: OutputItem[] = [];
   let usage: CodexUsage | undefined;
   let errorEvent: Extract<AdapterEvent, { type: "error" }> | undefined;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -67,6 +67,11 @@ Setup options:
   --restart-service            Explicitly restart this project's daemon after an update
   --login                      Refresh the stored ChatGPT login even if one exists
   --auto-approve-tool-calls    Opt in to per-call browser clicks on "Allow once" prompts
+  --external-api               Enable the authenticated external Responses listener
+  --no-external-api            Disable the external Responses listener
+  --external-api-host HOST     External listener IP (default: 127.0.0.1)
+  --external-api-port NUMBER   External listener port (default: 17842)
+  --external-api-token TOKEN   Existing bearer token; otherwise setup generates one
   --acknowledge-unofficial     Accept the one-time unofficial-browser-automation notice
 
 Global:
@@ -180,6 +185,19 @@ async function setupCommand(args: string[]): Promise<void> {
   if (runtimeKeyFile) options.runtimeKeyFile = runtimeKeyFile;
   options.forceLogin = takeFlag(args, "--login");
   options.autoApproveToolCalls = takeFlag(args, "--auto-approve-tool-calls");
+  const externalApiEnabled = takeFlag(args, "--external-api");
+  const externalApiDisabled = takeFlag(args, "--no-external-api");
+  if (externalApiEnabled && externalApiDisabled) throw new Error("Choose --external-api or --no-external-api, not both");
+  const externalApiHost = takeOption(args, "--external-api-host");
+  const externalApiPort = takeOption(args, "--external-api-port");
+  const externalApiToken = takeOption(args, "--external-api-token");
+  if ((externalApiHost || externalApiPort || externalApiToken) && !externalApiEnabled) {
+    throw new Error("External API options require --external-api");
+  }
+  if (externalApiEnabled || externalApiDisabled) options.externalApiEnabled = externalApiEnabled;
+  if (externalApiHost) options.externalApiHost = externalApiHost;
+  if (externalApiPort) options.externalApiPort = Number(externalApiPort);
+  if (externalApiToken) options.externalApiToken = externalApiToken;
   options.replaceCodexRoute = takeFlag(args, "--replace-codex-route");
   options.restartService = takeFlag(args, "--restart-service");
   assertNoArgs(args);
@@ -217,6 +235,10 @@ async function setupCommand(args: string[]): Promise<void> {
   if (result.connectorSetupRequired) {
     stdout.write("One account-level step remains: attach the tunnel to the ChatGPT connector named in config.\n");
     stdout.write("Open: https://chatgpt.com/#settings/Plugins\n");
+  }
+  if (externalApiEnabled && result.externalApi) {
+    stdout.write(`External API: http://${result.externalApi.host}:${result.externalApi.port}/v1\n`);
+    stdout.write(`External API token: ${result.externalApi.token}\n`);
   }
   stdout.write("Restart the Codex app once so its native model catalog refreshes through the installed route.\n");
 }
@@ -413,6 +435,9 @@ async function main(): Promise<void> {
     const config = loadConfig();
     const server = startServer(config);
     stdout.write(`codex-chatgpt-web ${VERSION} listening on http://${config.host}:${server.port}/v1 (${config.mode})\n`);
+    if (config.externalApi?.enabled) {
+      stdout.write(`external Responses API listening on http://${config.externalApi.host}:${config.externalApi.port}/v1\n`);
+    }
     await new Promise<void>(() => {});
   } else if (command === "dev") await runDevCommand(args);
   else if (command === "mcp") await runChatGptMcpMain(args);

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ import { createHash, randomBytes } from "node:crypto";
 import { chmodSync, mkdirSync, openSync, closeSync, renameSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, delimiter, dirname, isAbsolute, join, resolve, sep, win32 } from "node:path";
+import { isIP } from "node:net";
 import { tmpdir } from "node:os";
 import type { CodexProviderConfig } from "./types";
 import { VERSION } from "./version";
@@ -61,6 +62,13 @@ export interface TunnelConfig {
   alias: string;
 }
 
+export interface ExternalApiConfig {
+  enabled: true;
+  host: string;
+  port: number;
+  token: string;
+}
+
 export interface AppConfig {
   version: 3;
   purpose?: "dev-harness";
@@ -84,6 +92,24 @@ export interface AppConfig {
   runtimeCommand: string[];
   acknowledgedUnofficialAt?: string;
   tunnel?: TunnelConfig;
+  externalApi?: ExternalApiConfig;
+}
+
+export function assertExternalApiConfig(config: AppConfig, path = "configuration"): void {
+  const external = config.externalApi;
+  if (external === undefined) return;
+  if (!external || typeof external !== "object" || external.enabled !== true) {
+    throw new Error(`Invalid externalApi in ${path}`);
+  }
+  if (external.host !== "localhost" && isIP(external.host) === 0) {
+    throw new Error(`externalApi.host must be localhost or an IP address in ${path}`);
+  }
+  if (!Number.isInteger(external.port) || external.port < 1 || external.port > 65_535) {
+    throw new Error(`Invalid externalApi.port in ${path}`);
+  }
+  if (external.port === config.port) throw new Error(`externalApi.port must differ from the Responses port in ${path}`);
+  if (!/^[A-Za-z0-9_-]{40,}$/.test(external.token)) throw new Error(`Invalid externalApi.token in ${path}`);
+  if (external.token === config.controlToken) throw new Error(`externalApi.token must differ from controlToken in ${path}`);
 }
 
 export function expandUserPath(value: string): string {
@@ -408,6 +434,7 @@ function parseConfig(value: unknown, path: string): AppConfig {
   if (proAvailable && !solAvailable) {
     throw new Error(`Invalid ChatGPT account capabilities in ${path}: Pro requires Sol`);
   }
+  assertExternalApiConfig(parsed as AppConfig, path);
   return { ...parsed, subagentProtocol, solAvailable, proAvailable } as AppConfig;
 }
 

--- a/src/external-api.ts
+++ b/src/external-api.ts
@@ -1,0 +1,247 @@
+import { randomUUID, timingSafeEqual } from "node:crypto";
+import { isAbsolute, resolve } from "node:path";
+import { formatErrorResponse } from "./bridge";
+import {
+  availableChatGptWebModelRoutes,
+  isChatGptWebModelSlug,
+  requireChatGptWebModelRoute,
+} from "./chatgpt-web-models";
+import type { AppConfig } from "./config";
+import { readJsonRequestBody } from "./http-body";
+
+export interface ExternalResponseOptions {
+  responseId: string;
+}
+
+export type ExternalResponsesDelegate = (
+  request: Request,
+  config: AppConfig,
+  options: ExternalResponseOptions,
+) => Promise<Response>;
+
+const RESPONSE_ID = /^resp_ext_([a-f0-9]{32})_([a-f0-9]{32})_[a-f0-9]{16}$/;
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function randomHex(): string {
+  return randomUUID().replaceAll("-", "");
+}
+
+function responseId(threadId: string, turnId: string): string {
+  return `resp_ext_${threadId.slice("ext_thread_".length)}_${turnId.slice("ext_turn_".length)}_${randomHex().slice(0, 16)}`;
+}
+
+function previousIdentity(value: unknown): { threadId: string; turnId: string } | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string") throw new Error("previous_response_id must be a string");
+  const match = RESPONSE_ID.exec(value);
+  if (!match) throw new Error("previous_response_id was not issued by this external API");
+  return { threadId: `ext_thread_${match[1]}`, turnId: `ext_turn_${match[2]}` };
+}
+
+function authorized(request: Request, token: string): boolean {
+  const expected = Buffer.from(`Bearer ${token}`);
+  const actual = Buffer.from(request.headers.get("authorization") ?? "");
+  return actual.length === expected.length && timingSafeEqual(actual, expected);
+}
+
+function externalRoot(): string {
+  const root = process.platform === "win32" ? "C:\\codex-chatgpt-web-external" : "/codex-chatgpt-web-external";
+  if (!isAbsolute(root)) throw new Error("External API read-only root must be absolute");
+  return resolve(root);
+}
+
+function environmentContext(root: string): string {
+  const escaped = root
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+  return `<environment_context>
+  <cwd>${escaped}</cwd>
+  <filesystem><workspace_roots><root>${escaped}</root></workspace_roots><permission_profile type="managed"><file_system type="restricted"></file_system></permission_profile></filesystem>
+</environment_context>`;
+}
+
+function withTurnMetadata(value: unknown, turnId: string): unknown {
+  const item = record(value);
+  if (!item) return value;
+  const message = item.type === "message" || (item.type === undefined && typeof item.role === "string");
+  return {
+    ...item,
+    ...(message ? { type: "message", id: `msg_ext_${randomHex()}` } : {}),
+    internal_chat_message_metadata_passthrough: { turn_id: turnId },
+  };
+}
+
+function inputItemType(value: unknown): string | undefined {
+  const item = record(value);
+  if (!item) return undefined;
+  if (typeof item.type === "string") return item.type;
+  return typeof item.role === "string" ? "message" : undefined;
+}
+
+function validateExternalInput(input: unknown): { hasUser: boolean; error?: string } {
+  if (typeof input === "string") {
+    return input.length > 0
+      ? { hasUser: true }
+      : { hasUser: false, error: "input must not be empty" };
+  }
+  if (!Array.isArray(input) || input.length === 0) {
+    return { hasUser: false, error: "input must be a non-empty string or array" };
+  }
+  const allowed = new Set(["message", "reasoning", "function_call", "function_call_output"]);
+  let hasUser = false;
+  for (const value of input) {
+    const type = inputItemType(value);
+    if (!type || !allowed.has(type)) {
+      return { hasUser: false, error: "External API input supports only messages, reasoning, and function call items" };
+    }
+    const item = record(value)!;
+    if (type === "message" && item.role === "user") hasUser = true;
+  }
+  return { hasUser };
+}
+
+function canonicalInput(input: unknown, turnId: string, root: string): unknown[] {
+  const items = typeof input === "string"
+    ? [{ type: "message", role: "user", content: [{ type: "input_text", text: input }] }]
+    : Array.isArray(input)
+      ? input
+      : [];
+  const normalized = items.map(item => withTurnMetadata(item, turnId));
+  let userIndex = -1;
+  for (let index = normalized.length - 1; index >= 0; index -= 1) {
+    if (inputItemType(normalized[index]) === "message" && record(normalized[index])?.role === "user") {
+      userIndex = index;
+      break;
+    }
+  }
+  if (userIndex < 0) return normalized;
+  let environmentIndex = userIndex;
+  while (environmentIndex > 0 && record(normalized[environmentIndex - 1])?.role === "developer") {
+    environmentIndex -= 1;
+  }
+  normalized.splice(environmentIndex, 0, withTurnMetadata({
+    type: "message",
+    role: "user",
+    content: [{ type: "input_text", text: environmentContext(root) }],
+  }, turnId));
+  return normalized;
+}
+
+function validateExternalTools(value: unknown): { usesTools: boolean; error?: string } {
+  if (value === undefined) return { usesTools: false };
+  if (!Array.isArray(value)) return { usesTools: false, error: "tools must be an array" };
+  const names = new Set<string>();
+  for (const raw of value) {
+    const tool = record(raw);
+    if (!tool || tool.type !== "function" || typeof tool.name !== "string"
+      || !/^[A-Za-z0-9_-]{1,64}$/.test(tool.name)
+      || (tool.description !== undefined && typeof tool.description !== "string")
+      || (tool.parameters !== undefined && !record(tool.parameters))) {
+      return { usesTools: false, error: "External API supports only standard function tools" };
+    }
+    if (names.has(tool.name)) return { usesTools: false, error: `Duplicate tool name: ${tool.name}` };
+    names.add(tool.name);
+  }
+  return { usesTools: value.length > 0 };
+}
+
+function modelsResponse(config: AppConfig): Response {
+  const created = Math.floor(Date.now() / 1_000);
+  return Response.json({
+    object: "list",
+    data: availableChatGptWebModelRoutes(config).map(route => ({
+      id: route.slug,
+      object: "model",
+      created,
+      owned_by: "chatgpt-web",
+    })),
+  });
+}
+
+export async function externalApiRequest(
+  request: Request,
+  config: AppConfig,
+  delegate: ExternalResponsesDelegate,
+): Promise<Response> {
+  if (!config.externalApi?.enabled) return new Response("Not found", { status: 404 });
+  if (!authorized(request, config.externalApi.token)) {
+    return formatErrorResponse(401, "authentication_error", "Invalid external API bearer token");
+  }
+
+  const url = new URL(request.url);
+  if (request.method === "GET" && url.pathname === "/v1/models") return modelsResponse(config);
+  if (request.method !== "POST" || url.pathname !== "/v1/responses") {
+    return new Response("Not found", { status: 404 });
+  }
+
+  let raw: Record<string, unknown>;
+  try {
+    const body = await readJsonRequestBody(request);
+    if (!record(body)) throw new Error("Request body must be a JSON object");
+    raw = body as Record<string, unknown>;
+  } catch (error) {
+    return formatErrorResponse(400, "invalid_request_error", error instanceof Error ? error.message : String(error));
+  }
+
+  if (typeof raw.model !== "string" || !isChatGptWebModelSlug(raw.model)) {
+    return formatErrorResponse(400, "invalid_request_error", "External API model must use a chatgpt-web/ route");
+  }
+  try {
+    requireChatGptWebModelRoute(raw.model, config);
+  } catch (error) {
+    return formatErrorResponse(400, "invalid_request_error", error instanceof Error ? error.message : String(error));
+  }
+  const inputValidation = validateExternalInput(raw.input);
+  if (inputValidation.error) return formatErrorResponse(400, "invalid_request_error", inputValidation.error);
+  const toolValidation = validateExternalTools(raw.tools);
+  if (toolValidation.error) return formatErrorResponse(400, "invalid_request_error", toolValidation.error);
+  if (toolValidation.usesTools && config.mode !== "full") {
+    return formatErrorResponse(400, "invalid_request_error", "External function tools require a configured Full harness");
+  }
+
+  let previous: ReturnType<typeof previousIdentity>;
+  try {
+    previous = previousIdentity(raw.previous_response_id);
+  } catch (error) {
+    return formatErrorResponse(400, "invalid_request_error", error instanceof Error ? error.message : String(error));
+  }
+  const currentUserMessage = inputValidation.hasUser;
+  if (!previous && !currentUserMessage) {
+    return formatErrorResponse(400, "invalid_request_error", "A new external response requires user input");
+  }
+  const threadId = previous?.threadId ?? `ext_thread_${randomHex()}`;
+  const turnId = previous && !currentUserMessage ? previous.turnId : `ext_turn_${randomHex()}`;
+  const root = externalRoot();
+  const metadata = {
+    thread_id: threadId,
+    turn_id: turnId,
+    request_kind: "turn",
+    sandbox: "read-only",
+    workspaces: { [root]: {} },
+  };
+  const body = {
+    ...raw,
+    input: canonicalInput(raw.input, turnId, root),
+    prompt_cache_key: threadId,
+    client_metadata: { "x-codex-turn-metadata": JSON.stringify(metadata) },
+  };
+  const headers = new Headers(request.headers);
+  headers.delete("authorization");
+  headers.set("content-type", "application/json");
+  const internal = new Request("http://127.0.0.1/v1/responses", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+    signal: request.signal,
+  });
+  const scopedConfig = toolValidation.usesTools ? config : { ...config, mode: "browser-only" as const };
+  return delegate(internal, scopedConfig, { responseId: responseId(threadId, turnId) });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,7 +6,7 @@ import { chatGptTurnSessions } from "./adapters/chatgpt-web/turn-execution";
 import { chatGptBrowserTabClosedError } from "./adapters/chatgpt-web/adapter-error";
 import { bridgeToResponsesSSE, buildResponseJSON, formatErrorResponse } from "./bridge";
 import type { AppConfig } from "./config";
-import { providerConfig } from "./config";
+import { assertExternalApiConfig, providerConfig } from "./config";
 import { AsyncEventQueue } from "./event-queue";
 import { readJsonRequestBody } from "./http-body";
 import { httpStatusFromTerminalError } from "./lib/errors";
@@ -36,6 +36,7 @@ import { namespacedToolName, type AdapterEvent, type CodexParsedRequest } from "
 import type { CodexProviderConfig } from "./types";
 import type { ProviderAdapter } from "./adapters/base";
 import { VERSION } from "./version";
+import { externalApiRequest } from "./external-api";
 
 export class HttpTurnCounter {
   private readonly active = new Map<number, {
@@ -173,13 +174,20 @@ export class HttpTurnCounter {
   }
 }
 
-type ChatGptWebAdapterFactory = (provider: CodexProviderConfig) => ProviderAdapter;
+export type ChatGptWebAdapterFactory = (provider: CodexProviderConfig) => ProviderAdapter;
 
 export interface ResponseRequestOptions {
+  /** Use a caller-owned Responses id. */
+  responseId?: string;
   /** DEV and other in-process harnesses can keep continuation state in their own canonical store. */
   rememberState?: boolean;
   /** Observe the exact production adapter stream when invoking the handler in-process. */
   onAdapterEvent?: (event: AdapterEvent) => void;
+}
+
+export interface AppServer {
+  port: number;
+  stop(closeActiveConnections?: boolean): Promise<void>;
 }
 
 export function routeChatGptWebRequest(parsed: CodexParsedRequest, config: AppConfig): ChatGptWebModelRoute {
@@ -383,6 +391,7 @@ export async function responseRequest(
       () => abort.abort(),
       2_000,
       {
+        ...(options.responseId ? { responseId: options.responseId } : {}),
         hideThinkingSummary: parsed.options.hideThinkingSummary,
         ...(compaction ? { compaction: true } : {
           ...(options.rememberState === false ? {} : {
@@ -404,6 +413,7 @@ export async function responseRequest(
   await run();
   const events = await queue.collect();
   const json = buildResponseJSON(events, responseModel, {
+    ...(options.responseId ? { responseId: options.responseId } : {}),
     hideThinkingSummary: parsed.options.hideThinkingSummary,
     toolNsMap: maps.toolNsMap,
     freeformToolNames: maps.freeformToolNames,
@@ -527,19 +537,13 @@ export async function compactRequest(
 export function startServer(
   config: AppConfig,
   dependencies: { fetchUpstream?: NativeFetch } = {},
-): ReturnType<typeof Bun.serve> {
+): AppServer {
   if (config.purpose === "dev-harness") {
     throw new Error("DEV harness configuration cannot start a Responses listener");
   }
+  assertExternalApiConfig(config);
   const startedAt = Date.now();
   const turnBroker = config.mode === "full" ? TurnBroker.forSocket(config.brokerSocketPath) : undefined;
-  if (config.mode === "full") {
-    void turnBroker!.listen().catch(error => {
-      console.error(
-        `[chatgpt-web] turn broker endpoint is unavailable: ${error instanceof Error ? error.message : String(error)}`,
-      );
-    });
-  }
   let draining = false;
   let shutdownPromise: Promise<void> | undefined;
   let successfulModelCatalogRequests = 0;
@@ -692,6 +696,43 @@ export function startServer(
       return new Response("Not found", { status: 404 });
     },
   });
+  let externalServer: ReturnType<typeof Bun.serve> | undefined;
+  try {
+    if (config.externalApi?.enabled) {
+      externalServer = Bun.serve({
+        hostname: config.externalApi.host,
+        port: config.externalApi.port,
+        idleTimeout: 0,
+        fetch(req) {
+          if (draining) return formatErrorResponse(503, "server_error", "codex-chatgpt-web is draining for a requested service operation");
+          return httpTurns.track(
+            signal => externalApiRequest(
+              new Request(req, { signal }),
+              config,
+              (internal, scopedConfig, options) => responseRequest(internal, scopedConfig, createChatGptWebAdapter, options),
+            ),
+            req.signal,
+          );
+        },
+      });
+    }
+  } catch (error) {
+    void server.stop(true);
+    throw error;
+  }
+  if (config.mode === "full") {
+    void turnBroker!.listen().catch(error => {
+      console.error(
+        `[chatgpt-web] turn broker endpoint is unavailable: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    });
+  }
+  const stop = async (closeActiveConnections?: boolean): Promise<void> => {
+    await Promise.all([
+      ...(externalServer ? [externalServer.stop(closeActiveConnections)] : []),
+      server.stop(closeActiveConnections),
+    ]);
+  };
   function shutdown(): void {
     if (shutdownPromise) return;
     draining = true;
@@ -711,7 +752,7 @@ export function startServer(
           console.error(`[codex-chatgpt-web] shutdown cleanup failed: ${failure instanceof Error ? failure.message : String(failure)}`);
         }
       }
-      await server.stop(true);
+      await stop(true);
     })().catch(error => {
       process.exitCode = 1;
       console.error(`[codex-chatgpt-web] server shutdown failed: ${error instanceof Error ? error.message : String(error)}`);
@@ -719,5 +760,5 @@ export function startServer(
   }
   process.once("SIGINT", shutdown);
   process.once("SIGTERM", shutdown);
-  return server;
+  return { port: server.port!, stop };
 }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -2,8 +2,9 @@ import { existsSync } from "node:fs";
 import { randomBytes } from "node:crypto";
 import { createServer } from "node:net";
 import { join } from "node:path";
-import type { AppConfig, RuntimeMode, SubagentProtocol } from "./config";
+import type { AppConfig, ExternalApiConfig, RuntimeMode, SubagentProtocol } from "./config";
 import {
+  assertExternalApiConfig,
   currentRuntimeCommand,
   defaultBrokerEndpoint,
   defaultConfig,
@@ -58,6 +59,10 @@ export interface SetupOptions {
   tunnelId?: string;
   runtimeKeyFile?: string;
   runtimeKeyValue?: string;
+  externalApiEnabled?: boolean;
+  externalApiHost?: string;
+  externalApiPort?: number;
+  externalApiToken?: string;
 }
 
 export interface SetupResult {
@@ -68,6 +73,7 @@ export interface SetupResult {
   tunnelReady: boolean | null;
   codexRestartRequired: true;
   connectorSetupRequired: boolean;
+  externalApi?: ExternalApiConfig;
 }
 
 export interface DevProfileSetupResult {
@@ -126,6 +132,7 @@ function meaningfulRuntimeChange(before: AppConfig, after: AppConfig): boolean {
     controlToken: before.controlToken,
     runtimeCommand: before.runtimeCommand,
     tunnel: before.tunnel,
+    externalApi: before.externalApi,
   }) !== JSON.stringify({
     mode: after.mode,
     subagentProtocol: after.subagentProtocol,
@@ -146,6 +153,7 @@ function meaningfulRuntimeChange(before: AppConfig, after: AppConfig): boolean {
     controlToken: after.controlToken,
     runtimeCommand: after.runtimeCommand,
     tunnel: after.tunnel,
+    externalApi: after.externalApi,
   });
 }
 
@@ -225,6 +233,16 @@ function baseConfig(existing: AppConfig | undefined, options: SetupOptions): App
   config.appName = resolveSetupConnectorName(existing?.appName, options.appName);
   if (options.autoApproveToolCalls !== undefined) config.autoApproveToolCalls = options.autoApproveToolCalls;
   if (options.acknowledgedUnofficial) config.acknowledgedUnofficialAt = new Date().toISOString();
+  if (options.externalApiEnabled === false) delete config.externalApi;
+  if (options.externalApiEnabled === true) {
+    config.externalApi = {
+      enabled: true,
+      host: options.externalApiHost ?? config.externalApi?.host ?? "127.0.0.1",
+      port: options.externalApiPort ?? config.externalApi?.port ?? 17_842,
+      token: options.externalApiToken ?? config.externalApi?.token ?? randomBytes(32).toString("base64url"),
+    };
+  }
+  assertExternalApiConfig(config);
   if (!config.acknowledgedUnofficialAt) {
     throw new Error("Setup requires explicit acknowledgement that this is unofficial browser automation. Pass --acknowledge-unofficial.");
   }
@@ -462,6 +480,7 @@ export async function setup(options: SetupOptions): Promise<SetupResult> {
     tunnelReady,
     codexRestartRequired: true,
     connectorSetupRequired: config.mode === "full",
+    ...(config.externalApi ? { externalApi: config.externalApi } : {}),
   };
 }
 

--- a/tests/external-api.test.ts
+++ b/tests/external-api.test.ts
@@ -1,0 +1,242 @@
+import { expect, test } from "bun:test";
+import { assertExternalApiConfig, defaultConfig } from "../src/config";
+import { externalApiRequest } from "../src/external-api";
+import { responseRequest, type ChatGptWebAdapterFactory } from "../src/server";
+import { extractChatGptTurnEnvironment, extractChatGptTurnIdentity } from "../src/adapters/chatgpt-web/environment";
+import type { CodexProviderConfig } from "../src/types";
+
+const TOKEN = "external_api_token_abcdefghijklmnopqrstuvwxyz_1234567890";
+
+function externalConfig() {
+  const config = defaultConfig("full");
+  config.proAvailable = true;
+  config.externalApi = { enabled: true, host: "127.0.0.1", port: 17842, token: TOKEN };
+  return config;
+}
+
+function request(path: string, body?: unknown, token = TOKEN) {
+  return new Request(`http://127.0.0.1:17842${path}`, {
+    method: body === undefined ? "GET" : "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      ...(body === undefined ? {} : { "content-type": "application/json" }),
+    },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+}
+
+function handle(request: Request, config = externalConfig(), adapterFactory?: ChatGptWebAdapterFactory) {
+  return externalApiRequest(request, config, (internal, scopedConfig, options) => {
+    if (!adapterFactory) throw new Error("response delegate must not be called");
+    return responseRequest(internal, scopedConfig, adapterFactory, options);
+  });
+}
+
+test("external API requires its own bearer token and exposes only external routes", async () => {
+  const config = externalConfig();
+  expect((await handle(new Request("http://127.0.0.1:17842/v1/models"), config)).status).toBe(401);
+  expect((await handle(request("/admin/shutdown", {}), config)).status).toBe(404);
+
+  const models = await handle(request("/v1/models"), config);
+  expect(models.status).toBe(200);
+  const catalog = await models.json() as { object: string; data: Array<{ id: string }> };
+  expect(catalog.object).toBe("list");
+  expect(catalog.data.map(model => model.id)).toEqual([
+    "chatgpt-web/light", "chatgpt-web/medium", "chatgpt-web/high", "chatgpt-web/extra-high", "chatgpt-web/pro",
+  ]);
+});
+
+test("external API rejects native models before the internal passthrough branch", async () => {
+  const response = await handle(request("/v1/responses", {
+    model: "gpt-5.6-sol",
+    input: "hello",
+  }), externalConfig());
+
+  expect(response.status).toBe(400);
+  expect(await response.text()).toContain("chatgpt-web/");
+});
+
+test("external API rejects native input items before continuation replay", async () => {
+  for (const type of ["additional_tools", "compaction_trigger", "custom_tool_call_output"]) {
+    const response = await handle(request("/v1/responses", {
+      model: "chatgpt-web/high",
+      previous_response_id: `resp_ext_${"a".repeat(32)}_${"b".repeat(32)}_${"c".repeat(16)}`,
+      input: [{ type }],
+    }), externalConfig());
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain("supports only messages");
+  }
+});
+
+test("external Responses requests receive safe canonical turn metadata", async () => {
+  const config = externalConfig();
+  let identity: ReturnType<typeof extractChatGptTurnIdentity> | undefined;
+  const response = await handle(request("/v1/responses", {
+    model: "chatgpt-web/high",
+    input: "Explain this API in one sentence.",
+  }), config, provider => {
+    expect(provider.chatgptWeb?.localToolsEnabled).toBe(false);
+    return {
+      name: "external-api-test",
+      async runTurn(parsed, _incoming, emit) {
+        identity = extractChatGptTurnIdentity(parsed);
+        expect(identity.turnId).toMatch(/^ext_turn_/);
+        expect(identity.threadId).toMatch(/^ext_thread_/);
+        emit({ type: "text_delta", text: "External API works." });
+        emit({ type: "done", endTurn: true });
+      },
+    };
+  });
+
+  expect(response.status).toBe(200);
+  const body = await response.json() as { id: string; model: string; output: unknown[] };
+  expect(body.id).toMatch(/^resp_ext_/);
+  expect(body.model).toBe("chatgpt-web/high");
+  expect(body.output).not.toHaveLength(0);
+  expect(identity?.turnId).toBeTruthy();
+});
+
+test("external tools use a synthetic read-only environment and keep the same turn across tool output", async () => {
+  const config = externalConfig();
+  const identities: Array<ReturnType<typeof extractChatGptTurnIdentity>> = [];
+  let calls = 0;
+  const adapterFactory = (provider: CodexProviderConfig) => {
+    expect(provider.chatgptWeb?.localToolsEnabled).toBe(true);
+    return {
+      name: "external-api-tools-test",
+      async runTurn(parsed: any, _incoming: any, emit: any) {
+        identities.push(extractChatGptTurnIdentity(parsed));
+        expect(extractChatGptTurnEnvironment(parsed).sandboxPolicy.type).toBe("readOnly");
+        calls += 1;
+        if (calls === 1) {
+          emit({ type: "tool_call_start", id: "call_weather", name: "weather" });
+          emit({ type: "tool_call_delta", arguments: JSON.stringify({ city: "Toronto" }) });
+          emit({ type: "tool_call_end" });
+          emit({ type: "done", endTurn: false });
+        } else {
+          emit({ type: "text_delta", text: "It is sunny." });
+          emit({ type: "done", endTurn: true });
+        }
+      },
+    };
+  };
+  const tools = [{
+    type: "function",
+    name: "weather",
+    description: "Get weather",
+    parameters: { type: "object", properties: { city: { type: "string" } }, required: ["city"] },
+  }];
+
+  const first = await handle(request("/v1/responses", {
+    model: "chatgpt-web/high", input: "What is the weather?", tools,
+  }), config, adapterFactory);
+  const firstBody = await first.json() as { id: string; output: Array<Record<string, unknown>> };
+  expect(first.status).toBe(200);
+  expect(firstBody.output).toContainEqual(expect.objectContaining({
+    type: "function_call", call_id: "call_weather", name: "weather",
+  }));
+
+  const second = await handle(request("/v1/responses", {
+    model: "chatgpt-web/high",
+    previous_response_id: firstBody.id,
+    input: [{ type: "function_call_output", call_id: "call_weather", output: "sunny" }],
+    tools,
+  }), config, adapterFactory);
+  expect(second.status).toBe(200);
+  expect(identities).toHaveLength(2);
+  expect(identities[1]!.threadId).toBe(identities[0]!.threadId);
+  expect(identities[1]!.turnId).toBe(identities[0]!.turnId);
+});
+
+test("external function tools fail closed without the Full harness", async () => {
+  const config = externalConfig();
+  config.mode = "browser-only";
+  const response = await handle(request("/v1/responses", {
+    model: "chatgpt-web/high",
+    input: "Use the weather tool.",
+    tools: [{ type: "function", name: "weather", parameters: { type: "object" } }],
+  }), config);
+
+  expect(response.status).toBe(400);
+  expect(await response.text()).toContain("Full harness");
+});
+
+test("external continuations keep the thread but start a new logical turn for new user input", async () => {
+  const identities: Array<ReturnType<typeof extractChatGptTurnIdentity>> = [];
+  const adapterFactory: ChatGptWebAdapterFactory = () => ({
+    name: "external-api-continuation-test",
+    async runTurn(parsed, _incoming, emit) {
+      identities.push(extractChatGptTurnIdentity(parsed));
+      expect(extractChatGptTurnEnvironment(parsed).cwd).toContain("codex-chatgpt-web-external");
+      emit({ type: "text_delta", text: "ok" });
+      emit({ type: "done", endTurn: true });
+    },
+  });
+  const first = await handle(request("/v1/responses", {
+    model: "chatgpt-web/high",
+    input: "First question",
+    client_metadata: { "x-codex-turn-metadata": { thread_id: "attacker", turn_id: "attacker" } },
+  }), externalConfig(), adapterFactory);
+  const firstBody = await first.json() as { id: string };
+  const second = await handle(request("/v1/responses", {
+    model: "chatgpt-web/high",
+    previous_response_id: firstBody.id,
+    input: "Second question",
+  }), externalConfig(), adapterFactory);
+
+  expect(second.status).toBe(200);
+  expect(identities[1]!.threadId).toBe(identities[0]!.threadId);
+  expect(identities[1]!.turnId).not.toBe(identities[0]!.turnId);
+  expect(identities[0]).not.toMatchObject({ threadId: "attacker", turnId: "attacker" });
+});
+
+test("external streaming responses use the external continuation id", async () => {
+  const response = await handle(request("/v1/responses", {
+    model: "chatgpt-web/high",
+    input: "Stream this",
+    stream: true,
+  }), externalConfig(), () => ({
+    name: "external-api-stream-test",
+    async runTurn(_parsed, _incoming, emit) {
+      emit({ type: "text_delta", text: "streamed" });
+      emit({ type: "done", endTurn: true });
+    },
+  }));
+  const body = await response.text();
+
+  expect(response.headers.get("content-type")).toContain("text/event-stream");
+  expect(body).toContain('"id":"resp_ext_');
+  expect(body).toContain("response.completed");
+});
+
+test("external listener configuration rejects shared ports and control tokens", () => {
+  const config = externalConfig();
+  expect(() => assertExternalApiConfig(config)).not.toThrow();
+  config.externalApi!.port = config.port;
+  expect(() => assertExternalApiConfig(config)).toThrow("must differ from the Responses port");
+  config.externalApi!.port += 1;
+  config.externalApi!.token = config.controlToken;
+  expect(() => assertExternalApiConfig(config)).toThrow("must differ from controlToken");
+});
+
+test("startServer owns the external listener lifecycle", async () => {
+  const probe = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch: () => new Response() });
+  const port = probe.port!;
+  await probe.stop(true);
+  const config = externalConfig();
+  config.mode = "browser-only";
+  config.port = 0;
+  config.externalApi!.port = port;
+  const server = (await import("../src/server")).startServer(config);
+  try {
+    const unauthorized = await fetch(`http://127.0.0.1:${port}/v1/models`);
+    expect(unauthorized.status).toBe(401);
+    const models = await fetch(`http://127.0.0.1:${port}/v1/models`, {
+      headers: { authorization: `Bearer ${TOKEN}` },
+    });
+    expect(models.status).toBe(200);
+  } finally {
+    await server.stop(true);
+  }
+  expect(fetch(`http://127.0.0.1:${port}/v1/models`)).rejects.toThrow();
+});


### PR DESCRIPTION
## Summary
- add an opt-in, separately authenticated OpenAI Responses API listener
- expose only `chatgpt-web/*` models through `/v1/models` and `/v1/responses`
- normalize external requests into server-owned thread/turn metadata and a synthetic read-only environment
- support streaming, `previous_response_id`, and standard function-tool round trips in Full harness mode
- add setup flags, lifecycle integration, security documentation, and focused network/boundary tests

## Security
- disabled by default with a generated 256-bit bearer token
- no native model passthrough, admin, health, search, compaction, or native input items
- bearer credentials are stripped before internal dispatch
- requests without tools are forced to browser-only mode
- caller metadata and workspace authority are discarded

## Verification
- `bun test tests/external-api.test.ts tests/server-lifecycle.test.ts tests/setup-lifecycle.test.ts tests/cli.test.ts` (39 pass)
- `bun run typecheck`
- `bun run build`
- `bun audit` (no vulnerabilities)
- full Windows suite reached 357 pass / 1 unchanged baseline failure in `tests/dev-profile.test.ts` (Windows launcher candidate resolves the real profile instead of the injected test home); the file matches `upstream/main`