### PR TITLE
fix(browser): stabilize replaced turns and tool markdown

### DIFF
--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -88,6 +88,8 @@ export const CHATGPT_COMPLETION_SETTLE_MS = 2_000;
 export const CHATGPT_TOOL_CONFIRMATION_TIMEOUT_MS = 60_000;
 export const MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS = 3;
 const CHATGPT_CONVERSATION_TURN_SELECTOR = '[data-testid^="conversation-turn-"]';
+const CHATGPT_TOOL_MARKER_SELECTOR = '[data-testid^="cot-v5-tool-"], [data-testid^="cot-v5-native-tool-"]';
+const CHATGPT_SCREENSHOT_CONTENT_SELECTOR = "[data-conversation-screenshot-content]";
 const CHATGPT_SMOKE_TEXT = "Reply with exactly: CODEX WEB GPT READY";
 const CHATGPT_SMOKE_EXPECTED = "CODEX WEB GPT READY";
 /**
@@ -1838,8 +1840,13 @@ export class ChatGptBrowserWorker {
   }
 
   private async responseDomSnapshot(responseTurn: Locator): Promise<ChatGptResponseDomSnapshot> {
-    const snapshot = await responseTurn.evaluate((element, completionActionSelector) => {
+    const snapshot = await responseTurn.evaluate((element, selectors) => {
       const root = element as HTMLElement;
+      const {
+        completionActionSelector,
+        screenshotContentSelector,
+        toolMarkerSelector,
+      } = selectors;
       // Browser turn WebContents are intentionally allowed to run while their Electron view is
       // hidden or has no measured width. Layout geometry is therefore not response visibility:
       // completed Markdown can have width=0 while remaining connected, rendered and readable.
@@ -1856,9 +1863,19 @@ export class ChatGptBrowserWorker {
       // render a completed commentary Markdown root immediately before that live status container.
       // Final-answer Markdown follows the live status instead, so DOM order remains the semantic
       // boundary without relying on localized labels such as "Pro thinking".
+      const toolOwnedMarkdownRoot = (candidate: HTMLElement): boolean => {
+        let container = candidate.parentElement;
+        while (container && container !== root) {
+          if (container.querySelector(toolMarkerSelector)) return true;
+          if (container.matches(screenshotContentSelector)) break;
+          container = container.parentElement;
+        }
+        return false;
+      };
       const allMarkdownRoots = [...root.querySelectorAll<HTMLElement>(".markdown")]
         .filter(candidate => !candidate.parentElement?.closest(".markdown"))
-        .filter(renderedInDom);
+        .filter(renderedInDom)
+        .filter(candidate => !toolOwnedMarkdownRoot(candidate));
       const streamingStatusContainers = [...root.querySelectorAll<HTMLElement>("[data-streaming-response-status]")]
         .filter(renderedInDom);
       const commentaryRoots = allMarkdownRoots.filter(candidate => (
@@ -2015,7 +2032,11 @@ export class ChatGptBrowserWorker {
         completionActionVisible: completionAction !== undefined,
         traceBlocks,
       };
-    }, CHATGPT_COMPLETION_ACTION_SELECTOR, { timeout: 2_000 }).catch(() => {
+    }, {
+      completionActionSelector: CHATGPT_COMPLETION_ACTION_SELECTOR,
+      screenshotContentSelector: CHATGPT_SCREENSHOT_CONTENT_SELECTOR,
+      toolMarkerSelector: CHATGPT_TOOL_MARKER_SELECTOR,
+    }, { timeout: 2_000 }).catch(() => {
       if (responseTurn.page().isClosed()) {
         throw chatGptBrowserTabClosedError();
       }

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -87,6 +87,7 @@ export const CHATGPT_COMPLETION_ACTION_GRACE_MS = 60_000;
 export const CHATGPT_COMPLETION_SETTLE_MS = 2_000;
 export const CHATGPT_TOOL_CONFIRMATION_TIMEOUT_MS = 60_000;
 export const MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS = 3;
+const CHATGPT_CONVERSATION_TURN_SELECTOR = '[data-testid^="conversation-turn-"]';
 const CHATGPT_SMOKE_TEXT = "Reply with exactly: CODEX WEB GPT READY";
 const CHATGPT_SMOKE_EXPECTED = "CODEX WEB GPT READY";
 /**
@@ -389,6 +390,28 @@ export function chatGptSubmissionEvidence(state: {
   if (state.userTurnCount > state.initialUserTurnCount) return "user_turn";
   if (state.assistantTurnCount > state.initialAssistantTurnCount) return "assistant_turn";
   if (state.generationRunning) return "generation_running";
+  return undefined;
+}
+
+export interface ChatGptConversationTurnDescriptor {
+  testId: string | null;
+  isUser: boolean;
+  hasResponseEvidence: boolean;
+}
+
+export function chatGptCurrentResponseTurnIndex(
+  turns: readonly ChatGptConversationTurnDescriptor[],
+  initialTurnIds: readonly string[],
+): number | undefined {
+  const initial = new Set(initialTurnIds);
+  const currentUserIndex = turns.findLastIndex(turn => turn.isUser);
+  for (let index = turns.length - 1; index > currentUserIndex; index -= 1) {
+    const turn = turns[index]!;
+    if (turn.testId
+      && !turn.isUser
+      && turn.hasResponseEvidence
+      && !initial.has(turn.testId)) return index;
+  }
   return undefined;
 }
 
@@ -1237,7 +1260,8 @@ export class ChatGptBrowserWorker {
     page: Page,
     userTurns: Locator,
     responseTurns: Locator,
-    responseTurn: Locator,
+    conversationTurns: Locator,
+    initialConversationTurnIds: readonly string[],
     initialUserTurnCount: number,
     initialResponseTurnCount: number,
     signal?: AbortSignal,
@@ -1246,7 +1270,11 @@ export class ChatGptBrowserWorker {
     for (;;) {
       if (signal?.aborted) throw new DOMException("ChatGPT web turn aborted", "AbortError");
       await throwIfChatGptSessionFailureAlert(page);
-      await throwIfChatGptTerminalErrorAlert(responseTurn);
+      const responseTurn = await this.currentResponseTurn(
+        conversationTurns,
+        initialConversationTurnIds,
+      );
+      if (responseTurn) await throwIfChatGptTerminalErrorAlert(responseTurn);
       const evidence = await this.currentSubmissionEvidence(
         page,
         userTurns,
@@ -1278,6 +1306,32 @@ export class ChatGptBrowserWorker {
       assistantTurnCount,
       generationRunning: visibleStopButtonCount > 0,
     });
+  }
+
+  private async currentResponseTurn(
+    conversationTurns: Locator,
+    initialConversationTurnIds: readonly string[],
+  ): Promise<Locator | undefined> {
+    const turns = await conversationTurns.evaluateAll((elements, completionActionSelector) => (
+      elements.map(element => ({
+        testId: element.getAttribute("data-testid"),
+        isUser: element.matches('[data-turn="user"], [data-message-author-role="user"]')
+          || element.querySelector('[data-message-author-role="user"]') !== null,
+        hasResponseEvidence: element.matches('[data-turn="assistant"], [data-message-author-role="assistant"]')
+          || element.querySelector([
+            '[data-message-author-role="assistant"]',
+            "[data-streaming-response-status]",
+            ".markdown",
+            '[role="alert"]',
+            '[role="status"]',
+            '[aria-busy="true"]',
+            completionActionSelector,
+          ].join(", ")) !== null,
+      }))
+    ), CHATGPT_COMPLETION_ACTION_SELECTOR);
+    const index = chatGptCurrentResponseTurnIndex(turns, initialConversationTurnIds);
+    const testId = index === undefined ? undefined : turns[index]?.testId;
+    return testId ? conversationTurns.page().getByTestId(testId) : undefined;
   }
 
   private async attachedPromptText(page: Page): Promise<string> {
@@ -1973,8 +2027,8 @@ export class ChatGptBrowserWorker {
     return snapshot;
   }
 
-  private async stalledTurnDiagnostic(page: Page, responseTurn: Locator): Promise<string> {
-    const responseState = await responseTurn.count()
+  private async stalledTurnDiagnostic(page: Page, responseTurn?: Locator): Promise<string> {
+    const responseState = responseTurn && await responseTurn.count()
       ? await responseTurn.evaluate(element => {
         const root = element as HTMLElement;
         const descriptors = [...root.querySelectorAll<HTMLElement>("[role], [data-testid], button, [aria-label]")]
@@ -2166,9 +2220,14 @@ export class ChatGptBrowserWorker {
           checkpoint => diagnostics.capture(page, checkpoint),
         ),
       );
+      const conversationTurns = page.locator(CHATGPT_CONVERSATION_TURN_SELECTOR);
+      const initialConversationTurnIds = await conversationTurns.evaluateAll(elements => (
+        elements
+          .map(element => element.getAttribute("data-testid"))
+          .filter((testId): testId is string => Boolean(testId))
+      ));
       const responseTurns = page.locator(CHATGPT_ASSISTANT_TURN_SELECTOR);
       const initialResponseTurnCount = await responseTurns.count();
-      const responseTurn = responseTurns.nth(initialResponseTurnCount);
       const userTurns = page.locator(CHATGPT_USER_TURN_SELECTOR);
       const initialUserTurnCount = await userTurns.count();
       const submissionBaseline: ChatGptSubmissionBaseline = {
@@ -2250,7 +2309,8 @@ export class ChatGptBrowserWorker {
           page,
           userTurns,
           responseTurns,
-          responseTurn,
+          conversationTurns,
+          initialConversationTurnIds,
           initialUserTurnCount,
           initialResponseTurnCount,
           stageSignal,
@@ -2294,7 +2354,11 @@ export class ChatGptBrowserWorker {
         }
 
         await throwIfChatGptSessionFailureAlert(page);
-        await throwIfChatGptTerminalErrorAlert(responseTurn);
+        const responseTurn = await this.currentResponseTurn(
+          conversationTurns,
+          initialConversationTurnIds,
+        );
+        if (responseTurn) await throwIfChatGptTerminalErrorAlert(responseTurn);
 
         if (mode.localTools && await resolveChatGptToolConfirmation(
           page,
@@ -2308,7 +2372,9 @@ export class ChatGptBrowserWorker {
           continue;
         }
 
-        const snapshot = await this.responseDomSnapshot(responseTurn);
+        const snapshot = responseTurn
+          ? await this.responseDomSnapshot(responseTurn)
+          : absentResponseDomSnapshot();
         const stop = page.locator(CHATGPT_STOP_BUTTON_SELECTOR).last();
         const running = await stop.isVisible().catch(() => false);
         if (running) sawRunning = true;

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import type { Page } from "playwright-core";
-import { CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_PROMPT_INSERT_CHUNK_CHARS, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptSubmissionEvidence, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert } from "../src/adapters/chatgpt-web/browser-worker";
+import { CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_PROMPT_INSERT_CHUNK_CHARS, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptCurrentResponseTurnIndex, chatGptSubmissionEvidence, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert } from "../src/adapters/chatgpt-web/browser-worker";
 import { CHATGPT_WEB_MODEL_ID } from "../src/adapters/chatgpt-web/model";
 import { compileChatGptWebPrompt } from "../src/adapters/chatgpt-web/prompt";
 import { CHATGPT_CONNECTOR_NAME, DEV_CHATGPT_CONNECTOR_NAME, defaultChromeExecutable, legacyChatGptConnectorMigrationMessage } from "../src/config";
@@ -1264,7 +1264,8 @@ test("submission acceptance stops when its stage is aborted", async () => {
       page: Page,
       userTurns: unknown,
       responseTurns: unknown,
-      responseTurn: unknown,
+      conversationTurns: unknown,
+      initialConversationTurnIds: readonly string[],
       initialUserTurnCount: number,
       initialResponseTurnCount: number,
       signal: AbortSignal,
@@ -1279,6 +1280,7 @@ test("submission acceptance stops when its stage is aborted", async () => {
     {},
     {},
     {},
+    [],
     0,
     0,
     controller.signal,
@@ -1756,6 +1758,69 @@ test("browser send accepts only conclusive ChatGPT submission evidence", () => {
   expect(chatGptSubmissionEvidence({ ...idle, userTurnCount: 2 })).toBe("user_turn");
   expect(chatGptSubmissionEvidence({ ...idle, assistantTurnCount: 3 })).toBe("assistant_turn");
   expect(chatGptSubmissionEvidence({ ...idle, generationRunning: true })).toBe("generation_running");
+});
+
+test("current response identity follows a removed provisional turn to its replacement", () => {
+  const initialTurnIds = ["conversation-turn-old-user", "conversation-turn-old-assistant"];
+  const oldTurns = [
+    { testId: initialTurnIds[0]!, isUser: true, hasResponseEvidence: false },
+    { testId: initialTurnIds[1]!, isUser: false, hasResponseEvidence: true },
+  ];
+  const currentUser = {
+    testId: "conversation-turn-current-user",
+    isUser: true,
+    hasResponseEvidence: false,
+  };
+  const provisional = {
+    testId: "conversation-turn-provisional",
+    isUser: false,
+    hasResponseEvidence: true,
+  };
+
+  expect(chatGptCurrentResponseTurnIndex(
+    [...oldTurns, currentUser, provisional],
+    initialTurnIds,
+  )).toBe(3);
+  expect(chatGptCurrentResponseTurnIndex(
+    [...oldTurns, currentUser],
+    initialTurnIds,
+  )).toBeUndefined();
+  expect(chatGptCurrentResponseTurnIndex(
+    [oldTurns[0]!, {
+      testId: "conversation-turn-old-assistant-replaced",
+      isUser: false,
+      hasResponseEvidence: true,
+    }, currentUser],
+    initialTurnIds,
+  )).toBeUndefined();
+  expect(chatGptCurrentResponseTurnIndex(
+    [...oldTurns, currentUser, {
+      testId: "conversation-turn-generic-wrapper",
+      isUser: false,
+      hasResponseEvidence: false,
+    }],
+    initialTurnIds,
+  )).toBeUndefined();
+  for (const unowned of [
+    { testId: null, isUser: false, hasResponseEvidence: true },
+    { testId: initialTurnIds[1]!, isUser: false, hasResponseEvidence: true },
+    { testId: "conversation-turn-current-user-replacement", isUser: true, hasResponseEvidence: true },
+  ]) {
+    expect(chatGptCurrentResponseTurnIndex(
+      [...oldTurns, currentUser, unowned],
+      initialTurnIds,
+    )).toBeUndefined();
+  }
+
+  const replacement = {
+    testId: "conversation-turn-replacement",
+    isUser: false,
+    hasResponseEvidence: true,
+  };
+  expect(chatGptCurrentResponseTurnIndex(
+    [...oldTurns, currentUser, replacement],
+    initialTurnIds,
+  )).toBe(3);
 });
 
 test("visible reasoning keeps the browser turn healthy before final assistant markdown exists", () => {

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -1625,6 +1625,20 @@ test("response DOM separates streaming commentary from the final Markdown answer
   expect(workerSource).not.toContain('fullHtml: rendered?.innerHTML ?? ""');
 });
 
+test("response DOM excludes mutable native tool Markdown without disabling live answer streaming", () => {
+  const workerSource = readFileSync(new URL("../src/adapters/chatgpt-web/browser-worker.ts", import.meta.url), "utf8");
+  const markdownSource = readFileSync(new URL("../src/adapters/chatgpt-web/markdown.ts", import.meta.url), "utf8");
+  expect(workerSource).toContain('const CHATGPT_TOOL_MARKER_SELECTOR = \'[data-testid^="cot-v5-tool-"], [data-testid^="cot-v5-native-tool-"]\'');
+  expect(workerSource).toContain('const CHATGPT_SCREENSHOT_CONTENT_SELECTOR = "[data-conversation-screenshot-content]"');
+  expect(workerSource).toContain("const toolOwnedMarkdownRoot = (candidate: HTMLElement): boolean");
+  expect(workerSource).toContain("container.querySelector(toolMarkerSelector)");
+  expect(workerSource).toContain("if (container.matches(screenshotContentSelector)) break");
+  expect(workerSource).toContain(".filter(candidate => !toolOwnedMarkdownRoot(candidate))");
+  expect(workerSource).toContain("markdownBuffer.observe(snapshot.markdownSegments)");
+  expect(markdownSource).toContain("while (this.committed.length < segments.length)");
+  expect(markdownSource).not.toContain("incremental = false");
+});
+
 test("visible DOM trace keeps a complete action phrase instead of a nested count", () => {
   expect(new ChatGptVisibleTraceTracker(0).observe([
     { kind: "status", text: "Searched\n5\nsites" },


### PR DESCRIPTION
## Summary
- dynamically rebind the active browser turn when ChatGPT removes a provisional assistant turn and mounts its replacement
- exclude Markdown owned by native ChatGPT tool cards from the final-answer stream while preserving their status/commentary trace
- keep the existing incremental `ChatGptMarkdownBuffer` unchanged, including stable completed-block deltas
- preserve cancellation, submission evidence, completion-action requirements, and five-tab isolation

## Why this replaces #134
#134 correctly identified the two browser failures, but its follow-up buffered the entire final answer until completion. This version addresses the maintainer feedback: it does not add a non-incremental mode and does not disable live answer streaming.

The two root causes are separate:
1. ChatGPT can remove a provisional `conversation-turn-*` node while generation remains active. A locator bound once before send never sees the replacement.
2. Native Python/search tool cards contain `.markdown` nodes. When the analysis UI changes shape, those mutable tool nodes can otherwise be classified as final-answer blocks and violate Responses' append-only delta contract.

The tool-card filter is structural and label-independent: it checks current `cot-v5` tool markers only within the Markdown root's local screenshot-content container. Ordinary answer roots still use the existing stable-block buffer.

## Regression and live evidence
- current main reproduced the provisional-turn disappearance on an Extra High HTML-artifact task
- rebinding alone progressed to the Python tool card, then reproduced `ChatGPT changed a completed text block that was already streamed to Codex`
- the complete fix passed the same tool-heavy Extra High task with four live commentary items and one concise 183-character final-answer item; mutable Python/HTML code did not enter the final-answer channel
- one Light multi-section canary completed (585 final-answer characters)
- one High multi-section canary completed (5,426 final-answer characters)

These are tier-specific canaries, not a claim that every tier is universally stable.

## Verification
- `bun run verify` with Bun 1.4.0
  - 351 runtime tests
  - 186 launcher tests
  - dependency audit clean
  - TypeScript and renderer builds
  - relocatable runtime smoke
  - real Chrome launch smoke
