### PR TITLE
fix: report privacy-safe HTTP stream failures

### DIFF
--- a/src/http-stream-diagnostics.ts
+++ b/src/http-stream-diagnostics.ts
@@ -1,0 +1,38 @@
+export interface HttpStreamFailureDiagnostic {
+  stage: "direct" | "lifecycle";
+  platform: NodeJS.Platform;
+  chunks: number;
+  bytes: number;
+  errorName: string;
+  errorCode: string;
+}
+
+export type HttpStreamFailureReporter = (failure: HttpStreamFailureDiagnostic) => void;
+
+function safeErrorField(value: unknown, fallback: string): string {
+  return typeof value === "string" && /^[A-Za-z0-9_.-]{1,64}$/.test(value) ? value : fallback;
+}
+
+export function httpStreamFailureDiagnostic(
+  error: unknown,
+  stage: HttpStreamFailureDiagnostic["stage"],
+  platform: NodeJS.Platform,
+  chunks: number,
+  bytes: number,
+): HttpStreamFailureDiagnostic {
+  const candidate = error && typeof error === "object"
+    ? error as { name?: unknown; code?: unknown }
+    : {};
+  return {
+    stage,
+    platform,
+    chunks,
+    bytes,
+    errorName: safeErrorField(candidate.name, "Error"),
+    errorCode: safeErrorField(candidate.code, "unknown"),
+  };
+}
+
+export const reportHttpStreamFailure: HttpStreamFailureReporter = failure => {
+  console.warn(`[http-stream] tracked response failed ${JSON.stringify(failure)}`);
+};

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,11 @@ import type { AppConfig } from "./config";
 import { providerConfig } from "./config";
 import { AsyncEventQueue } from "./event-queue";
 import { readJsonRequestBody } from "./http-body";
+import {
+  httpStreamFailureDiagnostic,
+  reportHttpStreamFailure,
+  type HttpStreamFailureReporter,
+} from "./http-stream-diagnostics";
 import { httpStatusFromTerminalError } from "./lib/errors";
 import { createHash } from "node:crypto";
 import { augmentNativeModelCatalog } from "./model-catalog";
@@ -44,6 +49,8 @@ export class HttpTurnCounter {
     finish: () => void;
   }>();
   private nextId = 1;
+
+  constructor(private readonly reportStreamFailure: HttpStreamFailureReporter = reportHttpStreamFailure) {}
 
   count(): number {
     return this.active.size;
@@ -103,6 +110,9 @@ export class HttpTurnCounter {
         // pull chain: it keeps HTTP backpressure native and lets a client body cancellation reach
         // the original SSE reader without an eagerly drained tee branch racing the socket writer.
         const reader = response.body.getReader();
+        const reportStreamFailure = this.reportStreamFailure;
+        let chunks = 0;
+        let bytes = 0;
         streamAbortListener = () => {
           void reader.cancel(abort.signal.reason).catch(() => {}).finally(release);
         };
@@ -116,8 +126,13 @@ export class HttpTurnCounter {
                 controller.close();
                 return;
               }
+              chunks += 1;
+              bytes += chunk.value.byteLength;
               controller.enqueue(chunk.value);
             } catch (error) {
+              if (!abort.signal.aborted) {
+                reportStreamFailure(httpStreamFailureDiagnostic(error, "direct", platform, chunks, bytes));
+              }
               release();
               controller.error(error);
             }
@@ -143,6 +158,8 @@ export class HttpTurnCounter {
       // when the client disconnects and cancels the observer branch.
       const [clientBody, lifecycleBody] = response.body.tee();
       const reader = lifecycleBody.getReader();
+      let chunks = 0;
+      let bytes = 0;
       streamAbortListener = () => {
         void Promise.allSettled([
           reader.cancel(abort.signal.reason),
@@ -152,10 +169,17 @@ export class HttpTurnCounter {
       abort.signal.addEventListener("abort", streamAbortListener, { once: true });
       void (async () => {
         try {
-          while (!(await reader.read()).done) {
+          while (true) {
+            const chunk = await reader.read();
+            if (chunk.done) break;
+            chunks += 1;
+            bytes += chunk.value.byteLength;
             // Consume eagerly so the lifecycle branch never backpressures the client branch.
           }
-        } catch {
+        } catch (error) {
+          if (!abort.signal.aborted) {
+            this.reportStreamFailure(httpStreamFailureDiagnostic(error, "lifecycle", platform, chunks, bytes));
+          }
           // Stream failure is delivered to the client branch; lifecycle cleanup stays best-effort.
         } finally {
           release();

--- a/tests/server-lifecycle.test.ts
+++ b/tests/server-lifecycle.test.ts
@@ -40,7 +40,8 @@ test("HTTP turn tracking follows the response stream instead of Bun's global req
 });
 
 test("HTTP turn tracking releases a cancelled response stream", async () => {
-  const turns = new HttpTurnCounter();
+  const failures: unknown[] = [];
+  const turns = new HttpTurnCounter(failure => failures.push(failure));
   const request = new AbortController();
   const response = await turns.track(
     async () => new Response(new ReadableStream<Uint8Array>()),
@@ -52,6 +53,7 @@ test("HTTP turn tracking releases a cancelled response stream", async () => {
   request.abort("client disconnected");
   await cancelled;
   await waitForTurnCount(turns, 0);
+  expect(failures).toEqual([]);
 });
 
 test("HTTP turn tracking uses a tee branch on Windows", async () => {
@@ -86,6 +88,58 @@ test("HTTP turn tracking uses direct pull and cancellation outside Windows", asy
   await reader.cancel("client disconnected");
   await waitForTurnCount(turns, 0);
   expect(sourceCancelled).toBe(true);
+});
+
+test("HTTP turn tracking reports a content-free direct stream failure", async () => {
+  const failures: unknown[] = [];
+  const turns = new HttpTurnCounter(failure => failures.push(failure));
+  let source!: ReadableStreamDefaultController<Uint8Array>;
+  const response = await turns.track(async () => new Response(new ReadableStream<Uint8Array>({
+    start(controller) { source = controller; },
+  })), undefined, "darwin");
+  const reader = response.body!.getReader();
+
+  source.enqueue(new TextEncoder().encode("safe"));
+  expect(new TextDecoder().decode((await reader.read()).value)).toBe("safe");
+  source.error(Object.assign(new TypeError("sensitive upstream detail"), { code: "ECONNRESET" }));
+  await expect(reader.read()).rejects.toThrow("sensitive upstream detail");
+  await waitForTurnCount(turns, 0);
+
+  expect(failures).toEqual([{
+    stage: "direct",
+    platform: "darwin",
+    chunks: 1,
+    bytes: 4,
+    errorName: "TypeError",
+    errorCode: "ECONNRESET",
+  }]);
+  expect(JSON.stringify(failures)).not.toContain("sensitive upstream detail");
+});
+
+test("HTTP turn tracking reports a content-free Windows lifecycle stream failure", async () => {
+  const failures: unknown[] = [];
+  const turns = new HttpTurnCounter(failure => failures.push(failure));
+  let source!: ReadableStreamDefaultController<Uint8Array>;
+  const response = await turns.track(async () => new Response(new ReadableStream<Uint8Array>({
+    start(controller) { source = controller; },
+  })), undefined, "win32");
+  const reader = response.body!.getReader();
+
+  source.enqueue(new TextEncoder().encode("event"));
+  expect(new TextDecoder().decode((await reader.read()).value)).toBe("event");
+  source.error(Object.assign(new TypeError("private response fragment"), { code: "ECONNRESET" }));
+  await expect(reader.read()).rejects.toThrow("private response fragment");
+  await waitForTurnCount(turns, 0);
+
+  expect(failures).toEqual([{
+    stage: "lifecycle",
+    platform: "win32",
+    chunks: 1,
+    bytes: 5,
+    errorName: "TypeError",
+    errorCode: "ECONNRESET",
+  }]);
+  expect(JSON.stringify(failures)).not.toContain("private response fragment");
 });
 
 test("HTTP turn tracking releases a stream whose client disconnected without cancelling", async () => {


### PR DESCRIPTION
## Summary

- record privacy-safe chunk and byte counts when a tracked response stream fails
- distinguish direct readers from the Windows lifecycle tee observer
- suppress failure diagnostics for locally aborted/cancelled turns
- preserve the original stream error, backpressure, and cancellation behavior

Fixes #161.

## Why

When an upstream native Codex SSE socket resets after response headers, the client correctly receives a stream error, but the Windows lifecycle observer previously discarded its local failure evidence. The launcher therefore had only Bun's raw stack trace and could not tell whether the failure happened before or after response bytes crossed the proxy.

The new diagnostic contains only:

- reader stage and platform
- chunk and byte counts
- sanitized error name and code

It never records the error message, request, response body, URL, or authorization data. It also does not retry a partial Responses stream.

## Verification

- `bun test tests/server-lifecycle.test.ts`: 20 passed
- root suite: 360 passed; 1 pre-existing `installed launcher discovery has explicit platform candidates` failure, independently reproduced on an unmodified `v3.0.2` worktree
- launcher suite: 188 passed, 1 platform skip
- root TypeScript check: passed
- launcher TypeScript check: passed
- runtime bundle build: passed

