### PR TITLE
fix: detect localized ChatGPT cooldown dialogs

### DIFF
--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -152,15 +152,15 @@ export class ChatGptPromptAttachmentIntegrityError extends ChatGptWebAdapterErro
 }
 
 const chatGptRateLimitDialog = (page: Page): Locator => page.locator('[role="dialog"]')
-  .filter({ hasText: /Too many requests/i })
-  .filter({ hasText: /making requests too quickly/i })
+  .filter({ hasText: /Too many requests|太多要求|太多请求/i })
+  .filter({ hasText: /making requests too quickly|過於頻繁|过于频繁/i })
   .last();
 
 export async function throwIfChatGptRateLimitDialog(page: Page): Promise<void> {
   const dialog = chatGptRateLimitDialog(page);
   if (!await dialog.isVisible().catch(() => false)) return;
 
-  const acknowledge = dialog.getByRole("button", { name: "Got it", exact: true }).last();
+  const acknowledge = dialog.getByRole("button", { name: /^(Got it|知道了)$/ }).last();
   if (await acknowledge.isVisible().catch(() => false)) {
     try {
       await acknowledge.press("Enter");

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -1037,12 +1037,13 @@ test("an unrelated Continue dialog is never auto-accepted", async () => {
   expect(lookedForButton).toBeFalse();
 });
 
-function dialogPage(text: string): { page: Page; pressed: string[] } {
+function dialogPage(text: string, buttonText = "Got it"): { page: Page; pressed: string[] } {
   let matches = true;
+  let buttonMatches = true;
   const pressed: string[] = [];
   const button = {
     last: () => button,
-    isVisible: async () => matches,
+    isVisible: async () => matches && buttonMatches,
     press: async (key: string) => { pressed.push(key); },
   };
   const dialog = {
@@ -1052,7 +1053,12 @@ function dialogPage(text: string): { page: Page; pressed: string[] } {
     },
     last: () => dialog,
     isVisible: async () => matches,
-    getByRole: () => button,
+    getByRole: (_role: string, options?: { name?: string | RegExp }) => {
+      const name = options?.name;
+      buttonMatches = name === undefined
+        || (typeof name === "string" ? buttonText === name : name.test(buttonText));
+      return button;
+    },
   };
   return {
     page: {
@@ -1073,6 +1079,32 @@ test("the known ChatGPT rate-limit dialog is acknowledged and returns a structur
     code: "rate_limit_exceeded",
     retryable: true,
     message: "ChatGPT rate limit: too many requests. Try again in a few minutes.",
+  });
+  expect(fixture.pressed).toEqual(["Enter"]);
+});
+
+test("the Traditional Chinese ChatGPT rate-limit dialog is acknowledged and returns a structured 429", async () => {
+  const fixture = dialogPage("太多要求。你提出要求的頻率過於頻繁。", "知道了");
+
+  await expect(throwIfChatGptRateLimitDialog(fixture.page)).rejects.toMatchObject({
+    name: "ChatGptWebAdapterError",
+    status: 429,
+    errorType: "rate_limit_error",
+    code: "rate_limit_exceeded",
+    retryable: true,
+  });
+  expect(fixture.pressed).toEqual(["Enter"]);
+});
+
+test("the Simplified Chinese ChatGPT rate-limit dialog is acknowledged and returns a structured 429", async () => {
+  const fixture = dialogPage("太多请求。你提出请求的频率过于频繁。", "知道了");
+
+  await expect(throwIfChatGptRateLimitDialog(fixture.page)).rejects.toMatchObject({
+    name: "ChatGptWebAdapterError",
+    status: 429,
+    errorType: "rate_limit_error",
+    code: "rate_limit_exceeded",
+    retryable: true,
   });
   expect(fixture.pressed).toEqual(["Enter"]);
 });


### PR DESCRIPTION
## Summary

- detect the known ChatGPT rate-limit dialog in English, Traditional Chinese, and Simplified Chinese
- acknowledge the localized `Got it` / `知道了` action
- preserve the existing structured retryable `429 rate_limit_exceeded` response
- keep this limited to single-account cooldown handling; no account rotation or account switching

Extracted as a focused follow-up to #160.

## Verification

- `npx -y bun@1.4.0 run verify`
- `npx -y bun@1.4.0 run app:package`
- `npx -y bun@1.4.0 run app:smoke`