### PR TITLE
fix: detect expired ChatGPT sessions

### DIFF
--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -198,13 +198,24 @@ export async function dismissChatGptTemporaryChatOnboarding(page: Page): Promise
 
 type ChatGptTextScope = Pick<Locator, "getByText">;
 
-const chatGptSessionFailureAlert = (page: Page): Locator => page
+const chatGptSubscriptionFailureAlert = (page: Page): Locator => page
   .locator('[role="alert"]')
   .filter({ hasText: /Failed to load subscription/i })
   .last();
 
+const chatGptExpiredSessionAlert = (page: Page): Locator => page
+  .locator('[role="alert"], [role="dialog"]')
+  .filter({ hasText: /Your session has expired|你的工作階段已過期|您的工作階段已過期|你的会话已过期|您的会话已过期/i })
+  .last();
+
 export async function throwIfChatGptSessionFailureAlert(page: Page): Promise<void> {
-  if (!await chatGptSessionFailureAlert(page).isVisible().catch(() => false)) return;
+  if (await chatGptExpiredSessionAlert(page).isVisible().catch(() => false)) {
+    throw new ChatGptWebAdapterError(
+      "The ChatGPT session has expired. Sign in again in Codex Web GPT.",
+      { status: 401, errorType: "authentication_error", code: "chatgpt_session_expired", retryable: false },
+    );
+  }
+  if (!await chatGptSubscriptionFailureAlert(page).isVisible().catch(() => false)) return;
   throw new ChatGptWebAdapterError(
     "ChatGPT could not load the account subscription. Reload ChatGPT inside the launcher and retry; sign out only if the error persists.",
     { status: 503, errorType: "server_error", code: "chatgpt_subscription_unavailable", retryable: true },
@@ -1214,10 +1225,19 @@ export class ChatGptBrowserWorker {
       return mode;
     }
     const currentEffort = composerForm.locator(CHATGPT_EFFORT_CONTROL_SELECTOR).last();
+    const effortWaitAbort = new AbortController();
     try {
-      await currentEffort.waitFor({ state: "visible", timeout: 70_000 });
-    } catch {
+      const ready = await Promise.race([
+        currentEffort.waitFor({ state: "visible", timeout: 70_000, signal: effortWaitAbort.signal }).then(() => "effort" as const),
+        chatGptExpiredSessionAlert(page).waitFor({ state: "visible", timeout: 70_000, signal: effortWaitAbort.signal }).then(() => "session-expired" as const),
+      ]);
+      if (ready === "session-expired") await throwIfChatGptSessionFailureAlert(page);
+    } catch (error) {
+      if (error instanceof ChatGptWebAdapterError) throw error;
+      await throwIfChatGptSessionFailureAlert(page);
       throw new Error("ChatGPT rendered the composer but its model/effort control did not become ready");
+    } finally {
+      effortWaitAbort.abort();
     }
     await settleChatGptUi();
     await throwIfChatGptRateLimitDialog(page);
@@ -1237,18 +1257,21 @@ export class ChatGptBrowserWorker {
     const effortChoice = effortChoices.nth(uiEffortIndex);
     const effortSlider = page.locator(CHATGPT_EFFORT_SLIDER_SELECTOR).filter({ visible: true }).last();
     const waitAbort = new AbortController();
-    let ready: "effort" | "slider" | "rate-limit";
+    let ready: "effort" | "slider" | "rate-limit" | "session-expired";
     try {
       ready = await Promise.race([
         effortChoice.waitFor({ state: "visible", timeout: 70_000, signal: waitAbort.signal }).then(() => "effort" as const),
         effortSlider.waitFor({ state: "visible", timeout: 70_000, signal: waitAbort.signal }).then(() => "slider" as const),
         chatGptRateLimitDialog(page).waitFor({ state: "visible", timeout: 70_000, signal: waitAbort.signal }).then(() => "rate-limit" as const),
+        chatGptExpiredSessionAlert(page).waitFor({ state: "visible", timeout: 70_000, signal: waitAbort.signal }).then(() => "session-expired" as const),
       ]);
       if (ready === "rate-limit") await throwIfChatGptRateLimitDialog(page);
+      if (ready === "session-expired") await throwIfChatGptSessionFailureAlert(page);
       await captureDiagnostic?.(ready === "slider" ? "effort-slider-visible" : "effort-choice-visible");
     } catch (error) {
       if (error instanceof ChatGptWebAdapterError) throw error;
       await throwIfChatGptRateLimitDialog(page);
+      await throwIfChatGptSessionFailureAlert(page);
       throw new ChatGptWebAdapterError(
         `ChatGPT effort menu did not expose item index ${uiEffortIndex}`
         + `; item count: ${await effortChoices.count().catch(() => 0)}`,

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -1038,26 +1038,29 @@ test("an unrelated Continue dialog is never auto-accepted", async () => {
 });
 
 function dialogPage(text: string): { page: Page; pressed: string[] } {
-  let matches = true;
   const pressed: string[] = [];
-  const button = {
-    last: () => button,
-    isVisible: async () => matches,
-    press: async (key: string) => { pressed.push(key); },
-  };
-  const dialog = {
-    filter: ({ hasText }: { hasText: string | RegExp }) => {
-      matches &&= typeof hasText === "string" ? text.includes(hasText) : hasText.test(text);
-      return dialog;
-    },
-    last: () => dialog,
-    isVisible: async () => matches,
-    getByRole: () => button,
+  const createDialog = () => {
+    let matches = true;
+    const button = {
+      last: () => button,
+      isVisible: async () => matches,
+      press: async (key: string) => { pressed.push(key); },
+    };
+    const dialog = {
+      filter: ({ hasText }: { hasText: string | RegExp }) => {
+        matches &&= typeof hasText === "string" ? text.includes(hasText) : hasText.test(text);
+        return dialog;
+      },
+      last: () => dialog,
+      isVisible: async () => matches,
+      getByRole: () => button,
+    };
+    return dialog;
   };
   return {
     page: {
-      locator: () => dialog,
-      getByText: (hasText: string | RegExp) => dialog.filter({ hasText }),
+      locator: () => createDialog(),
+      getByText: (hasText: string | RegExp) => createDialog().filter({ hasText }),
     } as unknown as Page,
     pressed,
   };
@@ -1110,6 +1113,143 @@ test("a failed subscription fetch is retryable and does not falsely invalidate C
     errorType: "server_error",
     code: "chatgpt_subscription_unavailable",
     retryable: true,
+  });
+});
+
+test.each([
+  "Your session has expired. Please log in again to continue using the app. Log in",
+  "你的工作階段已過期 請重新登入以繼續使用應用程式。 登入",
+  "您的会话已过期 请重新登录以继续使用该应用。 登录",
+])("an expired ChatGPT session returns a non-retryable authentication failure: %s", async alertText => {
+  const fixture = dialogPage(alertText);
+
+  await expect(throwIfChatGptSessionFailureAlert(fixture.page)).rejects.toMatchObject({
+    name: "ChatGptWebAdapterError",
+    status: 401,
+    errorType: "authentication_error",
+    code: "chatgpt_session_expired",
+    retryable: false,
+  });
+});
+
+test("effort selection stops as soon as ChatGPT reports an expired session", async () => {
+  const neverVisible = new Promise<void>(() => {});
+  const effortControl = {
+    last() { return this; },
+    waitFor: async () => await neverVisible,
+  };
+  const composerForm = { locator: () => effortControl };
+  const composer = { locator: () => composerForm };
+  const sessionAlert = {
+    filter() { return this; },
+    last() { return this; },
+    waitFor: async () => {},
+    isVisible: async () => true,
+  };
+  const hiddenDialog = {
+    filter() { return this; },
+    last() { return this; },
+    waitFor: async () => await neverVisible,
+    isVisible: async () => false,
+  };
+  const selectModelAndEffort = (ChatGptBrowserWorker.prototype as unknown as {
+    selectModelAndEffort(
+      page: unknown,
+      modelId: string,
+      reasoning: string,
+      capabilities: { localToolsEnabled: boolean; solAvailable: boolean; proAvailable: boolean },
+    ): Promise<unknown>;
+  }).selectModelAndEffort;
+
+  const selection = selectModelAndEffort.call({
+    activeComposer: async () => composer,
+  }, {
+    locator: (selector: string) => selector.includes('[role="alert"]') ? sessionAlert : hiddenDialog,
+  }, "gpt-5.6-sol", "high", {
+    localToolsEnabled: true,
+    solAvailable: true,
+    proAvailable: true,
+  });
+  const result = await Promise.race([
+    selection.catch(error => error),
+    new Promise(resolve => setTimeout(() => resolve("still waiting"), 100)),
+  ]);
+
+  expect(result).toMatchObject({
+    name: "ChatGptWebAdapterError",
+    status: 401,
+    code: "chatgpt_session_expired",
+    retryable: false,
+  });
+});
+
+test("effort menu waiting stops when ChatGPT reports an expired session", async () => {
+  const neverVisible = new Promise<void>(() => {});
+  const effortControl = {
+    last() { return this; },
+    waitFor: async () => {},
+    getAttribute: async () => "true",
+  };
+  const composerForm = { locator: () => effortControl };
+  const composer = { locator: () => composerForm };
+  const effortChoice = { waitFor: async () => await neverVisible };
+  const effortChoices = { nth: () => effortChoice, count: async () => 3 };
+  const effortMenu = {
+    last() { return this; },
+    isVisible: async () => true,
+    locator: () => effortChoices,
+  };
+  const effortSlider = {
+    filter() { return this; },
+    last() { return this; },
+    waitFor: async () => await neverVisible,
+  };
+  const sessionAlert = {
+    filter() { return this; },
+    last() { return this; },
+    waitFor: async () => {},
+    isVisible: async () => true,
+  };
+  const hiddenDialog = {
+    filter() { return this; },
+    last() { return this; },
+    waitFor: async () => await neverVisible,
+    isVisible: async () => false,
+  };
+  const selectModelAndEffort = (ChatGptBrowserWorker.prototype as unknown as {
+    selectModelAndEffort(
+      page: unknown,
+      modelId: string,
+      reasoning: string,
+      capabilities: { localToolsEnabled: boolean; solAvailable: boolean; proAvailable: boolean },
+    ): Promise<unknown>;
+  }).selectModelAndEffort;
+
+  const selection = selectModelAndEffort.call({
+    activeComposer: async () => composer,
+  }, {
+    locator: (selector: string) => {
+      if (selector.includes('[role="alert"]')) return sessionAlert;
+      if (selector.includes('[role="menu"]') || selector.includes("composer-intelligence-picker-content")) return effortMenu;
+      if (selector.includes("data-model-reasoning-effort-slider")) return effortSlider;
+      if (selector.includes('[role="dialog"]')) return hiddenDialog;
+      return effortMenu;
+    },
+  }, "gpt-5.6-sol", "high", {
+    localToolsEnabled: true,
+    solAvailable: true,
+    proAvailable: true,
+  });
+  const result = await Promise.race([
+    selection.catch(error => error),
+    new Promise(resolve => setTimeout(() => resolve("still waiting"), 400)),
+  ]);
+
+  expect(result).toMatchObject({
+    name: "ChatGptWebAdapterError",
+    status: 401,
+    code: "chatgpt_session_expired",
+    retryable: false,
   });
 });
 


### PR DESCRIPTION
## Summary

- detect expired ChatGPT sessions in English, Traditional Chinese, and Simplified Chinese
- return a structured non-retryable 401 authentication error
- stop model and effort UI waits as soon as the expiry notice appears
- keep this change single-account focused with no rotation or account switching

Extracted as a focused follow-up from #160.

## Verification

- `npx -y bun@1.4.0 run verify`
- `npx -y bun@1.4.0 run app:package`
- `npx -y bun@1.4.0 run app:smoke`