### PR TITLE
fix: reject partial launcher shutdown

### DIFF
--- a/launcher/electron/main.cjs
+++ b/launcher/electron/main.cjs
@@ -27,6 +27,7 @@ const {
 const { RuntimeHost } = require("./runtime.cjs");
 const { ensurePackagedRuntime } = require("./runtime-install.cjs");
 const { RuntimeSupervisor } = require("./runtime-supervisor.cjs");
+const { requireCompleteShutdown } = require("./shutdown-result.cjs");
 const { DEVELOPMENT_PROFILE, resolveLauncherProfile } = require("./profile.cjs");
 const { runtimeBundlePaths } = require("./runtime-command.cjs");
 const { createUpdateController } = require("./update.cjs");
@@ -703,7 +704,8 @@ async function requestQuit() {
     if (activeOperation) {
       throw new Error(`Wait for ${activeOperation} to finish before quitting Codex Web GPT`);
     }
-    await runtimeSupervisor?.shutdown({ cancelActiveTurns: true, force: true });
+    const shutdown = await runtimeSupervisor?.shutdown({ cancelActiveTurns: true, force: true });
+    requireCompleteShutdown(shutdown);
     stopCatalogVerificationMonitor();
     quitting = true;
     await browserHost?.persistSession();

--- a/launcher/electron/shutdown-result.cjs
+++ b/launcher/electron/shutdown-result.cjs
@@ -1,0 +1,17 @@
+function requireCompleteShutdown(result) {
+  if (result === undefined || result?.status === "stopped" || result?.status === "forced") return;
+  if (result?.status === "forced-partial") {
+    const failures = Array.isArray(result.failures)
+      ? result.failures.filter((failure) => typeof failure === "string" && failure.trim())
+      : [];
+    const detail = failures.length > 0
+      ? failures.join("; ")
+      : typeof result.detail === "string" && result.detail.trim()
+        ? result.detail.trim()
+        : "local runtime cleanup did not complete";
+    throw new Error(`Codex Web GPT could not fully stop its local runtime: ${detail}`);
+  }
+  throw new Error("Codex Web GPT received an invalid local runtime shutdown result");
+}
+
+module.exports = { requireCompleteShutdown };

--- a/launcher/tests/shutdown-result.test.cjs
+++ b/launcher/tests/shutdown-result.test.cjs
@@ -1,0 +1,27 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+let requireCompleteShutdown;
+try {
+  ({ requireCompleteShutdown } = require("../electron/shutdown-result.cjs"));
+} catch {}
+
+test("partial forced shutdown rejects exit with every cleanup failure", () => {
+  assert.equal(typeof requireCompleteShutdown, "function");
+  assert.throws(
+    () => requireCompleteShutdown({
+      status: "forced-partial",
+      detail: "graceful shutdown timed out",
+      failures: ["tunnel: still running", "daemon: permission denied"],
+    }),
+    {
+      message: "Codex Web GPT could not fully stop its local runtime: tunnel: still running; daemon: permission denied",
+    },
+  );
+});
+
+test("complete graceful and forced shutdown results permit exit", () => {
+  assert.doesNotThrow(() => requireCompleteShutdown({ status: "stopped" }));
+  assert.doesNotThrow(() => requireCompleteShutdown({ status: "forced" }));
+  assert.doesNotThrow(() => requireCompleteShutdown(undefined));
+});


### PR DESCRIPTION
## Summary

- validate the runtime supervisor result before committing launcher exit
- keep the app open when forced cleanup is only partially successful
- preserve all cleanup failures in the user-visible error
- keep this change independent from accounts and rotation

Extracted as a focused follow-up from #160.

## Verification

- `npx -y bun@1.4.0 run verify`
- `npx -y bun@1.4.0 run app:package`
- `npx -y bun@1.4.0 run app:smoke`