### PR TITLE
fix(chatgpt-web): harden full harness command lifecycle

### DIFF
--- a/scripts/summarize-command-observability.ts
+++ b/scripts/summarize-command-observability.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "node:fs";
+import { summarizeCommandObservabilityLog } from "../src/adapters/chatgpt-web/command-observability";
+
+const args = process.argv.slice(2);
+const logPath = args.find(arg => !arg.startsWith("--"));
+const option = (name: string): string | undefined => {
+  const prefix = `--${name}=`;
+  return args.find(arg => arg.startsWith(prefix))?.slice(prefix.length);
+};
+
+if (!logPath) {
+  console.error("usage: bun run scripts/summarize-command-observability.ts <log> [--since=ISO] [--until=ISO]");
+  process.exit(2);
+}
+
+const summary = summarizeCommandObservabilityLog(readFileSync(logPath, "utf8"), {
+  since: option("since"),
+  until: option("until"),
+});
+console.log(JSON.stringify(summary, null, 2));

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -50,15 +50,19 @@ import {
   CHATGPT_COMPOSER_SELECTOR,
   CHATGPT_EFFORT_CONTROL_SELECTOR,
   CHATGPT_EFFORT_ITEM_SELECTOR,
-  CHATGPT_EFFORT_MENU_SELECTOR,
   CHATGPT_EFFORT_SLIDER_SELECTOR,
   CHATGPT_STOP_BUTTON_SELECTOR,
   CHATGPT_TEMPORARY_CHAT_URL,
   CHATGPT_USER_TURN_SELECTOR,
   detectChatGptAccountCapabilities,
   parseChatGptEffortSliderState,
+  resolveChatGptEffortMenu,
 } from "../../chatgpt-session";
-import { loginVerificationMarkerPath } from "../../browser-login";
+import {
+  browserLoginStateExists,
+  storedBrowserLoginCapabilities,
+  writeBrowserLoginVerificationMarker,
+} from "../../browser-login";
 import {
   connectLauncherBrowserHost,
   LauncherBrowserTurnCancelledError,
@@ -77,6 +81,13 @@ import {
   chatGptBrowserTabClosedError,
   chatGptStoppedThinkingError,
 } from "./adapter-error";
+import {
+  chatGptEffortIndexFromControlLabel,
+  ChatGptEffortStaleDomError,
+  ensureChatGptEffortSelection,
+  type ChatGptEffortIndex,
+  type ChatGptEffortOpenState,
+} from "./effort-selection";
 import {
   ChatGptLunaCheckpointStream,
   type CapturedChatGptLunaCheckpoint,
@@ -156,14 +167,14 @@ const chatGptRateLimitDialog = (page: Page): Locator => page.locator('[role="dia
   .filter({ hasText: /making requests too quickly|過於頻繁|过于频繁/i })
   .last();
 
-export async function throwIfChatGptRateLimitDialog(page: Page): Promise<void> {
+export async function throwIfChatGptRateLimitDialog(page: Page, timeoutMs = 2_000): Promise<void> {
   const dialog = chatGptRateLimitDialog(page);
-  if (!await dialog.isVisible().catch(() => false)) return;
+  if (!await dialog.isVisible({ timeout: timeoutMs }).catch(() => false)) return;
 
   const acknowledge = dialog.getByRole("button", { name: /^(Got it|知道了)$/ }).last();
-  if (await acknowledge.isVisible().catch(() => false)) {
+  if (await acknowledge.isVisible({ timeout: timeoutMs }).catch(() => false)) {
     try {
-      await acknowledge.press("Enter");
+      await acknowledge.press("Enter", { timeout: timeoutMs });
     } catch (error) {
       throw new ChatGptWebAdapterError(
         `ChatGPT rate limit: too many requests, and the dialog could not be dismissed (${error instanceof Error ? error.message : String(error)}). Try again in a few minutes.`,
@@ -740,6 +751,22 @@ export function redactChatGptUiDiagnostic(value: string): string {
 }
 
 const CHATGPT_BROWSER_DIAGNOSTIC_TRACE_LIMIT = 10;
+const CHATGPT_BROWSER_DIAGNOSTIC_SCREENSHOT_TIMEOUT_MS = 1_000;
+const CHATGPT_BROWSER_DIAGNOSTIC_STATE_TIMEOUT_MS = 1_500;
+
+async function boundedBrowserDiagnostic<T>(operation: Promise<T>): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<never>((_, rejectTimeout) => {
+        timer = setTimeout(() => rejectTimeout(new Error("browser diagnostic state capture timed out")), CHATGPT_BROWSER_DIAGNOSTIC_STATE_TIMEOUT_MS);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
 
 export function browserDiagnosticCheckpoint(value: string): string {
   const safe = value.replace(/[^A-Za-z0-9_-]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 80);
@@ -794,11 +821,20 @@ class ChatGptBrowserDiagnostics {
       const sequence = String(++this.sequence).padStart(2, "0");
       const stem = `${sequence}-${browserDiagnosticCheckpoint(checkpoint)}`;
       const includeScreenshot = browserDiagnosticIncludesScreenshot(checkpoint);
+      let screenshotError: string | undefined;
       const [screenshot, state] = await Promise.all([
         includeScreenshot
-          ? page.screenshot({ animations: "disabled", caret: "hide", timeout: 5_000, type: "png" })
+          ? page.screenshot({
+            animations: "disabled",
+            caret: "hide",
+            timeout: CHATGPT_BROWSER_DIAGNOSTIC_SCREENSHOT_TIMEOUT_MS,
+            type: "png",
+          }).catch(error => {
+            screenshotError = redactChatGptUiDiagnostic(error instanceof Error ? error.message : String(error));
+            return undefined;
+          })
           : Promise.resolve(undefined),
-        page.evaluate(({ composerSelector, effortControlSelector, effortItemSelector, assistantTurnSelector }) => {
+        boundedBrowserDiagnostic(page.evaluate(({ composerSelector, effortControlSelector, effortItemSelector, effortSliderSelector, assistantTurnSelector }) => {
           const rendered = (element: Element): boolean => {
             const candidate = element as HTMLElement;
             const style = getComputedStyle(candidate);
@@ -825,6 +861,10 @@ class ChatGptBrowserDiagnostics {
                 testId: element.getAttribute("data-testid"),
                 ariaExpanded: element.getAttribute("aria-expanded"),
                 ariaChecked: element.getAttribute("aria-checked"),
+                ariaValueMin: element.getAttribute("aria-valuemin"),
+                ariaValueMax: element.getAttribute("aria-valuemax"),
+                ariaValueNow: element.getAttribute("aria-valuenow"),
+                ariaValueText: element.getAttribute("aria-valuetext"),
                 dataState: element.getAttribute("data-state"),
                 dataHighlighted: element.getAttribute("data-highlighted"),
                 rect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
@@ -847,6 +887,7 @@ class ChatGptBrowserDiagnostics {
             },
             effortControls: rows(effortControlSelector, 10),
             effortItems: rows(effortItemSelector, 20),
+            effortSliders: rows(effortSliderSelector, 10),
             menus: rows('[role="menu"], [role="listbox"], [data-testid="composer-intelligence-picker-content"]', 20),
             connectorRows: rows('.__menu-item[tabindex="0"]', 40),
             overlays: rows('[role="dialog"], [role="alert"], [role="status"]', 30),
@@ -862,8 +903,9 @@ class ChatGptBrowserDiagnostics {
           composerSelector: CHATGPT_COMPOSER_SELECTOR,
           effortControlSelector: CHATGPT_EFFORT_CONTROL_SELECTOR,
           effortItemSelector: CHATGPT_EFFORT_ITEM_SELECTOR,
+          effortSliderSelector: CHATGPT_EFFORT_SLIDER_SELECTOR,
           assistantTurnSelector: CHATGPT_ASSISTANT_TURN_SELECTOR,
-        }),
+        })),
       ]);
       const capturedAt = new Date().toISOString();
       if (screenshot) atomicWriteFile(join(this.directory, `${stem}.png`), screenshot);
@@ -872,6 +914,7 @@ class ChatGptBrowserDiagnostics {
         capturedAt,
         traceId: this.traceId,
         checkpoint,
+        ...(screenshotError ? { screenshotError } : {}),
         ...(error !== undefined ? {
           error: redactChatGptUiDiagnostic(error instanceof Error ? error.message : String(error)),
         } : {}),
@@ -1146,7 +1189,7 @@ export class ChatGptBrowserWorker {
       this.page = connection.page;
       return this.page;
     }
-    if (!existsSync(this.config.storageStatePath) || !existsSync(loginVerificationMarkerPath(this.config.storageStatePath))) {
+    if (!browserLoginStateExists(this.config)) {
       throw new Error(`ChatGPT web login state is missing: ${this.config.storageStatePath}`);
     }
     if (!existsSync(this.config.chromeExecutablePath)) {
@@ -1164,7 +1207,7 @@ export class ChatGptBrowserWorker {
   private async ensureManagedBrowser(): Promise<{ browser: Browser; context: BrowserContext }> {
     if (this.managedBrowserReady) return this.managedBrowserReady;
     const opening = (async () => {
-      if (!existsSync(this.config.storageStatePath) || !existsSync(loginVerificationMarkerPath(this.config.storageStatePath))) {
+      if (!browserLoginStateExists(this.config)) {
         throw new Error(`ChatGPT web login state is missing: ${this.config.storageStatePath}`);
       }
       if (!existsSync(this.config.chromeExecutablePath)) {
@@ -1206,6 +1249,7 @@ export class ChatGptBrowserWorker {
     modelId: string,
     reasoning: string | undefined,
     capabilities: ChatGptWebCapabilities,
+    abortSignal: AbortSignal,
     captureDiagnostic?: (checkpoint: string) => Promise<void>,
   ): Promise<ChatGptWebModelMode> {
     const mode = resolveChatGptWebModelMode(modelId, reasoning, capabilities);
@@ -1224,153 +1268,211 @@ export class ChatGptBrowserWorker {
       await captureDiagnostic?.("luna-default-confirmed");
       return mode;
     }
-    const currentEffort = composerForm.locator(CHATGPT_EFFORT_CONTROL_SELECTOR).last();
-    const effortWaitAbort = new AbortController();
-    try {
-      const ready = await Promise.race([
-        currentEffort.waitFor({ state: "visible", timeout: 70_000, signal: effortWaitAbort.signal }).then(() => "effort" as const),
-        chatGptExpiredSessionAlert(page).waitFor({ state: "visible", timeout: 70_000, signal: effortWaitAbort.signal }).then(() => "session-expired" as const),
-      ]);
-      if (ready === "session-expired") await throwIfChatGptSessionFailureAlert(page);
-    } catch (error) {
-      if (error instanceof ChatGptWebAdapterError) throw error;
-      await throwIfChatGptSessionFailureAlert(page);
-      throw new Error("ChatGPT rendered the composer but its model/effort control did not become ready");
-    } finally {
-      effortWaitAbort.abort();
-    }
-    await settleChatGptUi();
-    await throwIfChatGptRateLimitDialog(page);
-    await captureDiagnostic?.("effort-control-ready");
-    const effortMenu = page.locator(CHATGPT_EFFORT_MENU_SELECTOR).last();
-    const menuVisible = await effortMenu.isVisible().catch(() => false);
-    const menuExpanded = await currentEffort.getAttribute("aria-expanded").catch(() => null);
-    if (!menuVisible && menuExpanded !== "true") {
-      await throwIfChatGptRateLimitDialog(page);
-      // ChatGPT's current Radix trigger no longer responds to synthetic Enter/Space on background
-      // Electron surfaces. Force only the exact, visible effort control; the menu/slider state
-      // below remains the authoritative postcondition, so this cannot become an unproved click.
-      await currentEffort.click({ force: true });
-    }
-    await captureDiagnostic?.("effort-menu-open-requested");
-    const effortChoices = effortMenu.locator(CHATGPT_EFFORT_ITEM_SELECTOR);
-    const effortChoice = effortChoices.nth(uiEffortIndex);
-    const effortSlider = page.locator(CHATGPT_EFFORT_SLIDER_SELECTOR).filter({ visible: true }).last();
-    const waitAbort = new AbortController();
-    let ready: "effort" | "slider" | "rate-limit" | "session-expired";
-    try {
-      ready = await Promise.race([
-        effortChoice.waitFor({ state: "visible", timeout: 70_000, signal: waitAbort.signal }).then(() => "effort" as const),
-        effortSlider.waitFor({ state: "visible", timeout: 70_000, signal: waitAbort.signal }).then(() => "slider" as const),
-        chatGptRateLimitDialog(page).waitFor({ state: "visible", timeout: 70_000, signal: waitAbort.signal }).then(() => "rate-limit" as const),
-        chatGptExpiredSessionAlert(page).waitFor({ state: "visible", timeout: 70_000, signal: waitAbort.signal }).then(() => "session-expired" as const),
-      ]);
-      if (ready === "rate-limit") await throwIfChatGptRateLimitDialog(page);
-      if (ready === "session-expired") await throwIfChatGptSessionFailureAlert(page);
-      await captureDiagnostic?.(ready === "slider" ? "effort-slider-visible" : "effort-choice-visible");
-    } catch (error) {
-      if (error instanceof ChatGptWebAdapterError) throw error;
-      await throwIfChatGptRateLimitDialog(page);
-      await throwIfChatGptSessionFailureAlert(page);
-      throw new ChatGptWebAdapterError(
-        `ChatGPT effort menu did not expose item index ${uiEffortIndex}`
-        + `; item count: ${await effortChoices.count().catch(() => 0)}`,
-        { status: 502, errorType: "server_error", code: "upstream_server_error", retryable: false },
-      );
-    } finally {
-      waitAbort.abort();
-    }
-    if (ready === "slider") {
-      let sliderState = parseChatGptEffortSliderState(
-        await effortSlider.getAttribute("aria-valuemin"),
-        await effortSlider.getAttribute("aria-valuemax"),
-        await effortSlider.getAttribute("aria-valuenow"),
-      );
-      if (!sliderState) {
-        throw new ChatGptWebAdapterError(
-          "ChatGPT effort slider exposed an invalid ARIA range",
-          { status: 502, errorType: "server_error", code: "upstream_server_error", retryable: false },
-        );
-      }
-      const targetValue = sliderState.min + uiEffortIndex;
-      if (targetValue > sliderState.max) {
-        throw new ChatGptWebAdapterError(
-          `ChatGPT effort slider does not expose item index ${uiEffortIndex}`
-          + ` (min=${sliderState.min}; max=${sliderState.max})`,
-          { status: 502, errorType: "server_error", code: "upstream_server_error", retryable: false },
-        );
-      }
-      const sliderControl = effortSlider.locator("xpath=ancestor::*[@role='menuitem'][1]");
-      while (sliderState.value !== targetValue) {
-        await throwIfChatGptRateLimitDialog(page);
-        const direction = targetValue > sliderState.value ? 1 : -1;
-        const key = direction > 0 ? "ArrowRight" : "ArrowLeft";
-        const previousValue = sliderState.value;
-        await sliderControl.press(key);
-        const changeDeadline = Date.now() + 5_000;
-        do {
-          sliderState = parseChatGptEffortSliderState(
-            await effortSlider.getAttribute("aria-valuemin"),
-            await effortSlider.getAttribute("aria-valuemax"),
-            await effortSlider.getAttribute("aria-valuenow"),
-          );
-          if (!sliderState) throw new Error("ChatGPT effort slider lost its semantic ARIA state");
-          if (sliderState.value !== previousValue) break;
-          await new Promise(resolveSleep => setTimeout(resolveSleep, 50));
-        } while (Date.now() < changeDeadline);
-        if (sliderState.value !== previousValue + direction) {
-          throw new Error(
-            `ChatGPT effort slider did not move exactly one step with ${key}`
-            + ` (before=${previousValue}; after=${sliderState.value})`,
-          );
+    const targetIndex = uiEffortIndex as ChatGptEffortIndex;
+    const deadline = Date.now() + 60_000;
+    const remaining = (cap = 15_000): number => {
+      if (abortSignal.aborted) throw new DOMException("ChatGPT effort selection aborted", "AbortError");
+      const value = Math.min(cap, deadline - Date.now());
+      if (value <= 0) throw new Error("ChatGPT effort selection did not reach an authoritative state within 60000ms");
+      return value;
+    };
+    const pause = async (): Promise<void> => {
+      await new Promise<void>((resolveSleep, rejectSleep) => {
+        const onAbort = () => {
+          clearTimeout(timer);
+          rejectSleep(new DOMException("ChatGPT effort selection aborted", "AbortError"));
+        };
+        const timer = setTimeout(() => {
+          abortSignal.removeEventListener("abort", onAbort);
+          resolveSleep();
+        }, Math.min(50, remaining(50)));
+        abortSignal.addEventListener("abort", onAbort, { once: true });
+      });
+    };
+    const resolveControl = async (waitMs = 0): Promise<Locator> => {
+      const waitDeadline = Math.min(deadline, Date.now() + waitMs);
+      while (true) {
+        const controls = composerForm.locator(CHATGPT_EFFORT_CONTROL_SELECTOR).filter({ visible: true });
+        const count = await controls.count();
+        if (count === 1) return controls.first();
+        if (count > 1) throw new Error(`ChatGPT effort control is ambiguous (visibleCount=${count})`);
+        if (Date.now() >= waitDeadline) {
+          await throwIfChatGptSessionFailureAlert(page);
+          throw new Error(`ChatGPT effort control is absent (visibleCount=${count})`);
         }
+        await throwIfChatGptSessionFailureAlert(page);
+        await pause();
       }
-      await captureDiagnostic?.("effort-selected");
-      await page.keyboard.press("Escape");
-      return mode;
-    }
-    const selected = await effortChoice.getAttribute("aria-checked");
-    if (selected !== "true" && selected !== "false") {
-      throw new Error(`ChatGPT effort item index ${uiEffortIndex} has no semantic checked state`);
-    }
-    if (selected === "true") {
-      await captureDiagnostic?.("effort-selected");
-      await page.keyboard.press("Escape");
-      return mode;
-    }
-    await throwIfChatGptRateLimitDialog(page);
-    await effortChoice.press("Enter");
-    await captureDiagnostic?.("effort-choice-activated");
-
-    const deadline = Date.now() + 40_000;
-    let confirmed: string | null = null;
-    while (Date.now() < deadline) {
-      if (!await effortMenu.isVisible().catch(() => false)) {
-        const expanded = await currentEffort.getAttribute("aria-expanded").catch(() => null);
-        if (expanded !== "true") {
-          await throwIfChatGptRateLimitDialog(page);
-          await currentEffort.click({ force: true });
-        }
-        await effortChoice.waitFor({
-          state: "visible",
-          timeout: Math.max(1, Math.min(5_000, deadline - Date.now())),
-        });
-      }
-      confirmed = await effortChoice.getAttribute("aria-checked");
-      if (confirmed === "true") {
-        await captureDiagnostic?.("effort-selected");
-        await page.keyboard.press("Escape");
-        return mode;
-      }
-      if (confirmed !== "false") {
-        throw new Error(`ChatGPT effort item index ${uiEffortIndex} lost its semantic checked state`);
-      }
-      await new Promise(resolveSleep => setTimeout(resolveSleep, 100));
-    }
-    throw new Error(
-      `ChatGPT did not confirm effort item index ${uiEffortIndex}`
-      + ` (aria-checked=${JSON.stringify(confirmed)})`,
+    };
+    const resolveMenu = async (): Promise<Locator | undefined> => {
+      const control = await resolveControl(5_000);
+      return await resolveChatGptEffortMenu(page, control, remaining(2_000));
+    };
+    const sliderState = async (slider: Locator) => parseChatGptEffortSliderState(
+      await slider.getAttribute("aria-valuemin", { timeout: remaining() }),
+      await slider.getAttribute("aria-valuemax", { timeout: remaining() }),
+      await slider.getAttribute("aria-valuenow", { timeout: remaining() }),
     );
+    const readOpenState = async (): Promise<ChatGptEffortOpenState | undefined> => {
+      const menu = await resolveMenu();
+      if (!menu) return undefined;
+      const choices = menu.locator(CHATGPT_EFFORT_ITEM_SELECTOR).filter({ visible: true });
+      const sliders = menu.locator(CHATGPT_EFFORT_SLIDER_SELECTOR).filter({ visible: true });
+      const [choiceCount, sliderCount] = await Promise.all([choices.count(), sliders.count()]);
+      if (choiceCount > 0 && sliderCount > 0) {
+        throw new Error(`ChatGPT effort menu exposes conflicting controls (items=${choiceCount}; sliders=${sliderCount})`);
+      }
+      if (sliderCount > 1) throw new Error(`ChatGPT effort slider is ambiguous (visibleCount=${sliderCount})`);
+      if (sliderCount === 1) {
+        const parsed = await sliderState(sliders.first());
+        if (!parsed) throw new Error("ChatGPT effort slider exposed an invalid ARIA range");
+        return { kind: "slider", ...parsed };
+      }
+      if (choiceCount > 0) {
+        if (choiceCount > 5 || targetIndex >= choiceCount) {
+          return { kind: "menu", optionCount: choiceCount, targetLabel: "" };
+        }
+        const checked = await Promise.all(Array.from({ length: choiceCount }, (_, index) => (
+          choices.nth(index).getAttribute("aria-checked", { timeout: remaining() })
+        )));
+        if (checked.some(value => value !== "true" && value !== "false")) {
+          throw new Error("ChatGPT effort menu lost its semantic checked state");
+        }
+        const selected = checked.flatMap((value, index) => value === "true" ? [index] : []);
+        if (selected.length !== 1) {
+          throw new Error(`ChatGPT effort menu current state is ambiguous (selectedCount=${selected.length})`);
+        }
+        const targetLabel = (await choices.nth(targetIndex).innerText({ timeout: remaining() })).replace(/\s+/g, " ").trim();
+        if (!targetLabel) throw new Error(`ChatGPT effort item index ${targetIndex} has no visible label`);
+        return { kind: "menu", optionCount: choiceCount, currentIndex: selected[0], targetLabel };
+      }
+      return undefined;
+    };
+    const waitForOpenState = async (): Promise<ChatGptEffortOpenState> => {
+      while (true) {
+        try {
+          const state = await readOpenState();
+          if (state) return state;
+        } catch (error) {
+          if (abortSignal.aborted) throw error;
+          const message = error instanceof Error ? error.message : String(error);
+          if (!/detached|not attached|not connected/i.test(message)) throw error;
+          throw new ChatGptEffortStaleDomError(message);
+        }
+        await throwIfChatGptRateLimitDialog(page, remaining(2_000));
+        await throwIfChatGptSessionFailureAlert(page);
+        await pause();
+      }
+    };
+    let openedBySelection = false;
+    await ensureChatGptEffortSelection({
+      readCurrent: async () => {
+        await resolveControl(30_000);
+        await settleChatGptUi();
+        await throwIfChatGptRateLimitDialog(page, remaining(2_000));
+        await throwIfChatGptSessionFailureAlert(page);
+        await captureDiagnostic?.("effort-control-ready");
+        const control = await resolveControl(5_000);
+        const label = await control.innerText({ timeout: remaining() });
+        return chatGptEffortIndexFromControlLabel(label);
+      },
+      openAndRead: async () => {
+        try {
+          const control = await resolveControl(5_000);
+          const expanded = await control.getAttribute("aria-expanded", { timeout: remaining() });
+          openedBySelection = true;
+          if (expanded !== "true") {
+            await throwIfChatGptRateLimitDialog(page, remaining(2_000));
+            await throwIfChatGptSessionFailureAlert(page);
+            // The launcher-owned background Electron surface does not reliably open the current
+            // Radix trigger with synthetic keyboard activation. The composer-scoped unique control
+            // and owned-menu postcondition keep this single forced pointer activation target-safe.
+            await control.click({ force: true, timeout: remaining(5_000) });
+          }
+          await captureDiagnostic?.("effort-menu-open-requested");
+          const state = await waitForOpenState();
+          await captureDiagnostic?.(state.kind === "slider" ? "effort-slider-visible" : "effort-choice-visible");
+          return state;
+        } catch (error) {
+          if (abortSignal.aborted) throw error;
+          const message = error instanceof Error ? error.message : String(error);
+          if (/detached|not attached|not connected|effort control is absent/i.test(message)) {
+            throw new ChatGptEffortStaleDomError(message);
+          }
+          throw error;
+        }
+      },
+      transition: async (state, desired) => {
+        await throwIfChatGptRateLimitDialog(page, remaining(2_000));
+        await throwIfChatGptSessionFailureAlert(page);
+        if (state.kind === "menu") {
+          const menu = await resolveMenu();
+          if (!menu) throw new Error("ChatGPT effort menu disappeared before transition");
+          const choices = menu.locator(CHATGPT_EFFORT_ITEM_SELECTOR).filter({ visible: true });
+          if (await choices.count() !== state.optionCount) {
+            throw new Error("ChatGPT effort menu changed shape before transition");
+          }
+          await choices.nth(desired).press("Enter", { timeout: remaining(5_000) });
+          await captureDiagnostic?.("effort-choice-activated");
+          return { changed: true };
+        }
+        const targetValue = state.min + desired;
+        let current = state.value;
+        for (let step = 0; current !== targetValue && step < state.max - state.min + 1; step += 1) {
+          const menu = await resolveMenu();
+          if (!menu) throw new Error("ChatGPT effort slider disappeared before transition completed");
+          const sliders = menu.locator(CHATGPT_EFFORT_SLIDER_SELECTOR).filter({ visible: true });
+          if (await sliders.count() !== 1) throw new Error("ChatGPT effort slider became absent or ambiguous");
+          const slider = sliders.first();
+          const control = slider.locator("xpath=ancestor::*[@role='menuitem'][1]");
+          if (await control.count() !== 1) throw new Error("ChatGPT effort slider has no unique semantic menu item");
+          const direction = targetValue > current ? 1 : -1;
+          const key = direction > 0 ? "ArrowRight" : "ArrowLeft";
+          const previous = current;
+          await control.press(key, { timeout: remaining(5_000) });
+          while (current === previous) {
+            const observed = await readOpenState();
+            if (observed?.kind !== "slider") throw new Error("ChatGPT effort slider lost its semantic ARIA state");
+            current = observed.value;
+            if (current !== previous) break;
+            await pause();
+          }
+          if (current !== previous + direction) {
+            throw new Error(`ChatGPT effort slider did not move exactly one step with ${key} (before=${previous}; after=${current})`);
+          }
+        }
+        return { changed: current !== state.value };
+      },
+      readActual: async (state, desired) => {
+        const acknowledgementDeadline = Math.min(deadline, Date.now() + 15_000);
+        while (Date.now() < acknowledgementDeadline) {
+          await throwIfChatGptSessionFailureAlert(page);
+          const control = await resolveControl(5_000);
+          const label = (await control.innerText({ timeout: remaining() })).replace(/\s+/g, " ").trim();
+          if (state.kind === "menu" && label === state.targetLabel) return desired;
+          const recognized = chatGptEffortIndexFromControlLabel(label);
+          if (recognized === desired) return desired;
+          const observed = await readOpenState();
+          if (observed?.kind === "slider") {
+            const actual = observed.value - observed.min;
+            if (actual === desired) return actual;
+          } else if (observed?.kind === "menu" && observed.currentIndex === desired) {
+            return observed.currentIndex;
+          }
+          await pause();
+        }
+        return undefined;
+      },
+      close: async () => {
+        if (!openedBySelection) return;
+        const control = await resolveControl(5_000);
+        if (await control.getAttribute("aria-expanded", { timeout: remaining() }) === "true") {
+          await control.press("Escape", { timeout: remaining(2_000) });
+        }
+        await captureDiagnostic?.("effort-selected");
+      },
+    }, targetIndex, abortSignal);
+    return mode;
   }
 
   private async activeComposer(page: Page, timeoutMs = 30_000): Promise<Locator> {
@@ -2460,12 +2562,13 @@ export class ChatGptBrowserWorker {
           checkpoint => diagnostics.capture(page, checkpoint),
         ),
       );
-      let mode = await this.runStage(turn.traceId, "effort_selection", browserStageTimeouts.effortSelection, () => (
+      let mode = await this.runStage(turn.traceId, "effort_selection", browserStageTimeouts.effortSelection, stageSignal => (
         this.selectModelAndEffort(
           page,
           turn.modelId,
           stagingMode.effort,
           turn.capabilities,
+          turn.abortSignal ? AbortSignal.any([stageSignal, turn.abortSignal]) : stageSignal,
           checkpoint => diagnostics.capture(page, checkpoint),
         )
       ));
@@ -2523,11 +2626,12 @@ export class ChatGptBrowserWorker {
             turn.traceId,
             "final_part_effort_selection",
             browserStageTimeouts.effortSelection,
-            () => this.selectModelAndEffort(
+            stageSignal => this.selectModelAndEffort(
               page,
               turn.modelId,
               requestedMode.effort,
               turn.capabilities,
+              turn.abortSignal ? AbortSignal.any([stageSignal, turn.abortSignal]) : stageSignal,
               checkpoint => diagnostics.capture(page, `final-part-${checkpoint}`),
             ),
           );
@@ -2566,7 +2670,7 @@ export class ChatGptBrowserWorker {
             turn.traceId,
             "connector_catalog_refresh",
             browserStageTimeouts.temporaryChatPreparation,
-            async () => {
+            async stageSignal => {
               await page.reload({ waitUntil: "domcontentloaded", timeout: 60_000 });
               await this.prepareTemporaryChatSurface(
                 page,
@@ -2577,6 +2681,7 @@ export class ChatGptBrowserWorker {
                 turn.modelId,
                 turn.reasoning,
                 turn.capabilities,
+                turn.abortSignal ? AbortSignal.any([stageSignal, turn.abortSignal]) : stageSignal,
                 checkpoint => diagnostics.capture(page, checkpoint),
               );
               submissionBaseline = await this.captureSubmissionBaseline(page);
@@ -2745,8 +2850,11 @@ export class ChatGptBrowserWorker {
       }
 
       if (this.context && this.config.browserHost === "managed-chrome") {
+        await assertAuthenticatedChatGptPage(page);
+        const capabilities = storedBrowserLoginCapabilities(this.config);
         const state = await this.context.storageState();
         atomicWriteFile(this.config.storageStatePath, `${JSON.stringify(state)}\n`);
+        writeBrowserLoginVerificationMarker(this.config.storageStatePath, capabilities);
       }
       await diagnostics.capture(page, "turn-completed");
       console.info(`[chatgpt-web] browser turn ${turn.traceId} completed (markdownChars=${finalText.length})`);

--- a/src/adapters/chatgpt-web/command-observability.ts
+++ b/src/adapters/chatgpt-web/command-observability.ts
@@ -1,0 +1,174 @@
+import { createHash } from "node:crypto";
+
+export const COMMAND_OBSERVATION_PREFIX = "[chatgpt-web-mcp-observation] ";
+export const PLATFORM_HTTP_ENDPOINT_NOT_OBSERVABLE = "PLATFORM_HTTP_ENDPOINT_NOT_OBSERVABLE";
+
+type RequestExtra = {
+  requestId: string | number;
+  sessionId?: string;
+  _meta?: unknown;
+};
+
+type CommandTerminalClass = "success" | "pending" | "terminal_error" | "unknown" | "handler_exception";
+
+function fingerprint(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 16);
+}
+
+function connectorCorrelation(extra: RequestExtra): string {
+  const meta = extra._meta && typeof extra._meta === "object" && !Array.isArray(extra._meta)
+    ? extra._meta as Record<string, unknown>
+    : {};
+  const platformSession = typeof meta["openai/session"] === "string" ? meta["openai/session"] : "";
+  return fingerprint(JSON.stringify({
+    platformSession,
+    requestId: String(extra.requestId),
+    sessionId: extra.sessionId ?? "",
+  }));
+}
+
+function commandTerminalClass(value: unknown): CommandTerminalClass {
+  const result = value && typeof value === "object" ? value as Record<string, unknown> : {};
+  const serialized = JSON.stringify(result);
+  if (serialized.includes("UNRESOLVED_UNKNOWN_OUTCOME")) return "unknown";
+  const structured = result.structuredContent && typeof result.structuredContent === "object"
+    ? result.structuredContent as Record<string, unknown>
+    : {};
+  if (structured.session_id !== undefined || structured.cell_id !== undefined
+    || structured.status === "running" || structured.status === "pending") return "pending";
+  if (result.isError === true) return "terminal_error";
+  return "success";
+}
+
+function emitObservation(value: Record<string, unknown>): void {
+  console.error(`${COMMAND_OBSERVATION_PREFIX}${JSON.stringify({ time: new Date().toISOString(), ...value })}`);
+}
+
+export async function observeCommandInvocation<T>(
+  tool: "codex_exec" | "codex_write_stdin",
+  extra: RequestExtra,
+  run: () => Promise<T>,
+): Promise<T> {
+  const correlation = connectorCorrelation(extra);
+  emitObservation({
+    schema: "command-observation-v1",
+    event: "connector_invocation_start",
+    tool,
+    correlation,
+  });
+  try {
+    const response = await run();
+    const terminalClass = commandTerminalClass(response);
+    emitObservation({
+      schema: "command-observation-v1",
+      event: "connector_invocation_terminal",
+      tool,
+      correlation,
+      terminal_class: terminalClass,
+      remote_failure_class: terminalClass === "unknown"
+        ? "native_outcome_unknown"
+        : terminalClass === "terminal_error"
+          ? "connector_result_error_unattributed"
+          : "none",
+    });
+    return response;
+  } catch (error) {
+    emitObservation({
+      schema: "command-observation-v1",
+      event: "connector_invocation_terminal",
+      tool,
+      correlation,
+      terminal_class: "handler_exception",
+      remote_failure_class: "connector_handler_exception",
+      error_class: error instanceof Error ? error.name : "unknown_error",
+    });
+    throw error;
+  }
+}
+
+interface ParsedLine {
+  time?: string;
+  msg?: string;
+  level?: string;
+  component?: string;
+  request_id?: string;
+  cmd_request_id?: string;
+  event?: string;
+  correlation?: string;
+  terminal_class?: string;
+  remote_failure_class?: string;
+}
+
+function parsedLine(line: string): ParsedLine | null {
+  const observationAt = line.indexOf(COMMAND_OBSERVATION_PREFIX);
+  const jsonText = observationAt >= 0
+    ? line.slice(observationAt + COMMAND_OBSERVATION_PREFIX.length)
+    : line.trim();
+  try {
+    const value: unknown = JSON.parse(jsonText);
+    return value && typeof value === "object" ? value as ParsedLine : null;
+  } catch {
+    return null;
+  }
+}
+
+function inWindow(entry: ParsedLine, since?: string, until?: string): boolean {
+  if (!entry.time) return true;
+  const time = Date.parse(entry.time);
+  if (!Number.isFinite(time)) return true;
+  return (!since || time >= Date.parse(since)) && (!until || time <= Date.parse(until));
+}
+
+export function summarizeCommandObservabilityLog(
+  text: string,
+  window: { since?: string; until?: string } = {},
+): Record<string, unknown> {
+  const entries = text.split(/\r?\n/)
+    .map(parsedLine)
+    .filter((entry): entry is ParsedLine => entry !== null)
+    .filter(entry => inWindow(entry, window.since, window.until));
+  const forwarded = entries.filter(entry => entry.msg === "dispatcher forwarded command to MCP server");
+  const posted = entries.filter(entry => entry.msg === "posted response to control-plane");
+  const forwardedIds = new Set(forwarded.flatMap(entry => [entry.request_id, entry.cmd_request_id])
+    .filter((value): value is string => Boolean(value)));
+  const matchingPosted = posted.filter(entry => [entry.request_id, entry.cmd_request_id]
+    .some(value => typeof value === "string" && forwardedIds.has(value)));
+  const starts = entries.filter(entry => entry.event === "connector_invocation_start");
+  const terminals = entries.filter(entry => entry.event === "connector_invocation_terminal");
+  const tunnelCorrelations = [...new Set(forwarded.flatMap(entry => [entry.cmd_request_id, entry.request_id])
+    .filter((value): value is string => Boolean(value))
+    .map(fingerprint))];
+  const connectorCorrelations = [...new Set(starts.map(entry => entry.correlation).filter((value): value is string => Boolean(value)))];
+  const tunnelFailures = entries
+    .filter(entry => entry.level === "ERROR" || entry.level === "WARN")
+    .map(entry => `${entry.component ?? "unknown"}_error`);
+  const remoteFailureClasses = [...new Set([
+    ...terminals.map(entry => entry.remote_failure_class).filter((value): value is string => Boolean(value) && value !== "none"),
+    ...tunnelFailures,
+  ])];
+  const boundedWindow = Boolean(window.since && window.until);
+  const temporalSingletonCandidate = boundedWindow
+    && forwarded.length === 1 && matchingPosted.length === 1 && starts.length === 1 && terminals.length === 1;
+
+  return {
+    schema: "command-observability-summary-v1",
+    platform_http_endpoint: PLATFORM_HTTP_ENDPOINT_NOT_OBSERVABLE,
+    window: { since: window.since ?? null, until: window.until ?? null },
+    candidate_poll_arrival: forwarded.length > 0,
+    candidate_poll_arrival_count: forwarded.length,
+    candidate_response_post: matchingPosted.length > 0,
+    candidate_response_post_count: matchingPosted.length,
+    unmatched_response_post_count: posted.length - matchingPosted.length,
+    connector_invocation_start: starts.length > 0,
+    connector_invocation_start_count: starts.length,
+    connector_terminal_classes: terminals.map(entry => entry.terminal_class ?? "unknown"),
+    remote_failure_classes: remoteFailureClasses,
+    sanitized_correlation: {
+      tunnel: tunnelCorrelations,
+      connector: connectorCorrelations,
+      method: "separate_stage_fingerprints_no_shared_connector_identifier",
+      temporal_singleton_candidate: temporalSingletonCandidate,
+      status: "INCONCLUSIVE_NO_SHARED_IDENTIFIER",
+    },
+  };
+}

--- a/src/adapters/chatgpt-web/effort-selection.ts
+++ b/src/adapters/chatgpt-web/effort-selection.ts
@@ -1,0 +1,124 @@
+export type ChatGptEffortIndex = 0 | 1 | 2 | 3 | 4;
+
+export type ChatGptEffortOpenState =
+  | {
+    kind: "menu";
+    optionCount: number;
+    currentIndex?: number;
+    targetLabel: string;
+  }
+  | {
+    kind: "slider";
+    min: number;
+    max: number;
+    value: number;
+  };
+
+export interface ChatGptEffortSelectionDriver {
+  /** Read a semantically recognizable current state without opening or changing the control. */
+  readCurrent(signal: AbortSignal): Promise<number | undefined>;
+  /** Open the single proven effort control and return its single proven menu/slider shape. */
+  openAndRead(targetIndex: ChatGptEffortIndex, signal: AbortSignal): Promise<ChatGptEffortOpenState>;
+  /** Perform the one intended logical transition. `changed` is advisory, never authoritative. */
+  transition(
+    state: ChatGptEffortOpenState,
+    targetIndex: ChatGptEffortIndex,
+    signal: AbortSignal,
+  ): Promise<{ changed: boolean }>;
+  /** Re-resolve the DOM and return the actual current index, or undefined when it is ambiguous. */
+  readActual(
+    state: ChatGptEffortOpenState,
+    targetIndex: ChatGptEffortIndex,
+    signal: AbortSignal,
+  ): Promise<number | undefined>;
+  close(signal: AbortSignal): Promise<void>;
+}
+
+export interface ChatGptEffortSelectionResult {
+  changed: boolean;
+  transitions: 0 | 1;
+}
+
+export class ChatGptEffortStaleDomError extends Error {
+  constructor(message = "ChatGPT effort DOM was replaced") {
+    super(message);
+    this.name = "ChatGptEffortStaleDomError";
+  }
+}
+
+function abortError(): DOMException {
+  return new DOMException("ChatGPT effort selection aborted", "AbortError");
+}
+
+function assertNotAborted(signal: AbortSignal): void {
+  if (signal.aborted) throw abortError();
+}
+
+function stateIndex(state: ChatGptEffortOpenState): number | undefined {
+  if (state.kind === "slider") return state.value - state.min;
+  return state.currentIndex;
+}
+
+function assertTargetAvailable(state: ChatGptEffortOpenState, targetIndex: ChatGptEffortIndex): void {
+  const optionCount = state.kind === "slider" ? state.max - state.min + 1 : state.optionCount;
+  if (!Number.isInteger(optionCount) || optionCount < 1 || optionCount > 5 || targetIndex >= optionCount) {
+    throw new Error(`ChatGPT effort control does not expose item index ${targetIndex} (optionCount=${optionCount})`);
+  }
+}
+
+/**
+ * One bounded logical flow: passive observation, one open/observation, at most one intended
+ * transition, and an authoritative post-transition observation. The driver owns DOM-specific
+ * bounded re-resolution; this coordinator never retries a transition.
+ */
+export async function ensureChatGptEffortSelection(
+  driver: ChatGptEffortSelectionDriver,
+  targetIndex: ChatGptEffortIndex,
+  signal: AbortSignal,
+): Promise<ChatGptEffortSelectionResult> {
+  assertNotAborted(signal);
+  const passiveCurrent = await driver.readCurrent(signal);
+  assertNotAborted(signal);
+  if (passiveCurrent === targetIndex) return { changed: false, transitions: 0 };
+
+  let state: ChatGptEffortOpenState;
+  try {
+    state = await driver.openAndRead(targetIndex, signal);
+  } catch (error) {
+    if (!(error instanceof ChatGptEffortStaleDomError)) throw error;
+    assertNotAborted(signal);
+    state = await driver.openAndRead(targetIndex, signal);
+  }
+  assertNotAborted(signal);
+  assertTargetAvailable(state, targetIndex);
+  if (stateIndex(state) === targetIndex) {
+    await driver.close(signal);
+    return { changed: false, transitions: 0 };
+  }
+
+  const transition = await driver.transition(state, targetIndex, signal);
+  assertNotAborted(signal);
+  const actual = await driver.readActual(state, targetIndex, signal);
+  assertNotAborted(signal);
+  if (actual !== targetIndex) {
+    throw new Error(
+      `ChatGPT did not confirm effort item index ${targetIndex}`
+      + ` (actual=${actual === undefined ? "ambiguous" : actual}; changed=${transition.changed})`,
+    );
+  }
+  await driver.close(signal);
+  return { changed: transition.changed, transitions: 1 };
+}
+
+export function chatGptEffortIndexFromControlLabel(value: string): ChatGptEffortIndex | undefined {
+  const normalized = value.replace(/\s+/g, " ").trim().toLocaleLowerCase("en-US");
+  const labels = new Map<string, ChatGptEffortIndex>([
+    ["instant", 0],
+    ["medium", 1],
+    ["high", 2],
+    ["高い", 2],
+    ["extra high", 3],
+    ["pro", 4],
+  ]);
+  return labels.get(normalized);
+}

--- a/src/adapters/chatgpt-web/index.ts
+++ b/src/adapters/chatgpt-web/index.ts
@@ -424,6 +424,31 @@ export function createChatGptWebAdapter(
       try {
         emit({ type: "heartbeat" });
         await session.runExclusive(async () => {
+          let turnToken: string | undefined;
+          const outstanding = session.outstanding();
+          if (outstanding.length > 0 && session.runtime.mode === "tools") {
+            turnToken = await withAbort(session.runtime.token, incoming.abortSignal);
+            if (!environment) throw new Error("Tool-capable ChatGPT web runtime lost its trusted environment");
+            await broker.updateEnvironment(turnToken, environment);
+
+            const results = currentToolResults(parsed, session);
+            if (results.length === 0) {
+              const reasoning = session.reasoningForOutstandingReplay();
+              replayEvents(session.eventsForOutstandingReplay(), emit);
+              emitToolBatch(outstanding, estimateChatGptWebUsage(currentUsageInput(parsed), { reasoning, toolRequests: outstanding }, turnCapabilities), emit);
+              return;
+            }
+            if (results.length !== outstanding.length) {
+              throw new Error(`Codex returned ${results.length} of ${outstanding.length} results for a parallel ChatGPT tool batch`);
+            }
+            for (const message of results) {
+              await broker.completeTool(turnToken, message.toolCallId, brokerResult(message));
+              session.markResultDelivered(message.toolCallId);
+            }
+          } else if (outstanding.length > 0) {
+            throw new Error("Read-only ChatGPT Web runtime cannot own local tool calls");
+          }
+
           const settled = session.settledOutcome();
           if (settled) {
             if (settled.type === "error") throw settled.error;
@@ -448,36 +473,16 @@ export function createChatGptWebAdapter(
               session.setFinalReasoning(reasoning);
               session.setFinalEvents(events);
             }
+            if (turnToken) await broker.revoke(turnToken);
             emitBrowserCompletion(settled, estimateChatGptWebUsage(currentUsageInput(parsed), { answer: settled.answer, reasoning }, turnCapabilities), emit);
             chatGptWebTurnRetryPolicy.clear(retryKey);
             return;
           }
 
-          let turnToken: string | undefined;
-          if (session.runtime.mode === "tools") {
+          if (session.runtime.mode === "tools" && !turnToken) {
             turnToken = await withAbort(session.runtime.token, incoming.abortSignal);
             if (!environment) throw new Error("Tool-capable ChatGPT web runtime lost its trusted environment");
             await broker.updateEnvironment(turnToken, environment);
-
-            const outstanding = session.outstanding();
-            if (outstanding.length > 0) {
-              const results = currentToolResults(parsed, session);
-              if (results.length === 0) {
-                const reasoning = session.reasoningForOutstandingReplay();
-                replayEvents(session.eventsForOutstandingReplay(), emit);
-                emitToolBatch(outstanding, estimateChatGptWebUsage(currentUsageInput(parsed), { reasoning, toolRequests: outstanding }, turnCapabilities), emit);
-                return;
-              }
-              if (results.length !== outstanding.length) {
-                throw new Error(`Codex returned ${results.length} of ${outstanding.length} results for a parallel ChatGPT tool batch`);
-              }
-              for (const message of results) {
-                await broker.completeTool(turnToken, message.toolCallId, brokerResult(message));
-                session.markResultDelivered(message.toolCallId);
-              }
-            }
-          } else if (session.outstanding().length > 0) {
-            throw new Error("Read-only ChatGPT Web runtime cannot own local tool calls");
           }
 
           const toolWaitAbort = new AbortController();

--- a/src/adapters/chatgpt-web/mcp-server.ts
+++ b/src/adapters/chatgpt-web/mcp-server.ts
@@ -5,6 +5,7 @@ import * as z from "zod/v4";
 import { namespacedToolName, type CodexTool } from "../../types";
 import type { ChatGptTurnEnvironment } from "./environment";
 import { callTurnBroker, type BrokerToolResult } from "./turn-broker";
+import { observeCommandInvocation } from "./command-observability";
 
 interface ClaimedTurn {
   bindingId: string;
@@ -14,9 +15,21 @@ interface ClaimedTurn {
 const turnTokenSchema = z.string().min(20).max(256);
 const jsonArgumentsSchema = z.record(z.string(), z.unknown()).default({});
 export const CHATGPT_WEB_AGENT_WAIT_POLL_MS = 10_000;
+const escalationSandboxPermissionsSchema = z.literal("require_escalated");
+const escalationJustificationSchema = z.string().min(1).max(4_000);
+const PENDING_CELL_TEXT = /^Script running with cell ID ([^\s\x00-\x1f\x7f]{1,256})(?:\r?\nWall time \d+(?:\.\d+)? seconds\r?\nOutput:\r?\n[\s\S]*)?$/;
+const TERMINAL_OUTPUT_TEXT = /^Script completed\r?\nWall time \d+(?:\.\d+)? seconds\r?\nOutput:\r?\n([\s\S]*)$/;
+const TERMINAL_FINAL_OUTPUT_TEXT = /^Script completed\r?\nWall time \d+(?:\.\d+)? seconds\r?\nProcess exited with code 0\r?\nFinal output:\r?\n([\s\S]*)$/;
+const TERMINAL_FAILURE_TEXT = /^(Script failed|Script terminated)(?:\r?\n[\s\S]*)?$/;
+const UNRESOLVED_UNKNOWN_OUTCOME = "UNRESOLVED_UNKNOWN_OUTCOME: outcome remains UNKNOWN; the original invocation cannot be retried and the command slot remains locked";
+const GATEWAY_COMMAND_RESULT_PROTOCOL = "codex_exec_gateway_result_v1";
 
 function scopeHash(value: string): string {
   return createHash("sha256").update(value).digest("hex").slice(0, 12);
+}
+
+function brokerInvocationKey(scope: string, value: unknown): string {
+  return createHash("sha256").update(JSON.stringify({ scope, value })).digest("base64url");
 }
 
 function requestScopeSummary(extra: {
@@ -38,7 +51,10 @@ function requestScopeSummary(extra: {
     ? Object.keys(extra.requestInfo as Record<string, unknown>).sort()
     : [];
   return JSON.stringify({
-    requestId: String(extra.requestId),
+    requestId: {
+      chars: String(extra.requestId).length,
+      hash: scopeHash(String(extra.requestId)),
+    },
     session: extra.sessionId ? { chars: extra.sessionId.length, hash: scopeHash(extra.sessionId) } : null,
     meta,
     requestInfoKeys,
@@ -58,13 +74,25 @@ function wireName(tool: CodexTool): string {
 }
 
 function exactTool(environment: ChatGptTurnEnvironment, name: string): CodexTool | undefined {
-  return environment.tools.find(tool => !tool.namespace && tool.name === name);
+  const matches = environment.tools.filter(tool => !tool.namespace && tool.name === name);
+  if (matches.length > 1) throw new Error(`This Codex turn advertised duplicate native tools: ${name}`);
+  return matches[0];
 }
 
 function namedTool(environment: ChatGptTurnEnvironment, requestedWireName: string): CodexTool {
-  const tool = environment.tools.find(candidate => wireName(candidate) === requestedWireName);
-  if (!tool) throw new Error(`Codex tool is not available in this turn: ${requestedWireName}`);
-  return tool;
+  const matches = environment.tools.filter(candidate => wireName(candidate) === requestedWireName);
+  if (matches.length === 0) throw new Error(`Codex tool is not available in this turn: ${requestedWireName}`);
+  if (matches.length > 1) throw new Error(`This Codex turn advertised duplicate tools: ${requestedWireName}`);
+  return matches[0];
+}
+
+function isDedicatedCommandTool(tool: CodexTool): boolean {
+  const normalized = gatewayNestedToolName(tool.name);
+  return normalized === "exec"
+    || normalized === "exec_command"
+    || normalized === "shell_command"
+    || normalized === "wait"
+    || normalized === "write_stdin";
 }
 
 function isAgentWaitTool(tool: CodexTool): boolean {
@@ -133,9 +161,270 @@ function asMcpResult(value: BrokerToolResult) {
   };
 }
 
+function asMcpError(value: BrokerToolResult) {
+  return asMcpResult({ ...value, isError: true });
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function schemaAllowsLiteral(schema: unknown, literal: string): boolean {
+  const value = record(schema);
+  if (!value) return false;
+  if (value.const === literal) return true;
+  if (Array.isArray(value.enum) && value.enum.includes(literal)) return true;
+  return [value.anyOf, value.oneOf]
+    .filter(Array.isArray)
+    .some(branches => branches.some(branch => schemaAllowsLiteral(branch, literal)));
+}
+
+function schemaAllowsString(schema: unknown): boolean {
+  const value = record(schema);
+  if (!value) return false;
+  if (value.type === "string") return true;
+  return [value.anyOf, value.oneOf]
+    .filter(Array.isArray)
+    .some(branches => branches.some(branch => schemaAllowsString(branch)));
+}
+
+function directExecSupportsEscalation(tool: CodexTool): boolean {
+  if (tool.name !== "exec_command" || tool.freeform) return false;
+  const properties = record(record(tool.parameters)?.properties);
+  return schemaAllowsLiteral(properties?.sandbox_permissions, "require_escalated")
+    && schemaAllowsString(properties?.justification);
+}
+
+function contentText(value: BrokerToolResult): string | undefined {
+  if (!Array.isArray(value.content) || value.content.length !== 1) return undefined;
+  const content = record(value.content[0]);
+  return content?.type === "text" && typeof content.text === "string" ? content.text : undefined;
+}
+
+type CommandFailureKind = "denial" | "failure" | "cancellation";
+type GatewayExecResultState =
+  | { kind: "pending"; cellId: string }
+  | { kind: "session"; sessionId: number }
+  | { kind: "success"; cellId?: string }
+  | { kind: CommandFailureKind; cellId?: string }
+  | { kind: "unknown" };
+
+function validCellId(value: unknown): value is string {
+  return typeof value === "string" && /^[^\s\x00-\x1f\x7f]{1,256}$/.test(value);
+}
+
+function failureKind(state: unknown): CommandFailureKind | undefined {
+  if (state === "denied" || state === "rejected") return "denial";
+  if (state === "failed" || state === "failure" || state === "error") return "failure";
+  if (state === "terminated" || state === "cancelled" || state === "canceled") return "cancellation";
+  return undefined;
+}
+
+type DirectCommandResultState = GatewayExecResultState;
+
+function directCommandResultState(value: BrokerToolResult): DirectCommandResultState {
+  const state = gatewayExecResultState(value);
+  return state.kind === "pending" ? { kind: "unknown" } : state;
+}
+
+function structuredGatewayState(structured: Record<string, unknown>): GatewayExecResultState {
+  const status = structured.status;
+  const state = structured.state;
+  if ((status !== undefined && typeof status !== "string")
+    || (state !== undefined && typeof state !== "string")
+    || (status !== undefined && state !== undefined && status !== state)) {
+    return { kind: "unknown" };
+  }
+  if (Object.hasOwn(structured, "cellId") || Object.hasOwn(structured, "cell")) {
+    return { kind: "unknown" };
+  }
+  const terminalState = status ?? state;
+  const cellId = structured.cell_id;
+  if (cellId !== undefined && !validCellId(cellId)) return { kind: "unknown" };
+  const hasSessionId = structured.session_id !== undefined;
+  if (terminalState === undefined && structured.exit_code === undefined && structured.session_id !== undefined) {
+    return cellId === undefined
+      && typeof structured.session_id === "number"
+      && Number.isSafeInteger(structured.session_id)
+      && structured.session_id >= 0
+      ? { kind: "session", sessionId: structured.session_id }
+      : { kind: "unknown" };
+  }
+  if (terminalState === "pending" || terminalState === "running") {
+    if (structured.exit_code !== undefined || hasSessionId || !validCellId(cellId)) return { kind: "unknown" };
+    return { kind: "pending", cellId };
+  }
+  if (terminalState === "completed" || terminalState === "success") {
+    if (hasSessionId || (structured.exit_code !== undefined && structured.exit_code !== 0)) return { kind: "unknown" };
+    return { kind: "success", ...(cellId ? { cellId } : {}) };
+  }
+  const failed = failureKind(terminalState);
+  if (failed) {
+    if (hasSessionId || structured.exit_code === 0) return { kind: "unknown" };
+    return { kind: failed, ...(cellId ? { cellId } : {}) };
+  }
+  if (terminalState !== undefined) return { kind: "unknown" };
+  if (typeof structured.exit_code === "number" && Number.isInteger(structured.exit_code)) {
+    if (hasSessionId) return { kind: "unknown" };
+    return structured.exit_code === 0
+      ? { kind: "success", ...(cellId ? { cellId } : {}) }
+      : { kind: "failure", ...(cellId ? { cellId } : {}) };
+  }
+  return { kind: "unknown" };
+}
+
+function taggedGatewayState(value: unknown): GatewayExecResultState {
+  const envelope = record(value);
+  if (!envelope
+    || envelope.protocol !== GATEWAY_COMMAND_RESULT_PROTOCOL
+    || Object.keys(envelope).sort().join(",") !== "protocol,result") {
+    return { kind: "unknown" };
+  }
+  const nestedResult = record(envelope.result);
+  if (!nestedResult) return { kind: "unknown" };
+  if (Array.isArray(nestedResult.content)) {
+    return gatewayExecResultState(nestedResult as unknown as BrokerToolResult);
+  }
+  return structuredGatewayState(nestedResult);
+}
+
+function textGatewayState(text: string): GatewayExecResultState {
+  const pending = PENDING_CELL_TEXT.exec(text);
+  if (pending && validCellId(pending[1])) return { kind: "pending", cellId: pending[1] };
+  const completedOutput = (TERMINAL_OUTPUT_TEXT.exec(text)?.[1]
+    ?? TERMINAL_FINAL_OUTPUT_TEXT.exec(text)?.[1])?.trim();
+  if (completedOutput) {
+    try {
+      const nested: unknown = JSON.parse(completedOutput);
+      return taggedGatewayState(nested);
+    } catch {
+      return { kind: "unknown" };
+    }
+    return { kind: "unknown" };
+  }
+  const terminal = TERMINAL_FAILURE_TEXT.exec(text)?.[1];
+  if (terminal === "Script failed") return { kind: "failure" };
+  if (terminal === "Script terminated") return { kind: "cancellation" };
+  return { kind: "unknown" };
+}
+
+function gatewayStatesConflict(
+  structured: GatewayExecResultState,
+  textual: GatewayExecResultState,
+): boolean {
+  if (textual.kind === "unknown") return false;
+  if (structured.kind !== textual.kind) return true;
+  if (structured.kind === "session" && textual.kind === "session") {
+    return structured.sessionId !== textual.sessionId;
+  }
+  const structuredCellId = "cellId" in structured ? structured.cellId : undefined;
+  const textualCellId = "cellId" in textual ? textual.cellId : undefined;
+  if (structuredCellId || textualCellId) return structuredCellId !== textualCellId;
+  return false;
+}
+
+function gatewayExecResultState(value: BrokerToolResult): GatewayExecResultState {
+  if (!record(value) || !Array.isArray(value.content)) return { kind: "unknown" };
+  let state: GatewayExecResultState;
+  if (value.structuredContent !== undefined) {
+    const structured = record(value.structuredContent);
+    if (!structured) return { kind: "unknown" };
+    state = structuredGatewayState(structured);
+    const text = contentText(value);
+    if (text !== undefined && gatewayStatesConflict(state, textGatewayState(text))) {
+      return { kind: "unknown" };
+    }
+  } else {
+    const text = contentText(value);
+    if (text === undefined) return { kind: "unknown" };
+    state = textGatewayState(text);
+  }
+  return value.isError === true
+    && state.kind !== "denial"
+    && state.kind !== "failure"
+    && state.kind !== "cancellation"
+    ? { kind: "unknown" }
+    : state;
+}
+
+function outerGatewayExecResultState(value: BrokerToolResult): GatewayExecResultState {
+  if (!record(value) || !Array.isArray(value.content)) return { kind: "unknown" };
+  let state: GatewayExecResultState;
+  if (value.structuredContent !== undefined) {
+    state = taggedGatewayState(value.structuredContent);
+    const text = contentText(value);
+    if (text !== undefined && gatewayStatesConflict(state, textGatewayState(text))) {
+      return { kind: "unknown" };
+    }
+  } else {
+    const text = contentText(value);
+    if (text === undefined) return { kind: "unknown" };
+    // A bare wrapper failure proves only that the outer Code Mode program stopped. The nested OS
+    // command may already have been dispatched and can still be running, so only a tagged nested
+    // result may supply terminal evidence for failure or cancellation.
+    state = TERMINAL_FAILURE_TEXT.test(text) ? { kind: "unknown" } : textGatewayState(text);
+  }
+  return value.isError === true
+    && state.kind !== "denial"
+    && state.kind !== "failure"
+    && state.kind !== "cancellation"
+    ? { kind: "unknown" }
+    : state;
+}
+
+function commandLifecycleError(message: string) {
+  return result({ error: message }, true);
+}
+
+function withContinuationToken(value: BrokerToolResult, continuationToken: string): McpExecResult {
+  const structured = record(value.structuredContent);
+  if (!structured) {
+    return commandLifecycleError(`The native command session omitted its structured result. ${UNRESOLVED_UNKNOWN_OUTCOME}`);
+  }
+  const augmented = { ...structured, continuation_token: continuationToken };
+  return asMcpResult({
+    ...value,
+    structuredContent: augmented,
+    content: [{ type: "text", text: JSON.stringify(augmented) }],
+  });
+}
+
+function refreshContinuationToken(value: McpExecResult, continuationToken: string): McpExecResult {
+  const structured = record(value.structuredContent);
+  if (!structured) return value;
+  const augmented = { ...structured, continuation_token: continuationToken };
+  return {
+    ...value,
+    structuredContent: augmented,
+    content: [{ type: "text", text: JSON.stringify(augmented) }],
+  };
+}
+
+type McpExecResult = ReturnType<typeof asMcpResult> | ReturnType<typeof commandLifecycleError>;
+interface McpExecOutcome {
+  response: McpExecResult;
+  terminalEvidence: boolean;
+  sessionId?: number;
+  continuationToken?: string;
+}
+
+interface BrokerOperationIdentity {
+  operationKey: string;
+  operationRequestKey: string;
+}
+
 function execGateway(environment: ChatGptTurnEnvironment): CodexTool | undefined {
   const tool = exactTool(environment, "exec");
   return tool?.freeform ? tool : undefined;
+}
+
+function directCommandTool(environment: ChatGptTurnEnvironment): CodexTool | undefined {
+  const candidates = [exactTool(environment, "exec_command"), exactTool(environment, "shell_command")]
+    .filter((tool): tool is CodexTool => Boolean(tool));
+  if (candidates.length > 1) throw new Error("This Codex turn advertised multiple native command tools");
+  return candidates[0];
 }
 
 function gatewayNestedToolName(toolName: string): string {
@@ -176,32 +465,112 @@ function execGatewayProgram(
 function execCommandGatewayProgram(
   execCommandArguments: Record<string, unknown>,
   shellCommandArguments: Record<string, unknown>,
+  escalationRequested = false,
 ): string {
   const execCommandName = gatewayNestedToolName("exec_command");
   const shellCommandName = gatewayNestedToolName("shell_command");
-  return execGatewayResultProgram([
+  return [
     "if (typeof ALL_TOOLS === \"undefined\" || !Array.isArray(ALL_TOOLS)) throw new Error(\"Native command tool registry is unavailable\");",
-    "const nativeCommandNames = new Set(ALL_TOOLS.map(tool => tool?.name));",
-    `const nativeCommandCandidates = ${JSON.stringify([execCommandName, shellCommandName])}.filter(name => nativeCommandNames.has(name));`,
+    "const nativeCommandNames = ALL_TOOLS.map(tool => tool?.name);",
+    "const normalizeNativeCommandName = name => String(name).replace(/[^A-Za-z0-9_$]/g, \"_\");",
+    `const nativeCommandCandidates = nativeCommandNames.filter(name => ${JSON.stringify(escalationRequested ? [execCommandName] : [execCommandName, shellCommandName])}.includes(normalizeNativeCommandName(name)));`,
     "if (nativeCommandCandidates.length !== 1) throw new Error(\"Expected exactly one native command tool; found \" + (nativeCommandCandidates.join(\", \") || \"none\"));",
     "const nativeCommandName = nativeCommandCandidates[0];",
+    "if (nativeCommandName !== normalizeNativeCommandName(nativeCommandName)) throw new Error(\"Native command tool name is non-canonical: \" + nativeCommandName);",
+    ...(escalationRequested ? [
+      "const nativeCommandEntry = ALL_TOOLS.find(tool => tool?.name === nativeCommandName);",
+      "const nativeCommandSchema = nativeCommandEntry?.description;",
+      "const sandboxPermissionsSchema = /sandbox_permissions\\?\\s*:\\s*(?:\\\"use_default\\\"\\s*\\|\\s*)?\\\"require_escalated\\\"(?:\\s*\\|\\s*\\\"use_default\\\")?\\s*;/.test(nativeCommandSchema ?? \"\");",
+      "const justificationSchema = /justification\\?\\s*:\\s*string\\s*;/.test(nativeCommandSchema ?? \"\");",
+      "if (!sandboxPermissionsSchema || !justificationSchema) throw new Error(\"Native exec_command escalation ABI is unavailable\");",
+    ] : []),
     "const nativeCommand = tools[nativeCommandName];",
     "if (typeof nativeCommand !== \"function\") throw new Error(\"Native command tool \" + nativeCommandName + \" is listed but unavailable\");",
     `const nativeCommandInput = nativeCommandName === ${JSON.stringify(execCommandName)} ? ${JSON.stringify(execCommandArguments)} : ${JSON.stringify(shellCommandArguments)};`,
     "const result = await nativeCommand(nativeCommandInput);",
-  ]);
+    `text({ protocol: ${JSON.stringify(GATEWAY_COMMAND_RESULT_PROTOCOL)}, result });`,
+  ].join("\n");
 }
 
 export async function runChatGptMcpServer(options: { brokerSocketPath: string }): Promise<void> {
   const server = new McpServer({ name: "codex-native", version: "4.0.0" });
+  type ActiveExecOperation = {
+    operationKey: string;
+    requestKey: string;
+    promise: Promise<McpExecResult>;
+    sessionId?: number;
+    continuationToken?: string;
+    bindingId?: string;
+    continuation?: { requestKey: string; promise: Promise<McpExecResult> };
+    published: boolean;
+  };
+  const activeExecOperations = new Map<string, ActiveExecOperation>();
+  const terminalizedExecRequests = new Set<string>();
+  const commandOperationKey = brokerInvocationKey("codex_exec_global_operation", {
+    brokerSocketPath: options.brokerSocketPath,
+  });
 
   const claimTurn = async (
     toolName: string,
     turnToken: string,
-    extra: Parameters<typeof requestScopeSummary>[0],
+    extra: Parameters<typeof requestScopeSummary>[0] & { signal: AbortSignal },
   ): Promise<ClaimedTurn> => {
     console.error(`[chatgpt-web-mcp] ${toolName} scope=${requestScopeSummary(extra)}`);
-    return await callTurnBroker<ClaimedTurn>(options.brokerSocketPath, { method: "claim", token: turnToken });
+    return await callTurnBroker<ClaimedTurn>(
+      options.brokerSocketPath,
+      { method: "claim", token: turnToken },
+      undefined,
+      extra.signal,
+    );
+  };
+
+  const invokeBroker = (
+    bindingId: string,
+    bound: ChatGptTurnEnvironment & { expiresAt?: number },
+    tool: CodexTool,
+    payload: { arguments?: Record<string, unknown>; input?: string },
+    invocationKey: string,
+    timeout: number | null = invocationTimeout(bound),
+    signal?: AbortSignal,
+    operationIdentity?: BrokerOperationIdentity,
+    continuationToken?: string,
+  ) => callTurnBroker<BrokerToolResult>(options.brokerSocketPath, {
+      method: "invoke",
+      bindingId,
+      invocationKey,
+      wireName: wireName(tool),
+      freeform: tool.freeform === true,
+      ...operationIdentity,
+      ...(continuationToken ? { continuationToken } : {}),
+      ...(tool.freeform ? { input: payload.input ?? "" } : { arguments: payload.arguments ?? {} }),
+    }, timeout, signal);
+
+  const brokerContinuationToken = async (
+    method: "continuation" | "advance_continuation",
+    bindingId: string,
+    operationIdentity: BrokerOperationIdentity,
+    currentToken?: string,
+    invocationKey?: string,
+  ): Promise<string> => {
+    let lastError: unknown;
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      try {
+        const response = await callTurnBroker<{ continuationToken: string }>(options.brokerSocketPath, {
+          method,
+          bindingId,
+          ...operationIdentity,
+          ...(currentToken ? { continuationToken: currentToken } : {}),
+          ...(invocationKey ? { invocationKey } : {}),
+        });
+        if (!/^[A-Za-z0-9_-]{20,256}$/.test(response.continuationToken)) {
+          throw new Error("Codex command broker returned an invalid continuation token");
+        }
+        return response.continuationToken;
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    throw lastError;
   };
 
   const invoke = async (
@@ -209,15 +578,88 @@ export async function runChatGptMcpServer(options: { brokerSocketPath: string })
     bound: ChatGptTurnEnvironment & { expiresAt?: number },
     tool: CodexTool,
     payload: { arguments?: Record<string, unknown>; input?: string },
-  ) => {
-    const response = await callTurnBroker<BrokerToolResult>(options.brokerSocketPath, {
-      method: "invoke",
-      bindingId,
-      wireName: wireName(tool),
-      freeform: tool.freeform === true,
-      ...(tool.freeform ? { input: payload.input ?? "" } : { arguments: payload.arguments ?? {} }),
-    }, invocationTimeout(bound));
-    return asMcpResult(response);
+    invocationKey: string,
+    signal?: AbortSignal,
+  ) => asMcpResult(await invokeBroker(bindingId, bound, tool, payload, invocationKey, invocationTimeout(bound), signal));
+
+  const terminalizeExecOperation = async (
+    bindingId: string,
+    operationIdentity: BrokerOperationIdentity,
+  ): Promise<void> => {
+    let lastError: unknown;
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      try {
+        const terminalized = await callTurnBroker<{ terminalized: boolean; pending: boolean }>(
+          options.brokerSocketPath,
+          { method: "terminalize", bindingId, ...operationIdentity },
+        );
+        if (!terminalized.terminalized || terminalized.pending) {
+          throw new Error("Codex command operation could not be safely terminalized");
+        }
+        return;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        lastError = error;
+      }
+    }
+    throw lastError;
+  };
+
+  const execOperationStatus = (
+    bindingId: string,
+    operationIdentity: BrokerOperationIdentity,
+  ) => callTurnBroker<{ terminalized: boolean; active: boolean }>(options.brokerSocketPath, {
+    method: "operation_status",
+    bindingId,
+    ...operationIdentity,
+  });
+
+  const reconcileActiveExecOperation = async (
+    active: ActiveExecOperation,
+  ): Promise<"active" | "terminalized" | "unknown"> => {
+    if (!active.bindingId) return "active";
+    const operationIdentity = {
+      operationKey: active.operationKey,
+      operationRequestKey: active.requestKey,
+    };
+    let status: { terminalized: boolean; active: boolean };
+    try {
+      status = await execOperationStatus(active.bindingId, operationIdentity);
+    } catch {
+      return "unknown";
+    }
+    if (status.terminalized) {
+      terminalizedExecRequests.add(active.requestKey);
+      if (activeExecOperations.get(active.operationKey) === active) {
+        activeExecOperations.delete(active.operationKey);
+      }
+      return "terminalized";
+    }
+    if (!status.active) return "unknown";
+    if (active.sessionId !== undefined && active.continuationToken) {
+      try {
+        active.continuationToken = await brokerContinuationToken(
+          "continuation",
+          active.bindingId,
+          operationIdentity,
+        );
+      } catch {
+        try {
+          status = await execOperationStatus(active.bindingId, operationIdentity);
+        } catch {
+          return "unknown";
+        }
+        if (status.terminalized) {
+          terminalizedExecRequests.add(active.requestKey);
+          if (activeExecOperations.get(active.operationKey) === active) {
+            activeExecOperations.delete(active.operationKey);
+          }
+          return "terminalized";
+        }
+        return "unknown";
+      }
+    }
+    return "active";
   };
 
   const invokeNestedNative = (
@@ -226,6 +668,8 @@ export async function runChatGptMcpServer(options: { brokerSocketPath: string })
     nestedToolName: string,
     freeform: boolean,
     payload: { arguments?: Record<string, unknown>; input?: string },
+    invocationKey: string,
+    signal?: AbortSignal,
   ) => {
     const gateway = execGateway(bound);
     if (!gateway) {
@@ -233,7 +677,114 @@ export async function runChatGptMcpServer(options: { brokerSocketPath: string })
     }
     return invoke(bindingId, bound, gateway, {
       input: execGatewayProgram(nestedToolName, freeform, payload),
-    });
+    }, invocationKey, signal);
+  };
+
+  const awaitGatewayExec = async (
+    bindingId: string,
+    bound: ChatGptTurnEnvironment & { expiresAt?: number },
+    initial: BrokerToolResult,
+    originalInvocationKey: string,
+    operationIdentity: BrokerOperationIdentity,
+    signal?: AbortSignal,
+  ): Promise<McpExecOutcome> => {
+    const initialState = outerGatewayExecResultState(initial);
+    if (initialState.kind === "success") {
+      return { response: asMcpResult(initial), terminalEvidence: true };
+    }
+    if (initialState.kind === "denial" || initialState.kind === "failure" || initialState.kind === "cancellation") {
+      return { response: asMcpError(initial), terminalEvidence: true };
+    }
+    if (initialState.kind === "session") {
+      return {
+        response: commandLifecycleError("The outer exec gateway returned a live native session that cannot be continued safely"),
+        terminalEvidence: false,
+      };
+    }
+    if (initialState.kind !== "pending") {
+      return {
+        response: commandLifecycleError(
+          `The initial outer exec returned an unknown command state. ${UNRESOLVED_UNKNOWN_OUTCOME}`,
+        ),
+        terminalEvidence: false,
+      };
+    }
+
+    const waitTool = exactTool(bound, "wait");
+    if (!waitTool || waitTool.freeform) {
+      return {
+        response: commandLifecycleError(`Codex command is pending, but the outer wait tool is unavailable. ${UNRESOLVED_UNKNOWN_OUTCOME}`),
+        terminalEvidence: false,
+      };
+    }
+    if (signal?.aborted) {
+      return {
+        response: commandLifecycleError(`Waiting for the pending Codex command was aborted. ${UNRESOLVED_UNKNOWN_OUTCOME}`),
+        terminalEvidence: false,
+      };
+    }
+
+    let waited: BrokerToolResult;
+    try {
+      waited = await invokeBroker(
+        bindingId,
+        bound,
+        waitTool,
+        { arguments: { cell_id: initialState.cellId } },
+        brokerInvocationKey("codex_exec_wait", { originalInvocationKey, cellId: initialState.cellId }),
+        null,
+        signal,
+        operationIdentity,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        response: commandLifecycleError(`${
+          signal?.aborted || (error instanceof DOMException && error.name === "AbortError")
+            ? "Waiting for the pending Codex command was aborted"
+            : `The outer wait tool failed before returning a terminal result: ${message}`
+        }. ${UNRESOLVED_UNKNOWN_OUTCOME}`),
+        terminalEvidence: false,
+      };
+    }
+
+    const waitedState = outerGatewayExecResultState(waited);
+    if (waitedState.kind === "pending") {
+      if (waitedState.cellId !== initialState.cellId) {
+        return {
+          response: commandLifecycleError(`The outer wait tool returned a different pending command handle. ${UNRESOLVED_UNKNOWN_OUTCOME}`),
+          terminalEvidence: false,
+        };
+      }
+      return {
+        response: commandLifecycleError(`The outer wait tool did not return a terminal command state. ${UNRESOLVED_UNKNOWN_OUTCOME}`),
+        terminalEvidence: false,
+      };
+    }
+    if ("cellId" in waitedState && waitedState.cellId && waitedState.cellId !== initialState.cellId) {
+      return {
+        response: commandLifecycleError(`The outer wait tool returned a different command handle. ${UNRESOLVED_UNKNOWN_OUTCOME}`),
+        terminalEvidence: false,
+      };
+    }
+    if (waitedState.kind === "success") {
+      return { response: asMcpResult(waited), terminalEvidence: true };
+    }
+    if (waitedState.kind === "denial" || waitedState.kind === "failure" || waitedState.kind === "cancellation") {
+      return { response: asMcpError(waited), terminalEvidence: true };
+    }
+    if (waitedState.kind === "session") {
+      return {
+        response: commandLifecycleError("The outer wait tool returned a live native session that cannot be continued safely"),
+        terminalEvidence: false,
+      };
+    }
+    return {
+      response: commandLifecycleError(
+        `The outer wait tool returned an unknown command state. ${UNRESOLVED_UNKNOWN_OUTCOME}`,
+      ),
+      terminalEvidence: false,
+    };
   };
 
   server.registerTool(
@@ -248,37 +799,203 @@ export async function runChatGptMcpServer(options: { brokerSocketPath: string })
         yield_time_ms: z.number().int().min(250).max(30_000).optional(),
         max_output_tokens: z.number().int().min(1).max(1_000_000).optional(),
         tty: z.boolean().optional(),
+        sandbox_permissions: escalationSandboxPermissionsSchema.optional(),
+        justification: escalationJustificationSchema.optional(),
       },
       annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
     },
-    async ({ turn_token, cmd, workdir, yield_time_ms, max_output_tokens, tty }, extra) => {
-      const claimed = await claimTurn("codex_exec", turn_token, extra);
-      const bound = claimed.environment;
+    async ({ turn_token, cmd, workdir, yield_time_ms, max_output_tokens, tty, sandbox_permissions, justification }, extra) => observeCommandInvocation("codex_exec", extra, async () => {
+      const escalationRequested = sandbox_permissions === "require_escalated";
+      if (escalationRequested && (!justification || justification.trim().length === 0)) {
+        throw new Error("codex_exec require_escalated requires a non-empty justification");
+      }
+      if (!escalationRequested && justification !== undefined) {
+        throw new Error("codex_exec justification is only valid with sandbox_permissions=require_escalated");
+      }
       const execCommandArguments = {
         cmd,
         ...(workdir ? { workdir } : {}),
         ...(yield_time_ms !== undefined ? { yield_time_ms } : {}),
         ...(max_output_tokens !== undefined ? { max_output_tokens } : {}),
         ...(tty !== undefined ? { tty } : {}),
+        ...(escalationRequested ? { sandbox_permissions, justification } : {}),
       };
       const shellCommandArguments = {
         command: cmd,
         ...(workdir ? { workdir } : {}),
         ...(yield_time_ms !== undefined ? { timeout_ms: yield_time_ms } : {}),
       };
-      const tool = exactTool(bound, "exec_command") ?? exactTool(bound, "shell_command");
-      if (tool) {
-        const args = tool.name === "exec_command" ? execCommandArguments : shellCommandArguments;
-        return invoke(claimed.bindingId, bound, tool, { arguments: args });
-      }
-      const gateway = execGateway(bound);
-      if (!gateway) {
-        throw new Error("This Codex turn did not advertise a native command tool or the native exec gateway");
-      }
-      return invoke(claimed.bindingId, bound, gateway, {
-        input: execCommandGatewayProgram(execCommandArguments, shellCommandArguments),
+      const operationKey = commandOperationKey;
+      const requestKey = brokerInvocationKey("codex_exec_request", {
+        turnToken: turn_token,
+        arguments: execCommandArguments,
       });
-    },
+      if (terminalizedExecRequests.has(requestKey)) {
+        return commandLifecycleError("This codex_exec request has already been terminalized and cannot be retried");
+      }
+      let active = activeExecOperations.get(operationKey);
+      while (active) {
+        if (active.requestKey === requestKey) {
+          const joinedBeforePublication = !active.published;
+          const response = await active.promise;
+          if (joinedBeforePublication) return response;
+          const reconciliation = await reconcileActiveExecOperation(active);
+          if (reconciliation === "terminalized") {
+            return commandLifecycleError("This codex_exec request has already been terminalized and cannot be retried");
+          }
+          if (reconciliation === "unknown") {
+            return commandLifecycleError(
+              `The active native command could not be reconciled with the broker. ${UNRESOLVED_UNKNOWN_OUTCOME}`,
+            );
+          }
+          return active.continuationToken
+            ? refreshContinuationToken(response, active.continuationToken)
+            : response;
+        }
+        if (!active.published) {
+          return commandLifecycleError("A codex_exec operation is already active under a different request identity");
+        }
+        const reconciliation = await reconcileActiveExecOperation(active);
+        if (reconciliation === "terminalized") {
+          const replacement = activeExecOperations.get(operationKey);
+          if (replacement && replacement !== active) {
+            active = replacement;
+            continue;
+          }
+          break;
+        } else if (reconciliation === "unknown") {
+          return commandLifecycleError(
+            `The active native command could not be reconciled with the broker. ${UNRESOLVED_UNKNOWN_OUTCOME}`,
+          );
+        } else {
+          return commandLifecycleError("A codex_exec operation is already active under a different request identity");
+        }
+      }
+
+      let dispatchAttempted = false;
+      let activeEntry!: ActiveExecOperation;
+      const operation = (async (): Promise<McpExecOutcome> => {
+        const claimed = await claimTurn("codex_exec", turn_token, extra);
+        activeEntry.bindingId = claimed.bindingId;
+        const bound = claimed.environment;
+        const tool = directCommandTool(bound);
+        const operationIdentity = { operationKey, operationRequestKey: requestKey };
+        // A stable turn+argument identity makes transport loss and MCP restarts replay the broker's
+        // original promise/result instead of enqueueing the command a second time.
+        const originalInvocationKey = brokerInvocationKey("codex_exec", operationIdentity);
+        if (tool) {
+          if (escalationRequested && !directExecSupportsEscalation(tool)) {
+            throw new Error("The advertised native command tool does not expose the formal exec_command escalation ABI");
+          }
+          const args = tool.name === "exec_command" ? execCommandArguments : shellCommandArguments;
+          dispatchAttempted = true;
+          const direct = await invokeBroker(
+            claimed.bindingId,
+            bound,
+            tool,
+            { arguments: args },
+            originalInvocationKey,
+            invocationTimeout(bound),
+            undefined,
+            operationIdentity,
+          );
+          const directState = directCommandResultState(direct);
+          if (directState.kind === "session") {
+            const issuedToken = await brokerContinuationToken(
+              "continuation",
+              claimed.bindingId,
+              operationIdentity,
+            );
+            return {
+              response: withContinuationToken(direct, issuedToken),
+              terminalEvidence: false,
+              sessionId: directState.sessionId,
+              continuationToken: issuedToken,
+            };
+          }
+          if (directState.kind === "success") {
+            return { response: asMcpResult(direct), terminalEvidence: true };
+          }
+          if (directState.kind === "denial" || directState.kind === "failure" || directState.kind === "cancellation") {
+            return { response: asMcpError(direct), terminalEvidence: true };
+          }
+          return {
+            response: commandLifecycleError(`The native exec returned an unknown command state. ${UNRESOLVED_UNKNOWN_OUTCOME}`),
+            terminalEvidence: false,
+          };
+        }
+        const gateway = execGateway(bound);
+        if (!gateway) {
+          throw new Error("This Codex turn did not advertise a native command tool or the native exec gateway");
+        }
+        dispatchAttempted = true;
+        const gatewayResult = await invokeBroker(claimed.bindingId, bound, gateway, {
+          input: execCommandGatewayProgram(execCommandArguments, shellCommandArguments, escalationRequested),
+        }, originalInvocationKey, invocationTimeout(bound), undefined, operationIdentity);
+        const outcome = await awaitGatewayExec(
+          claimed.bindingId,
+          bound,
+          gatewayResult,
+          originalInvocationKey,
+          operationIdentity,
+          undefined,
+        );
+        return outcome;
+      })();
+      const publishedResponse = (async (): Promise<McpExecResult> => {
+        try {
+          const outcome = await operation;
+          if (outcome.sessionId !== undefined && outcome.continuationToken) {
+            activeEntry.sessionId = outcome.sessionId;
+            activeEntry.continuationToken = outcome.continuationToken;
+          } else if (outcome.terminalEvidence) {
+            await terminalizeExecOperation(activeEntry.bindingId!, { operationKey, operationRequestKey: requestKey });
+            terminalizedExecRequests.add(requestKey);
+            if (activeExecOperations.get(operationKey) === activeEntry) {
+              activeExecOperations.delete(operationKey);
+            }
+          }
+          return outcome.response;
+        } catch (error) {
+          if (dispatchAttempted) {
+            if (activeEntry.bindingId) {
+              try {
+                const status = await execOperationStatus(activeEntry.bindingId, {
+                  operationKey,
+                  operationRequestKey: requestKey,
+                });
+                if (status.terminalized) {
+                  terminalizedExecRequests.add(requestKey);
+                  if (activeExecOperations.get(operationKey) === activeEntry) {
+                    activeExecOperations.delete(operationKey);
+                  }
+                  return commandLifecycleError("This codex_exec request has already been terminalized and cannot be retried");
+                }
+              } catch {
+                // Without a trusted terminal receipt, preserve UNKNOWN quarantine below.
+              }
+            }
+            return commandLifecycleError(
+              `The native command transport ended without terminal evidence. ${UNRESOLVED_UNKNOWN_OUTCOME}`,
+            );
+          }
+          if (activeExecOperations.get(operationKey) === activeEntry) {
+            activeExecOperations.delete(operationKey);
+          }
+          throw error;
+        } finally {
+          activeEntry.published = true;
+        }
+      })();
+      activeEntry = {
+        operationKey,
+        requestKey,
+        promise: publishedResponse,
+        published: false,
+      };
+      activeExecOperations.set(operationKey, activeEntry);
+      return await publishedResponse;
+    }),
   );
 
   server.registerTool(
@@ -289,26 +1006,98 @@ export async function runChatGptMcpServer(options: { brokerSocketPath: string })
       inputSchema: {
         turn_token: turnTokenSchema,
         session_id: z.number().int().nonnegative(),
+        continuation_token: turnTokenSchema,
         chars: z.string().max(1_000_000).optional(),
         yield_time_ms: z.number().int().min(250).max(300_000).optional(),
         max_output_tokens: z.number().int().min(1).max(1_000_000).optional(),
       },
       annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
     },
-    async ({ turn_token, session_id, chars, yield_time_ms, max_output_tokens }, extra) => {
-      const claimed = await claimTurn("codex_write_stdin", turn_token, extra);
-      const bound = claimed.environment;
-      const tool = exactTool(bound, "write_stdin");
+    async ({ turn_token, session_id, continuation_token, chars, yield_time_ms, max_output_tokens }, extra) => observeCommandInvocation("codex_write_stdin", extra, async () => {
+      const operationKey = commandOperationKey;
+      const active = activeExecOperations.get(operationKey);
+      if (!active || active.sessionId !== session_id) {
+        return commandLifecycleError("codex_write_stdin does not match the active codex_exec session");
+      }
+      if (!active.continuationToken || active.continuationToken !== continuation_token) {
+        return commandLifecycleError("codex_write_stdin continuation token is invalid or no longer current");
+      }
       const payload = { arguments: {
         session_id,
         ...(chars !== undefined ? { chars } : {}),
         ...(yield_time_ms !== undefined ? { yield_time_ms } : {}),
         ...(max_output_tokens !== undefined ? { max_output_tokens } : {}),
       } };
-      return tool
-        ? invoke(claimed.bindingId, bound, tool, payload)
-        : invokeNestedNative(claimed.bindingId, bound, "write_stdin", false, payload);
-    },
+      const requestKey = brokerInvocationKey("codex_write_stdin_request", {
+        operationRequestKey: active.requestKey,
+        continuationToken: continuation_token,
+        arguments: payload.arguments,
+      });
+      if (active.continuation) {
+        if (active.continuation.requestKey === requestKey) return await active.continuation.promise;
+        return commandLifecycleError("A codex_write_stdin operation is already active under a different request identity");
+      }
+      let continuationResolved = false;
+      const continuation = (async (): Promise<McpExecResult> => {
+        const claimed = await claimTurn("codex_write_stdin", turn_token, extra);
+        const bound = claimed.environment;
+        const tool = exactTool(bound, "write_stdin");
+        const operationIdentity = { operationKey, operationRequestKey: active.requestKey };
+        if (!tool) {
+          return commandLifecycleError("The active codex_exec session cannot be continued without the native write_stdin tool");
+        }
+        const invocationKey = brokerInvocationKey("codex_write_stdin", {
+          operationRequestKey: active.requestKey,
+          continuationToken: continuation_token,
+        });
+        const continued = await invokeBroker(
+          claimed.bindingId,
+          bound,
+          tool,
+          payload,
+          invocationKey,
+          invocationTimeout(bound),
+          undefined,
+          operationIdentity,
+          continuation_token,
+        );
+        const continuedState = directCommandResultState(continued);
+        if (continuedState.kind === "session" && continuedState.sessionId === session_id) {
+          const nextToken = await brokerContinuationToken(
+            "advance_continuation",
+            claimed.bindingId,
+            operationIdentity,
+            continuation_token,
+            invocationKey,
+          );
+          active.continuationToken = nextToken;
+          continuationResolved = true;
+          return withContinuationToken(continued, nextToken);
+        }
+        const terminal = continuedState.kind === "success"
+          || continuedState.kind === "denial"
+          || continuedState.kind === "failure"
+          || continuedState.kind === "cancellation";
+        const response = continuedState.kind === "success"
+          ? asMcpResult(continued)
+          : continuedState.kind === "denial" || continuedState.kind === "failure" || continuedState.kind === "cancellation"
+            ? asMcpError(continued)
+            : commandLifecycleError(`The native write_stdin returned an unknown command state. ${UNRESOLVED_UNKNOWN_OUTCOME}`);
+        if (terminal) {
+          await terminalizeExecOperation(claimed.bindingId, operationIdentity);
+          terminalizedExecRequests.add(active.requestKey);
+          if (activeExecOperations.get(operationKey) === active) activeExecOperations.delete(operationKey);
+          continuationResolved = true;
+        }
+        return response;
+      })();
+      active.continuation = { requestKey, promise: continuation };
+      try {
+        return await continuation;
+      } finally {
+        if (continuationResolved && active.continuation?.promise === continuation) delete active.continuation;
+      }
+    }),
   );
 
   server.registerTool(
@@ -323,10 +1112,14 @@ export async function runChatGptMcpServer(options: { brokerSocketPath: string })
       const claimed = await claimTurn("codex_apply_patch", turn_token, extra);
       const bound = claimed.environment;
       const tool = exactTool(bound, "apply_patch");
-      if (!tool) return invokeNestedNative(claimed.bindingId, bound, "apply_patch", true, { input: patch });
+      const invocationKey = brokerInvocationKey("codex_apply_patch", {
+        requestId: String(extra.requestId),
+        sessionId: extra.sessionId ?? null,
+      });
+      if (!tool) return invokeNestedNative(claimed.bindingId, bound, "apply_patch", true, { input: patch }, invocationKey, extra.signal);
       return tool.freeform
-        ? invoke(claimed.bindingId, bound, tool, { input: patch })
-        : invoke(claimed.bindingId, bound, tool, { arguments: { input: patch } });
+        ? invoke(claimed.bindingId, bound, tool, { input: patch }, invocationKey, extra.signal)
+        : invoke(claimed.bindingId, bound, tool, { arguments: { input: patch } }, invocationKey, extra.signal);
     },
   );
 
@@ -347,9 +1140,13 @@ export async function runChatGptMcpServer(options: { brokerSocketPath: string })
       const bound = claimed.environment;
       const tool = exactTool(bound, "view_image");
       const payload = { arguments: { path, ...(detail ? { detail } : {}) } };
+      const invocationKey = brokerInvocationKey("codex_view_image", {
+        requestId: String(extra.requestId),
+        sessionId: extra.sessionId ?? null,
+      });
       return tool
-        ? invoke(claimed.bindingId, bound, tool, payload)
-        : invokeNestedNative(claimed.bindingId, bound, "view_image", false, payload);
+        ? invoke(claimed.bindingId, bound, tool, payload, invocationKey, extra.signal)
+        : invokeNestedNative(claimed.bindingId, bound, "view_image", false, payload, invocationKey, extra.signal);
     },
   );
 
@@ -410,15 +1207,22 @@ export async function runChatGptMcpServer(options: { brokerSocketPath: string })
       const claimed = await claimTurn("codex_tool_call", turn_token, extra);
       const bound = claimed.environment;
       const tool = namedTool(bound, wire_name);
+      if (isDedicatedCommandTool(tool)) {
+        throw new Error(`Codex command tool ${wire_name} is reserved for codex_exec and codex_write_stdin`);
+      }
+      const invocationKey = brokerInvocationKey("codex_tool_call", {
+        requestId: String(extra.requestId),
+        sessionId: extra.sessionId ?? null,
+      });
       if (tool.freeform) {
         if (input === undefined) throw new Error(`Freeform Codex tool ${wire_name} requires input`);
         if (args && Object.keys(args).length > 0) throw new Error(`Freeform Codex tool ${wire_name} does not accept arguments`);
-        return invoke(claimed.bindingId, bound, tool, { input });
+        return invoke(claimed.bindingId, bound, tool, { input }, invocationKey, extra.signal);
       }
       if (input !== undefined) throw new Error(`Function Codex tool ${wire_name} does not accept freeform input`);
       const invocationArguments = args ?? {};
       assertBrowserToolArguments(tool, invocationArguments);
-      return invoke(claimed.bindingId, bound, tool, { arguments: invocationArguments });
+      return invoke(claimed.bindingId, bound, tool, { arguments: invocationArguments }, invocationKey, extra.signal);
     },
   );
 

--- a/src/adapters/chatgpt-web/prompt.ts
+++ b/src/adapters/chatgpt-web/prompt.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import type { CodexAssistantContentPart, CodexContentPart, CodexMessage, CodexParsedRequest } from "../../types";
+import { namespacedToolName, type CodexAssistantContentPart, type CodexContentPart, type CodexMessage, type CodexParsedRequest } from "../../types";
 import { isOnePixelPngDataUrl, isReadableCompactionSummaryText } from "../../responses/compaction";
 import { CHATGPT_WEB_LUNA_MODEL_ID, resolveChatGptWebModelMode, type ChatGptWebCapabilities } from "./model";
 import {
@@ -210,7 +210,7 @@ function assistantContent(content: CodexAssistantContentPart[]): unknown[] {
   return content.map(part => {
     if (part.type === "text") return { type: "text", text: part.text };
     if (part.type === "thinking") return { type: "thinking_summary", text: part.thinking };
-    return { type: "tool_call", id: part.id, name: part.name, arguments: part.arguments };
+    return { type: "tool_call", id: part.id, name: namespacedToolName(part.namespace, part.name), arguments: part.arguments };
   });
 }
 
@@ -265,7 +265,7 @@ function messageEnvelope(
     return {
       role: "tool_result",
       tool_call_id: message.toolCallId,
-      tool_name: message.toolName,
+      tool_name: namespacedToolName(message.toolNamespace, message.toolName),
       is_error: message.isError,
       content: inputContent(message.content, images, budget),
     };

--- a/src/adapters/chatgpt-web/turn-broker.ts
+++ b/src/adapters/chatgpt-web/turn-broker.ts
@@ -1,7 +1,8 @@
 import { createHash, randomBytes } from "node:crypto";
-import { chmodSync, existsSync, lstatSync, mkdirSync, unlinkSync } from "node:fs";
+import { chmodSync, existsSync, lstatSync, mkdirSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { createConnection, createServer, type Server, type Socket } from "node:net";
-import { dirname, isAbsolute, relative, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { isWindowsPipeEndpoint } from "../../config";
 import type { ChatGptTurnEnvironment } from "./environment";
 
@@ -26,8 +27,19 @@ export interface BrokerToolResult {
 
 interface PendingInvocation {
   request: BrokerToolRequest;
+  invocationKey: string;
+  fingerprint: string;
+  promise: Promise<BrokerToolResult>;
   resolve: (result: BrokerToolResult) => void;
   reject: (error: Error) => void;
+  operationKey?: string;
+  operationRequestKey?: string;
+  continuationToken?: string;
+}
+
+interface OperationContinuation {
+  currentToken: string;
+  uses: Map<string, { invocationKey: string; nextToken?: string }>;
 }
 
 interface ToolWaiter {
@@ -41,9 +53,17 @@ interface TurnChannel {
   traceId: string;
   externalOwner: boolean;
   environment: PendingTurn;
+  retiring: boolean;
   bindingId?: string;
   queuedCallIds: string[];
   invocations: Map<string, PendingInvocation>;
+  invocationsByKey: Map<string, PendingInvocation>;
+  replayCacheChars: number;
+  replayCacheExhausted: boolean;
+  activeOperations: Map<string, string>;
+  operationContinuations: Map<string, OperationContinuation>;
+  terminalizedOperationRequests: Set<string>;
+  terminalizedOperationFingerprints: Map<string, Set<string>>;
   waiters: Set<ToolWaiter>;
   batchTimer?: ReturnType<typeof setTimeout>;
 }
@@ -55,6 +75,10 @@ interface BrokerRequest {
     | "resolve"
     | "release"
     | "invoke"
+    | "terminalize"
+    | "operation_status"
+    | "continuation"
+    | "advance_continuation"
     | "owner_status"
     | "owner_register"
     | "owner_update"
@@ -72,6 +96,10 @@ interface BrokerRequest {
   traceId?: string;
   callId?: string;
   toolResult?: BrokerToolResult;
+  invocationKey?: string;
+  operationKey?: string;
+  operationRequestKey?: string;
+  continuationToken?: string;
 }
 
 interface BrokerResponse {
@@ -82,7 +110,18 @@ interface BrokerResponse {
 
 const brokers = new Map<string, TurnBroker>();
 const MAX_BROKER_LINE_CHARS = 67_108_864;
+const MAX_REPLAY_CACHE_ENTRIES = 512;
+const MAX_REPLAY_CACHE_CHARS = 16_777_216;
+const MAX_REPLAY_RESULT_CHARS = 8_388_608;
 const MAX_RETIRED_TURN_HANDLES = 64;
+
+const REPLAY_CACHE_EXHAUSTED_RESULT: BrokerToolResult = {
+  content: [{
+    type: "text",
+    text: "UNRESOLVED_BROKER_RESULT_TOO_LARGE: the native result exceeded the bounded replay cache; redispatch is forbidden",
+  }],
+  isError: true,
+};
 
 export async function closeTurnBrokers(): Promise<void> {
   const active = [...brokers.values()];
@@ -105,6 +144,10 @@ function handleFingerprint(value: string): string {
 
 function errorOf(value: unknown): Error {
   return value instanceof Error ? value : new Error(String(value));
+}
+
+function opaqueLogId(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 12);
 }
 
 function retiredTurnLabel(traceId: string): string {
@@ -169,10 +212,24 @@ export class TurnBroker implements TurnBrokerOwner {
   private readonly retiredBindings = new Map<string, string>();
   private readonly retiredTokens = new Map<string, string>();
   private acceptingExternalOwners = true;
+  private protectedOperation?: {
+    token: string;
+    channel: TurnChannel;
+    operationKey: string;
+    operationRequestKey: string;
+    delivered: boolean;
+  };
+  private readonly commandQuarantinePath: string;
+  private orphanedCommandQuarantine: boolean;
   private server?: Server;
   private startPromise?: Promise<void>;
 
-  private constructor(readonly socketPath: string) {}
+  private constructor(readonly socketPath: string) {
+    this.commandQuarantinePath = isWindowsPipeEndpoint(socketPath)
+      ? join(tmpdir(), `codex-chatgpt-web-command-${opaqueLogId(socketPath)}.lock`)
+      : `${socketPath}.command-quarantine`;
+    this.orphanedCommandQuarantine = existsSync(this.commandQuarantinePath);
+  }
 
   /**
    * A ChatGPT turn outlives the request that started it, and its Codex Native calls arrive from a
@@ -206,8 +263,16 @@ export class TurnBroker implements TurnBrokerOwner {
         ...environment,
         ...(ttlMs !== undefined ? { expiresAt: Date.now() + ttlMs } : {}),
       },
+      retiring: false,
       queuedCallIds: [],
       invocations: new Map(),
+      invocationsByKey: new Map(),
+      replayCacheChars: 0,
+      replayCacheExhausted: false,
+      activeOperations: new Map(),
+      operationContinuations: new Map(),
+      terminalizedOperationRequests: new Set(),
+      terminalizedOperationFingerprints: new Map(),
       waiters: new Set(),
     };
     this.channels.set(token, channel);
@@ -256,16 +321,51 @@ export class TurnBroker implements TurnBrokerOwner {
     const channel = this.channels.get(token);
     if (!channel) throw new Error("turn token is invalid or expired");
     const invocation = channel.invocations.get(callId);
-    if (!invocation) throw new Error(`tool call is not pending: ${callId}`);
-    if (channel.queuedCallIds.includes(callId)) throw new Error(`tool call was completed before it was delivered: ${callId}`);
+    if (!invocation) throw new Error(`tool call is not pending: ${opaqueLogId(callId)}`);
+    if (channel.queuedCallIds.includes(callId)) {
+      throw new Error(`tool call was completed before it was delivered: ${opaqueLogId(callId)}`);
+    }
     channel.invocations.delete(callId);
-    console.info(`[chatgpt-web] broker trace=${channel.traceId} completed call=${callId.slice(0, 17)} pending=${channel.invocations.size}`);
-    invocation.resolve(result);
+    // Keep the resolved promise addressable by invocationKey until the turn is revoked. A retry
+    // after transport loss must observe the original terminal result, never enqueue the tool again.
+    let replayResult = result;
+    let resultChars = 0;
+    try {
+      resultChars = JSON.stringify(result).length;
+    } catch {
+      channel.replayCacheExhausted = true;
+      replayResult = REPLAY_CACHE_EXHAUSTED_RESULT;
+      resultChars = JSON.stringify(replayResult).length;
+    }
+    if (resultChars > MAX_REPLAY_RESULT_CHARS
+      || channel.replayCacheChars + resultChars > MAX_REPLAY_CACHE_CHARS) {
+      channel.replayCacheExhausted = true;
+      replayResult = REPLAY_CACHE_EXHAUSTED_RESULT;
+      resultChars = JSON.stringify(replayResult).length;
+    }
+    channel.replayCacheChars += resultChars;
+    console.info(`[chatgpt-web] broker trace=${channel.traceId} completed callHash=${opaqueLogId(callId)} pending=${channel.invocations.size}`);
+    invocation.resolve(replayResult);
   }
 
   revoke(token: string, reason = new Error("Codex turn binding was revoked")): void {
     const channel = this.channels.get(token);
     if (!channel) return;
+    const protectedOperation = this.protectedOperation;
+    if (protectedOperation?.channel === channel && protectedOperation.delivered) {
+      channel.retiring = true;
+      this.pending.delete(token);
+      return;
+    }
+    if (protectedOperation?.channel === channel) this.releaseCommandQuarantine();
+    this.retireChannel(token, channel, reason);
+  }
+
+  private retireChannel(
+    token: string,
+    channel: TurnChannel,
+    reason = new Error("Codex turn binding was revoked"),
+  ): void {
     this.channels.delete(token);
     this.pending.delete(token);
     if (channel.bindingId) {
@@ -309,6 +409,32 @@ export class TurnBroker implements TurnBrokerOwner {
       if (oldest.done) return;
       history.delete(oldest.value);
     }
+  }
+
+  private acquireCommandQuarantine(): void {
+    if (this.orphanedCommandQuarantine || existsSync(this.commandQuarantinePath)) {
+      this.orphanedCommandQuarantine = true;
+      throw new Error("an unresolved command quarantine is already active");
+    }
+    mkdirSync(dirname(this.commandQuarantinePath), { recursive: true, mode: 0o700 });
+    const temporaryPath = `${this.commandQuarantinePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
+    try {
+      writeFileSync(temporaryPath, "unresolved-command\n", { encoding: "utf8", mode: 0o600, flag: "wx" });
+      renameSync(temporaryPath, this.commandQuarantinePath);
+    } catch (error) {
+      try { unlinkSync(temporaryPath); } catch { /* best effort for an unpublished temporary file */ }
+      throw error;
+    }
+  }
+
+  private releaseCommandQuarantine(): void {
+    if (!existsSync(this.commandQuarantinePath)) {
+      this.orphanedCommandQuarantine = true;
+      throw new Error("command quarantine marker disappeared before terminal evidence was committed");
+    }
+    unlinkSync(this.commandQuarantinePath);
+    this.orphanedCommandQuarantine = false;
+    this.protectedOperation = undefined;
   }
 
   async close(): Promise<void> {
@@ -411,8 +537,10 @@ export class TurnBroker implements TurnBrokerOwner {
   private handleSocket(socket: Socket): void {
     let buffered = "";
     let handled = false;
+    const abort = new AbortController();
     socket.setEncoding("utf8");
     socket.on("error", () => {});
+    socket.once("close", () => abort.abort());
     socket.on("data", chunk => {
       if (handled) return;
       buffered += chunk;
@@ -434,7 +562,7 @@ export class TurnBroker implements TurnBrokerOwner {
         this.writeSocketResponse(socket, { id: request?.id ?? "unknown", error: errorOf(error).message });
         return;
       }
-      void Promise.resolve().then(() => this.dispatch(request!)).then(
+      void Promise.resolve().then(() => this.dispatch(request!, abort.signal)).then(
         result => this.writeSocketResponse(socket, { id: request!.id, result }),
         error => this.writeSocketResponse(socket, { id: request!.id, error: errorOf(error).message }),
       );
@@ -454,12 +582,12 @@ export class TurnBroker implements TurnBrokerOwner {
     if (!request || typeof request !== "object" || typeof request.id !== "string" || request.id.length === 0 || request.id.length > 256) {
       throw new Error("turn broker request id is invalid");
     }
-    if (!["claim", "resolve", "release", "invoke", "owner_status", "owner_register", "owner_update", "owner_next", "owner_complete", "owner_revoke"].includes(request.method)) {
+    if (!["claim", "resolve", "release", "invoke", "terminalize", "operation_status", "continuation", "advance_continuation", "owner_status", "owner_register", "owner_update", "owner_next", "owner_complete", "owner_revoke"].includes(request.method)) {
       throw new Error("turn broker method is invalid");
     }
   }
 
-  private dispatch(request: BrokerRequest): unknown | Promise<unknown> {
+  private dispatch(request: BrokerRequest, signal?: AbortSignal): unknown | Promise<unknown> {
     this.prune();
     if (request.method === "owner_status") {
       return { protocolVersion: 1, acceptingExternalOwners: this.acceptingExternalOwners };
@@ -478,7 +606,7 @@ export class TurnBroker implements TurnBrokerOwner {
     }
     if (request.method === "owner_next") {
       if (!request.token) throw new Error("turn owner token is required");
-      return this.nextToolBatch(request.token).then(requests => ({ requests }));
+      return this.nextToolBatch(request.token, signal).then(requests => ({ requests }));
     }
     if (request.method === "owner_complete") {
       if (!request.token) throw new Error("turn owner token is required");
@@ -529,7 +657,7 @@ export class TurnBroker implements TurnBrokerOwner {
     if (!binding) {
       const retiredTurn = this.retiredBindings.get(bindingId);
       console.error(
-        `[chatgpt-web] broker rejected ${request.method} (binding=${bindingId.slice(0, 17)},`
+        `[chatgpt-web] broker rejected ${request.method} (bindingHash=${opaqueLogId(bindingId)},`
         + ` retiredTurn=${retiredTurn ?? "unknown"})`,
       );
       throw new Error(retiredTurn !== undefined
@@ -541,9 +669,237 @@ export class TurnBroker implements TurnBrokerOwner {
       return { released: true };
     }
     if (request.method === "resolve") return { environment: binding.channel.environment };
-
-    const wireName = request.wireName?.trim();
-    if (!wireName) throw new Error("wire tool name is required");
+    if (request.method === "operation_status") {
+      const operationKey = request.operationKey;
+      const operationRequestKey = request.operationRequestKey;
+      this.validateOperationIdentity(operationKey, operationRequestKey);
+      if (!operationKey || !operationRequestKey) throw new Error("broker operation identity is incomplete");
+      const identityKey = this.operationIdentityKey(operationKey, operationRequestKey);
+      return {
+        terminalized: binding.channel.terminalizedOperationRequests.has(identityKey),
+        active: binding.channel.activeOperations.get(operationKey) === operationRequestKey,
+      };
+    }
+    if (this.orphanedCommandQuarantine) {
+      throw new Error("an unresolved command quarantine from an earlier broker process is active");
+    }
+    if (request.method === "continuation" || request.method === "advance_continuation") {
+      const operationKey = request.operationKey;
+      const operationRequestKey = request.operationRequestKey;
+      this.validateOperationIdentity(operationKey, operationRequestKey);
+      if (!operationKey || !operationRequestKey) throw new Error("broker operation identity is incomplete");
+      const identityKey = this.operationIdentityKey(operationKey, operationRequestKey);
+      const owner = binding.channel.activeOperations.get(operationKey);
+      const protectedOperation = this.protectedOperation;
+      if (owner !== operationRequestKey
+        || !protectedOperation
+        || protectedOperation.channel !== binding.channel
+        || protectedOperation.operationKey !== operationKey
+        || protectedOperation.operationRequestKey !== operationRequestKey) {
+        throw new Error("broker protected operation identity does not match the active command");
+      }
+      let continuation = binding.channel.operationContinuations.get(identityKey);
+      if (request.method === "continuation") {
+        if (!continuation) {
+          continuation = { currentToken: opaqueId("continuation"), uses: new Map() };
+          binding.channel.operationContinuations.set(identityKey, continuation);
+        }
+        return { continuationToken: continuation.currentToken };
+      }
+      const continuationToken = request.continuationToken;
+      const invocationKey = request.invocationKey;
+      if (!continuation
+        || !continuationToken
+        || !/^[A-Za-z0-9_-]{20,256}$/.test(continuationToken)
+        || !invocationKey
+        || !/^[A-Za-z0-9_-]{1,256}$/.test(invocationKey)) {
+        throw new Error("broker continuation identity is incomplete");
+      }
+      const use = continuation.uses.get(continuationToken);
+      if (!use || use.invocationKey !== invocationKey) {
+        throw new Error("broker continuation token does not identify the completed invocation");
+      }
+      if (use.nextToken) return { continuationToken: use.nextToken };
+      if (continuation.currentToken !== continuationToken) {
+        throw new Error("broker continuation token is no longer current");
+      }
+      const invocationStillPending = [...binding.channel.invocations.values()]
+        .some(invocation => invocation.invocationKey === invocationKey);
+      if (invocationStillPending) throw new Error("broker continuation invocation is still pending");
+      const nextToken = opaqueId("continuation");
+      use.nextToken = nextToken;
+      continuation.currentToken = nextToken;
+      return { continuationToken: nextToken };
+    }
+    if (request.method === "terminalize") {
+      const operationKey = request.operationKey;
+      const operationRequestKey = request.operationRequestKey;
+      this.validateOperationIdentity(operationKey, operationRequestKey);
+      if (!operationKey || !operationRequestKey) throw new Error("broker operation identity is incomplete");
+      const identityKey = this.operationIdentityKey(operationKey, operationRequestKey);
+      if (binding.channel.terminalizedOperationRequests.has(identityKey)) {
+        return { terminalized: true, pending: false };
+      }
+      const protectedOperation = this.protectedOperation;
+      if (!protectedOperation
+        || protectedOperation.channel !== binding.channel
+        || protectedOperation.operationKey !== operationKey
+        || protectedOperation.operationRequestKey !== operationRequestKey) {
+        throw new Error("broker protected operation identity does not match the active command");
+      }
+      const owner = binding.channel.activeOperations.get(operationKey);
+      if (owner !== operationRequestKey) {
+        throw new Error(owner === undefined
+          ? "broker operation is not active"
+          : "broker operation is already active under a different request identity");
+      }
+      const invocationStillPending = [...binding.channel.invocations.values()].some(invocation => (
+        invocation.operationKey === operationKey && invocation.operationRequestKey === operationRequestKey
+      ));
+      if (invocationStillPending) return { terminalized: false, pending: true };
+      const fingerprints = binding.channel.terminalizedOperationFingerprints.get(operationKey) ?? new Set<string>();
+      for (const invocation of binding.channel.invocationsByKey.values()) {
+        if (invocation.operationKey === operationKey && invocation.operationRequestKey === operationRequestKey) {
+          fingerprints.add(invocation.fingerprint);
+        }
+      }
+      binding.channel.terminalizedOperationFingerprints.set(operationKey, fingerprints);
+      binding.channel.activeOperations.delete(operationKey);
+      binding.channel.operationContinuations.delete(identityKey);
+      binding.channel.terminalizedOperationRequests.add(identityKey);
+      this.releaseCommandQuarantine();
+      if (binding.channel.retiring) this.retireChannel(binding.token, binding.channel);
+      return { terminalized: true, pending: false };
+    }
+    const wireName = request.wireName;
+    if (typeof wireName !== "string" || wireName.length === 0) {
+      throw new Error("wire tool name is required");
+    }
+    if (wireName.trim() !== wireName || /[\x00-\x1f\x7f]/.test(wireName)) {
+      throw new Error("wire tool name must be canonical");
+    }
+    const invocationKey = request.invocationKey ?? request.id;
+    if (!/^[A-Za-z0-9_-]{1,256}$/.test(invocationKey)) throw new Error("broker invocation key is invalid");
+    const fingerprint = createHash("sha256").update(JSON.stringify({
+      wireName,
+      freeform: request.freeform === true,
+      ...(request.freeform === true ? { input: request.input ?? "" } : { arguments: request.arguments ?? {} }),
+    })).digest("hex");
+    const operationKey = request.operationKey;
+    const operationRequestKey = request.operationRequestKey;
+    this.validateOperationIdentity(operationKey, operationRequestKey, true);
+    const continuationToken = request.continuationToken;
+    if (continuationToken !== undefined) {
+      if (!operationKey || !operationRequestKey || !/^[A-Za-z0-9_-]{20,256}$/.test(continuationToken)) {
+        throw new Error("broker continuation identity is invalid");
+      }
+    }
+    const protectedOperation = this.protectedOperation;
+    const matchesProtectedOperation = Boolean(
+      protectedOperation
+      && operationKey
+      && operationRequestKey
+      && protectedOperation.channel === binding.channel
+      && protectedOperation.operationKey === operationKey
+      && protectedOperation.operationRequestKey === operationRequestKey
+    );
+    if (protectedOperation && !matchesProtectedOperation) {
+      if (protectedOperation.channel === binding.channel
+        && protectedOperation.operationKey === operationKey) {
+        throw new Error("broker operation is already active under a different request identity");
+      }
+      throw new Error("a protected broker operation is already active");
+    }
+    if (binding.channel.retiring && !matchesProtectedOperation) {
+      throw new Error("Codex turn binding is retiring with an unresolved protected operation");
+    }
+    const replay = binding.channel.invocationsByKey.get(invocationKey);
+    if (replay) {
+      if (replay.fingerprint !== fingerprint) throw new Error("broker invocation key was reused with a different request");
+      if (replay.continuationToken !== continuationToken) {
+        throw new Error("broker invocation continuation identity changed during replay");
+      }
+      if (request.operationKey !== replay.operationKey || request.operationRequestKey !== replay.operationRequestKey) {
+        throw new Error("broker invocation operation identity changed during replay");
+      }
+      if (replay.operationKey && replay.operationRequestKey
+        && !binding.channel.terminalizedOperationRequests.has(
+          this.operationIdentityKey(replay.operationKey, replay.operationRequestKey),
+        )) {
+        const owner = binding.channel.activeOperations.get(replay.operationKey);
+        if (owner !== undefined && owner !== replay.operationRequestKey) {
+          throw new Error("broker operation is already active under a different request identity");
+        }
+        binding.channel.activeOperations.set(replay.operationKey, replay.operationRequestKey);
+      }
+      return replay.promise;
+    }
+    if (binding.channel.replayCacheExhausted
+      || binding.channel.invocationsByKey.size >= MAX_REPLAY_CACHE_ENTRIES) {
+      throw new Error("broker replay cache is exhausted; new native dispatch is forbidden");
+    }
+    if (operationKey && binding.channel.terminalizedOperationFingerprints.get(operationKey)?.has(fingerprint)) {
+      throw new Error("broker operation invocation has already been terminalized");
+    }
+    if (operationKey === undefined && binding.channel.activeOperations.size > 0) {
+      throw new Error("a protected broker operation is already active");
+    }
+    let continuation: OperationContinuation | undefined;
+    let continuationUseClaimed = false;
+    if (continuationToken && operationKey && operationRequestKey) {
+      continuation = binding.channel.operationContinuations.get(
+        this.operationIdentityKey(operationKey, operationRequestKey),
+      );
+      if (!continuation || continuation.currentToken !== continuationToken) {
+        throw new Error("broker continuation token is invalid or no longer current");
+      }
+      const priorUse = continuation.uses.get(continuationToken);
+      if (priorUse && priorUse.invocationKey !== invocationKey) {
+        throw new Error("broker continuation token was already used by another invocation");
+      }
+      if (priorUse) {
+        throw new Error("broker continuation invocation is unresolved and cannot be redispatched");
+      }
+    }
+    let claimedOperation = false;
+    let claimedProtectedOperation = false;
+    if (operationKey && operationRequestKey) {
+      if (binding.channel.terminalizedOperationRequests.has(
+        this.operationIdentityKey(operationKey, operationRequestKey),
+      )) {
+        throw new Error("broker operation request has already been terminalized");
+      }
+      const owner = binding.channel.activeOperations.get(operationKey);
+      if (owner !== undefined && owner !== operationRequestKey) {
+        throw new Error("broker operation is already active under a different request identity");
+      }
+      if (owner === undefined) {
+        binding.channel.activeOperations.set(operationKey, operationRequestKey);
+        claimedOperation = true;
+      }
+      if (!this.protectedOperation) {
+        this.acquireCommandQuarantine();
+        this.protectedOperation = {
+          token: binding.token,
+          channel: binding.channel,
+          operationKey,
+          operationRequestKey,
+          delivered: false,
+        };
+        claimedProtectedOperation = true;
+      }
+    }
+    const equivalentInFlight = [...binding.channel.invocations.values()]
+      .some(invocation => invocation.fingerprint === fingerprint);
+    if (equivalentInFlight) {
+      if (claimedOperation && operationKey) binding.channel.activeOperations.delete(operationKey);
+      if (claimedProtectedOperation) this.releaseCommandQuarantine();
+      throw new Error("an equivalent broker invocation is already executing under a different request identity");
+    }
+    if (continuation && continuationToken) {
+      continuation.uses.set(continuationToken, { invocationKey });
+      continuationUseClaimed = true;
+    }
     const callId = opaqueId("call");
     const toolRequest: BrokerToolRequest = {
       callId,
@@ -551,18 +907,74 @@ export class TurnBroker implements TurnBrokerOwner {
       freeform: request.freeform === true,
       ...(request.freeform === true ? { input: request.input ?? "" } : { arguments: request.arguments ?? {} }),
     };
-    return new Promise<BrokerToolResult>((resolveInvoke, rejectInvoke) => {
-      binding.channel.invocations.set(callId, { request: toolRequest, resolve: resolveInvoke, reject: rejectInvoke });
-      binding.channel.queuedCallIds.push(callId);
-      console.info(
-        `[chatgpt-web] broker trace=${binding.channel.traceId} queued call=${callId.slice(0, 17)} tool=${wireName} waiters=${binding.channel.waiters.size}`,
-      );
-      this.scheduleToolWaiters(binding.channel);
+    if (signal?.aborted) {
+      if (continuationUseClaimed && continuationToken) continuation?.uses.delete(continuationToken);
+      if (claimedOperation && operationKey) binding.channel.activeOperations.delete(operationKey);
+      if (claimedProtectedOperation) this.releaseCommandQuarantine();
+      throw new DOMException("broker invocation aborted", "AbortError");
+    }
+    let resolveInvoke!: (result: BrokerToolResult) => void;
+    let rejectInvoke!: (error: Error) => void;
+    const promise = new Promise<BrokerToolResult>((resolve, reject) => {
+      resolveInvoke = resolve;
+      rejectInvoke = reject;
     });
+    const invocation: PendingInvocation = {
+      request: toolRequest,
+      invocationKey,
+      fingerprint,
+      promise,
+      resolve: value => finish(() => resolveInvoke(value)),
+      reject: error => finish(() => rejectInvoke(error)),
+      ...(operationKey && operationRequestKey ? { operationKey, operationRequestKey } : {}),
+      ...(continuationToken ? { continuationToken } : {}),
+    };
+    const finish = (callback: () => void) => {
+      if (signal) signal.removeEventListener("abort", onAbort);
+      callback();
+    };
+    const onAbort = () => {
+      if (binding.channel.queuedCallIds.includes(callId)) {
+        binding.channel.invocations.delete(callId);
+        binding.channel.invocationsByKey.delete(invocationKey);
+        binding.channel.queuedCallIds = binding.channel.queuedCallIds.filter(id => id !== callId);
+        if (continuationUseClaimed && continuationToken) continuation?.uses.delete(continuationToken);
+        if (claimedOperation && operationKey
+          && binding.channel.activeOperations.get(operationKey) === operationRequestKey) {
+          binding.channel.activeOperations.delete(operationKey);
+        }
+        if (claimedProtectedOperation && this.protectedOperation?.delivered === false) {
+          this.releaseCommandQuarantine();
+        }
+        finish(() => rejectInvoke(new DOMException("broker invocation aborted", "AbortError")));
+        return;
+      }
+      // Delivery transfers execution ownership to the adapter. Keep the invocation until the
+      // adapter reports its terminal result so a disconnected caller cannot orphan an already
+      // executing command and make a later retry appear safe.
+      if (signal) signal.removeEventListener("abort", onAbort);
+    };
+    binding.channel.invocations.set(callId, invocation);
+    binding.channel.invocationsByKey.set(invocationKey, invocation);
+    if (signal) signal.addEventListener("abort", onAbort, { once: true });
+    binding.channel.queuedCallIds.push(callId);
+    console.info(
+      `[chatgpt-web] broker trace=${binding.channel.traceId} queued callHash=${opaqueLogId(callId)} tool=${wireName} waiters=${binding.channel.waiters.size}`,
+    );
+    this.scheduleToolWaiters(binding.channel);
+    return promise;
   }
 
   private takeQueued(channel: TurnChannel): BrokerToolRequest[] {
     const ids = channel.queuedCallIds.splice(0);
+    if (this.protectedOperation?.channel === channel) {
+      const deliveredProtectedCall = ids.some(id => {
+        const invocation = channel.invocations.get(id);
+        return invocation?.operationKey === this.protectedOperation?.operationKey
+          && invocation?.operationRequestKey === this.protectedOperation?.operationRequestKey;
+      });
+      if (deliveredProtectedCall) this.protectedOperation.delivered = true;
+    }
     return ids.map(id => channel.invocations.get(id)?.request).filter((request): request is BrokerToolRequest => Boolean(request));
   }
 
@@ -604,7 +1016,35 @@ export class TurnBroker implements TurnBrokerOwner {
     channel.waiters.clear();
     for (const invocation of channel.invocations.values()) invocation.reject(error);
     channel.invocations.clear();
+    channel.invocationsByKey.clear();
+    channel.replayCacheChars = 0;
+    channel.replayCacheExhausted = false;
+    channel.activeOperations.clear();
+    channel.operationContinuations.clear();
+    channel.terminalizedOperationRequests.clear();
+    channel.terminalizedOperationFingerprints.clear();
     channel.queuedCallIds = [];
+  }
+
+  private operationIdentityKey(operationKey: string, operationRequestKey: string): string {
+    return `${operationKey}\0${operationRequestKey}`;
+  }
+
+  private validateOperationIdentity(
+    operationKey: string | undefined,
+    operationRequestKey: string | undefined,
+    optional = false,
+  ): asserts operationKey is string {
+    if (optional && operationKey === undefined && operationRequestKey === undefined) return;
+    if (operationKey === undefined || operationRequestKey === undefined) {
+      throw new Error("broker operation identity is incomplete");
+    }
+    if (!/^[A-Za-z0-9_-]{1,256}$/.test(operationKey)) {
+      throw new Error("broker operation key is invalid");
+    }
+    if (!/^[A-Za-z0-9_-]{1,256}$/.test(operationRequestKey)) {
+      throw new Error("broker operation request key is invalid");
+    }
   }
 
   private prune(): void {
@@ -628,6 +1068,7 @@ export async function callTurnBroker<T>(
   timeoutMs: number | null = 5_000,
   signal?: AbortSignal,
 ): Promise<T> {
+  if (signal?.aborted) throw new DOMException("broker call aborted", "AbortError");
   const id = opaqueId("request");
   return new Promise<T>((resolveCall, rejectCall) => {
     const socket = createConnection(socketPath);

--- a/src/adapters/chatgpt-web/turn-execution.ts
+++ b/src/adapters/chatgpt-web/turn-execution.ts
@@ -230,7 +230,7 @@ export class ChatGptTurnSession {
   }
 
   isActive(): boolean {
-    return this.settledBrowserOutcome === undefined;
+    return this.settledBrowserOutcome === undefined || this.outstandingById.size > 0;
   }
 
   setOutstanding(requests: BrokerToolRequest[], reasoning: string[] = [], prelude: AdapterEvent[] = []): void {

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -342,6 +342,7 @@ export function bridgeToResponsesSSE(
               type: "custom_tool_call", id: currentToolCall.itemId,
               call_id: currentToolCall.callId, name: currentToolCall.name,
               input: freeformInput(currentToolCall.args), status: "completed",
+              ...(currentToolCall.namespace ? { namespace: currentToolCall.namespace } : {}),
             }
           : {
               type: "function_call", id: currentToolCall.itemId,
@@ -528,13 +529,13 @@ export function bridgeToResponsesSSE(
               const mapped = toolNsMap?.get(event.name);
               const realName = mapped?.name ?? event.name;
               const ns = mapped?.namespace;
-              const toolSearch = toolSearchToolNames?.has(realName) ?? false;
-              const freeform = !toolSearch && (freeformToolNames?.has(realName) ?? false);
+              const toolSearch = toolSearchToolNames?.has(event.name) ?? false;
+              const freeform = !toolSearch && (freeformToolNames?.has(event.name) ?? false);
               const itemId = `${toolSearch ? "tsc" : freeform ? "ctc" : "fc"}_${uuid()}`;
               const item = toolSearch
                 ? { type: "tool_search_call", id: itemId, call_id: event.id, execution: "client", arguments: {}, status: "in_progress" }
                 : freeform
-                ? { type: "custom_tool_call", id: itemId, call_id: event.id, name: realName, input: "", status: "in_progress" }
+                ? { type: "custom_tool_call", id: itemId, call_id: event.id, name: realName, input: "", status: "in_progress", ...(ns ? { namespace: ns } : {}) }
                 : {
                     type: "function_call", id: itemId, call_id: event.id, name: realName,
                     arguments: "", status: "in_progress", ...(ns ? { namespace: ns } : {}),
@@ -911,8 +912,8 @@ export function buildResponseJSON(
     const mapped = options?.toolNsMap?.get(currentToolCallName);
     const realName = mapped?.name ?? currentToolCallName;
     const ns = mapped?.namespace;
-    const toolSearch = options?.toolSearchToolNames?.has(realName) ?? false;
-    const freeform = !toolSearch && (options?.freeformToolNames?.has(realName) ?? false);
+    const toolSearch = options?.toolSearchToolNames?.has(currentToolCallName) ?? false;
+    const freeform = !toolSearch && (options?.freeformToolNames?.has(currentToolCallName) ?? false);
     if (toolSearch) {
       output.push({
         type: "tool_search_call", id: `tsc_${uuid()}`,
@@ -924,6 +925,7 @@ export function buildResponseJSON(
         type: "custom_tool_call", id: `ctc_${uuid()}`,
         call_id: currentToolCallId, name: realName,
         input: freeformInput(currentToolCallArgs), status: "completed",
+        ...(ns ? { namespace: ns } : {}),
       });
     } else {
       output.push({

--- a/src/browser-login.ts
+++ b/src/browser-login.ts
@@ -1,12 +1,14 @@
 import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { chromium, type BrowserContextOptions } from "playwright-core";
+import { chromium, type BrowserContextOptions, type Page } from "playwright-core";
 import type { AppConfig } from "./config";
 import { atomicWriteFile } from "./config";
 import {
   assertAuthenticatedChatGptPage,
   assertTemporaryChatPage,
+  CHATGPT_COMPOSER_SELECTOR,
   CHATGPT_TEMPORARY_CHAT_URL,
   detectChatGptAccountCapabilities,
 } from "./chatgpt-session";
@@ -20,9 +22,10 @@ export interface BrowserLoginResult {
 }
 
 interface LoginVerificationMarker {
-  version: 1;
+  version: 2;
   authenticated: true;
   verifiedAt: string;
+  storageStateSha256: string;
   solAvailable?: boolean;
   proAvailable?: boolean;
 }
@@ -31,17 +34,30 @@ export function loginVerificationMarkerPath(storageStatePath: string): string {
   return `${storageStatePath}.verified.json`;
 }
 
-function writeVerificationMarker(
+export function writeBrowserLoginVerificationMarker(
   storageStatePath: string,
-  capabilities: ChatGptWebAccountCapabilities,
+  capabilities: Partial<ChatGptWebAccountCapabilities>,
 ): void {
   const marker: LoginVerificationMarker = {
-    version: 1,
+    version: 2,
     authenticated: true,
     verifiedAt: new Date().toISOString(),
+    storageStateSha256: createHash("sha256").update(readFileSync(storageStatePath)).digest("hex"),
     ...capabilities,
   };
   atomicWriteFile(loginVerificationMarkerPath(storageStatePath), `${JSON.stringify(marker)}\n`);
+}
+
+async function waitForAuthenticatedComposer(page: Page, timeoutMs = 60_000): Promise<void> {
+  try {
+    await page.locator(CHATGPT_COMPOSER_SELECTOR)
+      .filter({ visible: true })
+      .first()
+      .waitFor({ state: "visible", timeout: timeoutMs });
+  } catch {
+    throw new Error("The authenticated ChatGPT page did not produce a visible composer");
+  }
+  await assertAuthenticatedChatGptPage(page);
 }
 
 async function inspectStoredState(
@@ -59,8 +75,7 @@ async function inspectStoredState(
     try {
       const verifierPage = await verifierContext.newPage();
       await verifierPage.goto(CHATGPT_TEMPORARY_CHAT_URL, { waitUntil: "domcontentloaded", timeout: 60_000 });
-      await verifierPage.getByRole("textbox", { name: "Chat with ChatGPT" }).waitFor({ state: "visible", timeout: 60_000 });
-      await assertAuthenticatedChatGptPage(verifierPage);
+      await waitForAuthenticatedComposer(verifierPage);
       await assertTemporaryChatPage(verifierPage);
       return { ...await detectChatGptAccountCapabilities(verifierPage), url: verifierPage.url() };
     } finally {
@@ -74,12 +89,12 @@ async function inspectStoredState(
 export async function inspectBrowserLoginCapabilities(config: AppConfig): Promise<ChatGptWebAccountCapabilities> {
   if (!browserLoginStateExists(config)) throw new Error("ChatGPT login state is missing or unverified");
   const inspected = await inspectStoredState(config, config.storageStatePath);
-  writeVerificationMarker(config.storageStatePath, inspected);
+  writeBrowserLoginVerificationMarker(config.storageStatePath, inspected);
   return { solAvailable: inspected.solAvailable, proAvailable: inspected.proAvailable };
 }
 
 export function storedBrowserLoginCapabilities(
-  config: AppConfig,
+  config: Pick<AppConfig, "storageStatePath">,
 ): Partial<ChatGptWebAccountCapabilities> {
   if (!browserLoginStateExists(config)) return {};
   try {
@@ -134,21 +149,13 @@ export async function loginToChatGpt(
       waitUntil: "domcontentloaded",
       timeout: 60_000,
     });
-    const composer = page.getByRole("textbox", { name: "Chat with ChatGPT" }).or(
-      page.locator('[data-testid="prompt-textarea"], [contenteditable="true"][data-lexical-editor="true"]'),
-    ).first();
-    try {
-      await composer.waitFor({ state: "visible", timeout: options.timeoutMs ?? 60_000 });
-    } catch {
-      throw new Error("The authenticated ChatGPT page did not produce a visible composer");
-    }
-    await assertAuthenticatedChatGptPage(page);
+    await waitForAuthenticatedComposer(page, options.timeoutMs);
     await assertTemporaryChatPage(page);
     const state = await context.storageState();
 
     const inspected = await inspectStoredState(config, state);
     atomicWriteFile(config.storageStatePath, `${JSON.stringify(state)}\n`);
-    writeVerificationMarker(config.storageStatePath, inspected);
+    writeBrowserLoginVerificationMarker(config.storageStatePath, inspected);
     return {
       storageStatePath: config.storageStatePath,
       accountSurfaceUrl: page.url(),
@@ -161,13 +168,19 @@ export async function loginToChatGpt(
   }
 }
 
-export function browserLoginStateExists(config: AppConfig): boolean {
+export function browserLoginStateExists(config: Pick<AppConfig, "storageStatePath">): boolean {
   if (!existsSync(config.storageStatePath)) return false;
   const markerPath = loginVerificationMarkerPath(config.storageStatePath);
   if (!existsSync(markerPath)) return false;
   try {
     const marker = JSON.parse(readFileSync(markerPath, "utf8")) as Partial<LoginVerificationMarker>;
-    return marker.version === 1 && marker.authenticated === true && typeof marker.verifiedAt === "string";
+    const storageStateSha256 = createHash("sha256")
+      .update(readFileSync(config.storageStatePath))
+      .digest("hex");
+    return marker.version === 2
+      && marker.authenticated === true
+      && typeof marker.verifiedAt === "string"
+      && marker.storageStateSha256 === storageStateSha256;
   } catch {
     return false;
   }

--- a/src/chatgpt-session.ts
+++ b/src/chatgpt-session.ts
@@ -7,15 +7,23 @@ export const CHATGPT_COMPOSER_SELECTOR = [
   "#prompt-textarea",
   '[contenteditable="true"][data-lexical-editor="true"]',
 ].join(", ");
+export const CHATGPT_AUTHENTICATED_ACCOUNT_SELECTOR = [
+  '[data-testid="accounts-profile-button"][role="button"]',
+  '[data-testid="profile-button"][role="button"]',
+  '[data-testid="user-menu-button"][role="button"]',
+].join(", ");
 export const CHATGPT_EFFORT_CONTROL_SELECTOR = [
   'button[aria-haspopup="menu"][data-tone="neutral"]:has([data-animated-slider-trigger="true"])',
   'button[data-testid="model-switcher-dropdown-button"][aria-haspopup="menu"]',
 ].join(", ");
-export const CHATGPT_EFFORT_MENU_SELECTOR = [
-  '[data-testid="composer-intelligence-picker-content"]:has([role="menuitemradio"], [data-model-reasoning-effort-slider])',
+export const CHATGPT_EFFORT_CANONICAL_MENU_SELECTOR =
+  '[data-testid="composer-intelligence-picker-content"]:has([role="menuitemradio"], [data-model-reasoning-effort-slider])';
+export const CHATGPT_EFFORT_MENU_SELECTORS = [
+  CHATGPT_EFFORT_CANONICAL_MENU_SELECTOR,
   '[role="menu"]:has([role="menuitemradio"], [data-model-reasoning-effort-slider])',
   '[role="group"]:has([role="menuitemradio"], [data-model-reasoning-effort-slider])',
-].join(", ");
+] as const;
+export const CHATGPT_EFFORT_MENU_SELECTOR = CHATGPT_EFFORT_MENU_SELECTORS.join(", ");
 export const CHATGPT_EFFORT_ITEM_SELECTOR = '[role="menuitemradio"]';
 export const CHATGPT_EFFORT_SLIDER_SELECTOR = '[data-model-reasoning-effort-slider] [role="slider"]';
 export const CHATGPT_EFFORT_SLIDER_MAX_OPTIONS = 5;
@@ -44,6 +52,50 @@ function safeIntegerAttribute(value: string | null): number | undefined {
   return Number.isSafeInteger(parsed) ? parsed : undefined;
 }
 
+function cssAttributeString(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/[\r\n\f]/g, " ");
+}
+
+async function uniqueVisible(locator: Locator, description: string): Promise<Locator | undefined> {
+  const visible = locator.filter({ visible: true });
+  const count = await visible.count();
+  if (count > 1) throw new Error(`ChatGPT ${description} is ambiguous (visibleCount=${count})`);
+  return count === 1 ? visible.first() : undefined;
+}
+
+/** Resolve only a picker proven to belong to the selected effort control. */
+export async function resolveChatGptEffortMenu(
+  page: Page,
+  effortControl: Locator,
+  timeoutMs = 2_000,
+): Promise<Locator | undefined> {
+  const relationshipValues = await Promise.all([
+    effortControl.getAttribute("aria-controls", { timeout: timeoutMs }).catch(() => null),
+    effortControl.getAttribute("aria-owns", { timeout: timeoutMs }).catch(() => null),
+  ]);
+  const ownedIds = [...new Set(relationshipValues
+    .flatMap(value => value?.trim().split(/\s+/) ?? [])
+    .filter(Boolean))];
+  if (ownedIds.length > 1) {
+    throw new Error(`ChatGPT effort control owns multiple picker candidates (ownedCount=${ownedIds.length})`);
+  }
+  if (ownedIds.length === 1) {
+    const owned = await uniqueVisible(
+      page.locator(`[id="${cssAttributeString(ownedIds[0])}"]`),
+      "effort menu",
+    );
+    if (!owned) return undefined;
+    const semanticCount = await owned.locator(
+      `${CHATGPT_EFFORT_ITEM_SELECTOR}, ${CHATGPT_EFFORT_SLIDER_SELECTOR}`,
+    ).filter({ visible: true }).count();
+    return semanticCount > 0 ? owned : undefined;
+  }
+
+  // The current picker has a purpose-specific test id. Generic global menus/groups are accepted
+  // only through aria-controls/aria-owns; otherwise ownership cannot be proven safely.
+  return await uniqueVisible(page.locator(CHATGPT_EFFORT_CANONICAL_MENU_SELECTOR), "effort menu");
+}
+
 export function parseChatGptEffortSliderState(
   rawMin: string | null,
   rawMax: string | null,
@@ -68,11 +120,13 @@ async function anyVisible(locator: Locator): Promise<boolean> {
 }
 
 export async function assertAuthenticatedChatGptPage(page: Page): Promise<void> {
-  const composer = page.locator(
-    CHATGPT_COMPOSER_SELECTOR,
-  );
+  const composer = page.locator(CHATGPT_COMPOSER_SELECTOR);
   if (!await anyVisible(composer)) {
     throw new Error("ChatGPT authentication could not be verified: no visible composer is present");
+  }
+  const accountControl = page.locator(CHATGPT_AUTHENTICATED_ACCOUNT_SELECTOR);
+  if (!await anyVisible(accountControl)) {
+    throw new Error("ChatGPT authentication could not be verified: no authenticated account control is present");
   }
 }
 
@@ -89,27 +143,41 @@ export async function detectChatGptAccountCapabilities(
   options: { selectorTimeoutMs?: number; stableAbsenceMs?: number } = {},
 ): Promise<ChatGptWebAccountCapabilities> {
   const composers = page.locator(CHATGPT_COMPOSER_SELECTOR).filter({ visible: true });
-  const composer = composers.last();
-  const composerForm = composer.locator("xpath=ancestor::form[1]");
-  const effortButton = composerForm.locator(CHATGPT_EFFORT_CONTROL_SELECTOR).last();
   const deadline = Date.now() + (options.selectorTimeoutMs ?? 30_000);
   const stableAbsenceMs = options.stableAbsenceMs ?? 3_000;
+  const remaining = (): number => {
+    const value = deadline - Date.now();
+    if (value <= 0) throw new Error("ChatGPT account capability probe did not reach a stable composer state");
+    return value;
+  };
   let absenceSince: number | undefined;
   let presenceObservations = 0;
+  let effortButton: Locator | undefined;
   while (true) {
-    const effortVisible = await effortButton.isVisible().catch(() => false);
-    if (effortVisible) {
+    const composerCount = await composers.count().catch(() => 0);
+    if (composerCount > 1) throw new Error(`ChatGPT account capability probe found ambiguous composers (visibleCount=${composerCount})`);
+    const composer = composerCount === 1 ? composers.first() : undefined;
+    const composerForm = composer?.locator("xpath=ancestor::form[1]");
+    const formReady = await composerForm?.count().then(count => count === 1).catch(() => false) ?? false;
+    const controls = formReady
+      ? composerForm!.locator(CHATGPT_EFFORT_CONTROL_SELECTOR).filter({ visible: true })
+      : undefined;
+    const controlCount = await controls?.count().catch(() => 0) ?? 0;
+    if (controlCount > 1) throw new Error(`ChatGPT effort control is ambiguous (visibleCount=${controlCount})`);
+    if (controlCount === 1) {
       presenceObservations += 1;
       absenceSince = undefined;
+      effortButton = controls!.first();
       if (presenceObservations >= 2) break;
+      remaining();
       await new Promise(resolveSleep => setTimeout(resolveSleep, 100));
       continue;
+    } else {
+      presenceObservations = 0;
+      effortButton = undefined;
     }
-    presenceObservations = 0;
-    const composerReady = await composers.count().then(count => count === 1).catch(() => false);
-    const formReady = await composerForm.count().then(count => count === 1).catch(() => false);
     const documentReady = await page.evaluate(() => document.readyState === "complete").catch(() => false);
-    if (composerReady && formReady && documentReady) {
+    if (composerCount === 1 && formReady && controlCount === 0 && documentReady) {
       absenceSince ??= Date.now();
       if (Date.now() - absenceSince >= stableAbsenceMs) {
         return { solAvailable: false, proAvailable: false };
@@ -117,40 +185,56 @@ export async function detectChatGptAccountCapabilities(
     } else {
       absenceSince = undefined;
     }
-    if (Date.now() >= deadline) {
-      throw new Error("ChatGPT account capability probe did not reach a stable composer state");
-    }
+    remaining();
     await new Promise(resolveSleep => setTimeout(resolveSleep, 100));
   }
-  const menu = page.locator(CHATGPT_EFFORT_MENU_SELECTOR).last();
-  const menuVisible = await menu.isVisible().catch(() => false);
+  if (!effortButton) throw new Error("ChatGPT effort control disappeared during capability probe");
   const menuExpanded = await effortButton.getAttribute("aria-expanded").catch(() => null);
-  if (!menuVisible && menuExpanded !== "true") await effortButton.press("Enter");
+  const menuBeforeOpen = await resolveChatGptEffortMenu(page, effortButton, remaining());
+  let openedByProbe = false;
+  if (!menuBeforeOpen && menuExpanded !== "true") {
+    await effortButton.press("Enter", { timeout: remaining() });
+    openedByProbe = true;
+  }
   try {
-    const efforts = menu.locator(CHATGPT_EFFORT_ITEM_SELECTOR);
-    const slider = page.locator(CHATGPT_EFFORT_SLIDER_SELECTOR).filter({ visible: true }).last();
-    const waitAbort = new AbortController();
-    try {
-      const ready = await Promise.race([
-        efforts.first().waitFor({ state: "visible", timeout: 70_000, signal: waitAbort.signal })
-          .then(() => "items" as const),
-        slider.waitFor({ state: "visible", timeout: 70_000, signal: waitAbort.signal })
-          .then(() => "slider" as const),
-      ]);
-      if (ready === "items") {
-        return { solAvailable: true, proAvailable: await efforts.count() >= 5 };
+    while (true) {
+      const menu = await resolveChatGptEffortMenu(page, effortButton, remaining());
+      if (menu) {
+        const efforts = menu.locator(CHATGPT_EFFORT_ITEM_SELECTOR).filter({ visible: true });
+        const sliders = menu.locator(CHATGPT_EFFORT_SLIDER_SELECTOR).filter({ visible: true });
+        const [effortCount, sliderCount] = await Promise.all([efforts.count(), sliders.count()]);
+        if (effortCount > 0 && sliderCount > 0) {
+          throw new Error("ChatGPT effort capability probe found conflicting menu and slider controls");
+        }
+        if (effortCount > 0) {
+          if (effortCount > CHATGPT_EFFORT_SLIDER_MAX_OPTIONS) {
+            throw new Error(`ChatGPT effort capability probe found unsupported option count ${effortCount}`);
+          }
+          const checked = await Promise.all(Array.from({ length: effortCount }, (_, index) => (
+            efforts.nth(index).getAttribute("aria-checked", { timeout: remaining() })
+          )));
+          if (checked.filter(value => value === "true").length !== 1
+            || checked.some(value => value !== "true" && value !== "false")) {
+            throw new Error("ChatGPT effort capability probe found ambiguous checked state");
+          }
+          return { solAvailable: true, proAvailable: effortCount >= 5 };
+        }
+        if (sliderCount > 1) throw new Error(`ChatGPT effort capability probe found ambiguous sliders (${sliderCount})`);
+        if (sliderCount === 1) {
+          const slider = sliders.first();
+          const state = parseChatGptEffortSliderState(
+            await slider.getAttribute("aria-valuemin", { timeout: remaining() }),
+            await slider.getAttribute("aria-valuemax", { timeout: remaining() }),
+            await slider.getAttribute("aria-valuenow", { timeout: remaining() }),
+          );
+          if (!state) throw new Error("ChatGPT effort slider exposed an invalid ARIA range");
+          return { solAvailable: true, proAvailable: state.max - state.min + 1 >= 5 };
+        }
       }
-      const state = parseChatGptEffortSliderState(
-        await slider.getAttribute("aria-valuemin"),
-        await slider.getAttribute("aria-valuemax"),
-        await slider.getAttribute("aria-valuenow"),
-      );
-      if (!state) throw new Error("ChatGPT effort slider exposed an invalid ARIA range");
-      return { solAvailable: true, proAvailable: state.max - state.min + 1 >= 5 };
-    } finally {
-      waitAbort.abort();
+      remaining();
+      await new Promise(resolveSleep => setTimeout(resolveSleep, 50));
     }
   } finally {
-    await page.keyboard.press("Escape").catch(() => {});
+    if (openedByProbe) await effortButton.press("Escape", { timeout: Math.max(1, deadline - Date.now()) }).catch(() => {});
   }
 }

--- a/src/responses/parser.ts
+++ b/src/responses/parser.ts
@@ -20,6 +20,27 @@ function isObj(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null && !Array.isArray(v);
 }
 
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (isObj(value)) {
+    return `{${Object.keys(value).sort().map(key => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "undefined";
+}
+
+function toolAbiSignature(tool: CodexTool): string {
+  return canonicalJson({
+    name: tool.name,
+    namespace: tool.namespace,
+    description: tool.description,
+    parameters: tool.parameters,
+    strict: tool.strict,
+    freeform: tool.freeform,
+    customFormat: tool.customFormat,
+    toolSearch: tool.toolSearch,
+  });
+}
+
 type InputBlock =
   | { type: "input_text"; text: string }
   | { type: "text"; text: string }
@@ -115,82 +136,142 @@ function normalizedToolNamespace(value: unknown): string | undefined {
 function buildTools(tools: unknown[] | undefined): CodexTool[] | undefined {
   if (!tools) return undefined;
   const out: CodexTool[] = [];
+  const seenWireNames = new Map<string, string>();
+  const pushTool = (tool: CodexTool) => {
+    const wireName = namespacedToolName(tool.namespace, tool.name);
+    const signature = toolAbiSignature(tool);
+    const previous = seenWireNames.get(wireName);
+    if (previous === signature) return;
+    if (previous !== undefined) {
+      throw new Error(`responses tool parse error: duplicate Codex tool wire name: ${wireName}`);
+    }
+    seenWireNames.set(wireName, signature);
+    out.push(tool);
+  };
+  const toolName = (t: Record<string, unknown>, kind: string): string => {
+    if (typeof t.name !== "string" || t.name.length === 0
+      || t.name.trim() !== t.name || /[\x00-\x1f\x7f]/.test(t.name)) {
+      throw new Error(`responses tool parse error: invalid ${kind} tool name`);
+    }
+    return t.name;
+  };
+  const toolDescription = (t: Record<string, unknown>, kind: string): string => {
+    if (t.description === undefined || t.description === null) return "";
+    if (typeof t.description !== "string") {
+      throw new Error(`responses tool parse error: invalid ${kind} tool description`);
+    }
+    return t.description;
+  };
+  const toolParameters = (t: Record<string, unknown>, kind: string): Record<string, unknown> => {
+    if (t.parameters === undefined || t.parameters === null) return {};
+    if (!isObj(t.parameters)) {
+      throw new Error(`responses tool parse error: invalid ${kind} tool parameters`);
+    }
+    return t.parameters;
+  };
+  const customFormat = (t: Record<string, unknown>): CodexTool["customFormat"] => {
+    if (t.format === undefined || t.format === null) return undefined;
+    if (!isObj(t.format) || typeof t.format.type !== "string") {
+      throw new Error("responses tool parse error: invalid custom tool format");
+    }
+    if (t.format.type === "text") return { type: "text" };
+    if (t.format.type === "grammar") {
+      if ((t.format.syntax !== "lark" && t.format.syntax !== "regex")
+        || typeof t.format.definition !== "string") {
+        throw new Error("responses tool parse error: invalid custom tool grammar format");
+      }
+      return { type: "grammar", syntax: t.format.syntax, definition: t.format.definition };
+    }
+    throw new Error("responses tool parse error: invalid custom tool format type");
+  };
   const pushFn = (t: Record<string, unknown>, namespace?: string) => {
     const tool: CodexTool = {
-      name: t.name as string,
-      description: (t.description as string) ?? "",
-      parameters: (t.parameters ?? {}) as Record<string, unknown>,
+      name: toolName(t, "function"),
+      description: toolDescription(t, "function"),
+      parameters: toolParameters(t, "function"),
     };
-    if (t.strict !== undefined) tool.strict = t.strict as boolean;
+    if (t.strict !== undefined) {
+      if (typeof t.strict !== "boolean") {
+        throw new Error("responses tool parse error: invalid function tool strict flag");
+      }
+      tool.strict = t.strict;
+    }
     if (namespace) tool.namespace = namespace;
-    out.push(tool);
+    pushTool(tool);
   };
-  const pushFreeform = (t: Record<string, unknown>) => {
+  const pushCustom = (t: Record<string, unknown>, namespace?: string) => {
+    const format = customFormat(t);
     const tool: CodexTool = {
-      name: t.name as string,
-      description: (t.description as string) ?? "",
-      parameters: {
-        type: "object",
-        properties: {
-          input: {
-            type: "string",
-            description: "Raw tool input. For apply_patch, begin exactly with `*** Begin Patch` (no trailing `***`), then use its standard patch envelope.",
-          },
-        },
-        required: ["input"],
-      },
+      name: toolName(t, "custom"),
+      description: toolDescription(t, "custom"),
+      parameters: { type: "object", properties: { input: { type: "string", description: "Raw tool input. For apply_patch, begin exactly with `*** Begin Patch` (no trailing `***`), then use its standard patch envelope." } }, required: ["input"] },
       freeform: true,
+      ...(format ? { customFormat: format } : {}),
     };
-    out.push(tool);
+    if (namespace) tool.namespace = namespace;
+    pushTool(tool);
   };
   for (const t of tools) {
-    if (!isObj(t)) continue;
-    if (t.type === "function" && typeof t.name === "string") {
+    if (!isObj(t) || typeof t.type !== "string") {
+      throw new Error("responses tool parse error: malformed tool entry");
+    }
+    if (t.type === "function") {
       pushFn(t);
-    } else if (t.type === "namespace" && Array.isArray(t.tools)) {
-      // Responses Lite groups ordinary native functions and the native freeform `exec` tool under
-      // the default `functions` namespace. Flatten normal functions from every namespace, and the
-      // official freeform variant only from that default namespace. Non-default custom namespaces
-      // need a distinct round-trip contract and must not be silently exposed as function calls.
-      const ns = normalizedToolNamespace(t.name);
+    } else if (t.type === "namespace") {
+      // MCP tools arrive grouped under a namespace tool; flatten the inner function tools so
+      // chat-completions models receive them (round-trip restores the namespace in the bridge).
+      const wireNamespace = toolName(t, "namespace");
+      const namespace = normalizedToolNamespace(wireNamespace);
+      if (!Array.isArray(t.tools)) {
+        throw new Error("responses tool parse error: invalid namespace tools array");
+      }
       for (const inner of t.tools as unknown[]) {
-        if (!isObj(inner) || typeof inner.name !== "string") continue;
-        if (inner.type === "function") pushFn(inner, ns);
-        else if (t.name === DEFAULT_FUNCTION_NAMESPACE && inner.type === "custom") pushFreeform(inner);
+        if (!isObj(inner) || typeof inner.type !== "string") {
+          throw new Error(`responses tool parse error: malformed nested tool entry in namespace ${wireNamespace}`);
+        }
+        if (inner.type === "function") pushFn(inner, namespace);
+        else if (inner.type === "custom") {
+          // Codex's built-in command gateway is transported as namespace `functions` + custom
+          // `exec`, but its dedicated MCP route is the historical bare wire name `exec`.
+          // Preserve namespace for every other custom tool so names do not collide or misroute.
+          pushCustom(inner, wireNamespace === DEFAULT_FUNCTION_NAMESPACE && inner.name === "exec"
+            ? undefined
+            : wireNamespace);
+        }
+        // Unknown nested tool kinds stay non-executable until the parser has an explicit ABI for
+        // their call/result semantics.
       }
     }
-    else if (t.type === "custom" && typeof t.name === "string") {
+    else if (t.type === "custom") {
       // Freeform custom tool (e.g. apply_patch). Chat models can't emit a lark grammar, so expose a
       // function with a single string `input` carrying the raw tool body; the bridge relays the model's
       // call back as a custom_tool_call (Codex's freeform handler rejects a function_call → fatal abort).
-      pushFreeform(t);
+      pushCustom(t);
     }
     else if (t.type === "tool_search") {
       // Client-executed tool discovery — the gateway to deferred tools (subagents, extra MCP tools).
       // Expose as a function so chat models can call it; the bridge relays it as a tool_search_call.
-      out.push({
+      pushTool({
         name: "tool_search",
-        description: (t.description as string) ?? "Search for additional tools to load for the next turn.",
-        parameters: (isObj(t.parameters) ? t.parameters : {
+        description: t.description === undefined
+          ? "Search for additional tools to load for the next turn."
+          : toolDescription(t, "tool_search"),
+        parameters: (t.parameters === undefined ? {
           type: "object",
           properties: {
             query: { type: "string", description: "Search query for tools to load." },
             limit: { type: "number", description: "Maximum number of tools to return." },
           },
           required: ["query"],
-        }) as Record<string, unknown>,
+        } : toolParameters(t, "tool_search")),
         toolSearch: true,
       });
     }
-    else if (typeof t.name === "string" && t.type !== "web_search" && t.type !== "image_generation") {
-      // Any other named tool (for example a native computer-use tool type this parser does not
-      // model) is client-executed — pass it through as a function so the routed model can read and
-      // call it naturally; the bridge relays its call as a function_call. Previously such tools were
-      // silently dropped, so the model never saw them.
+    else if ((t.type === "computer_use" || t.type === "computer_use_preview") && typeof t.name === "string") {
+      // Explicit compatibility allowlist for named client-executed computer-use definitions.
+      // Unknown and OpenAI-hosted kinds remain non-executable until they have a defined call ABI.
       pushFn(t);
     }
-    // Only the OpenAI-hosted server-side tools (web_search, image_generation) are intentionally
-    // dropped — they're executed by OpenAI and can't be relayed to a routed chat model.
   }
   return out.length > 0 ? out : undefined;
 }
@@ -454,10 +535,15 @@ export function parseRequest(body: unknown): CodexParsedRequest {
       }
 
       if (effectiveType === "custom_tool_call") {
-        const call = item as { id?: string; call_id: string; name: string; input: string };
+        const call = item as { id?: string; call_id: string; name: string; input: string; namespace?: string };
+        const namespace = call.namespace === "functions" && call.name === "exec"
+          ? undefined
+          : call.namespace;
         const toolCall: CodexToolCall = {
           type: "toolCall", id: call.call_id, name: call.name,
           arguments: { input: call.input ?? "" },
+          customWireName: call.name,
+          ...(namespace ? { namespace } : {}),
         };
         assistantHolderWithReasoning().content.push(toolCall);
         continue;
@@ -505,17 +591,8 @@ export function parseRequest(body: unknown): CodexParsedRequest {
         loadedToolSpecs.push(...specs);
         // List the EXACT wire names the model must call (flattened for namespaced specs), matching
         // how buildTools exposes them — otherwise the model guesses wrong names (e.g. the bare namespace).
-        const wireNames: string[] = [];
-        for (const spec of specs) {
-          if (spec.type === "namespace" && Array.isArray(spec.tools)) {
-            const namespace = normalizedToolNamespace(spec.name);
-            for (const inner of spec.tools as Record<string, unknown>[]) {
-              if (typeof inner.name === "string") wireNames.push(namespacedToolName(namespace, inner.name));
-            }
-          } else if (typeof spec.name === "string") {
-            wireNames.push(spec.name);
-          }
-        }
+        const wireNames = (buildTools(specs) ?? [])
+          .map(tool => namespacedToolName(tool.namespace, tool.name));
         const failed = typeof out.status === "string" && out.status !== "completed" && out.status !== "success";
         messages.push({
           role: "toolResult", toolCallId: out.call_id ?? "", toolName: "tool_search",
@@ -558,14 +635,23 @@ export function parseRequest(body: unknown): CodexParsedRequest {
 
   const declaredTools = buildTools(data.tools as unknown[] | undefined) ?? [];
   const loadedTools = buildTools(loadedToolSpecs) ?? [];
-  const seenTools = new Set<string>();
+  const loadedToolNames = new Set(loadedTools.map(t => namespacedToolName(t.namespace, t.name)));
+  const seenTools = new Map<string, string>();
   const mergedTools = [...declaredTools, ...loadedTools]
     .filter(t => {
       const k = namespacedToolName(t.namespace, t.name);
-      if (seenTools.has(k)) return false;
-      seenTools.add(k);
+      const signature = toolAbiSignature(t);
+      const previous = seenTools.get(k);
+      if (previous === signature) return false;
+      if (previous !== undefined) {
+        throw new Error(`responses tool parse error: duplicate Codex tool wire name: ${k}`);
+      }
+      seenTools.set(k, signature);
       return true;
-    });
+    })
+    .map(t => loadedToolNames.has(namespacedToolName(t.namespace, t.name))
+      ? { ...t, loadedFromToolSearch: true }
+      : t);
   const context: CodexContext = {
     ...(systemPrompt.length > 0 ? { systemPrompt } : {}),
     messages,

--- a/src/responses/schema.ts
+++ b/src/responses/schema.ts
@@ -87,6 +87,7 @@ const customToolCallItemSchema = z.object({
   id: z.string().optional(),
   call_id: z.string().min(1),
   name: z.string().min(1),
+  namespace: z.string().optional(),
   input: z.string(),
 });
 const customToolCallOutputItemSchema = z.object({

--- a/src/server.ts
+++ b/src/server.ts
@@ -233,7 +233,7 @@ export async function nativeSearchRequest(
   }
 }
 
-function toolBridgeMaps(parsed: CodexParsedRequest): {
+export function toolBridgeMaps(parsed: CodexParsedRequest): {
   toolNsMap: Map<string, { namespace: string; name: string }>;
   freeformToolNames: Set<string>;
   toolSearchToolNames: Set<string>;
@@ -242,9 +242,10 @@ function toolBridgeMaps(parsed: CodexParsedRequest): {
   const freeformToolNames = new Set<string>();
   const toolSearchToolNames = new Set<string>();
   for (const tool of parsed.context.tools ?? []) {
-    if (tool.namespace) toolNsMap.set(namespacedToolName(tool.namespace, tool.name), { namespace: tool.namespace, name: tool.name });
-    if (tool.freeform) freeformToolNames.add(tool.name);
-    if (tool.toolSearch) toolSearchToolNames.add(tool.name);
+    const wireName = namespacedToolName(tool.namespace, tool.name);
+    if (tool.namespace) toolNsMap.set(wireName, { namespace: tool.namespace, name: tool.name });
+    if (tool.freeform) freeformToolNames.add(wireName);
+    if (tool.toolSearch) toolSearchToolNames.add(wireName);
   }
   return { toolNsMap, freeformToolNames, toolSearchToolNames };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,6 +97,8 @@ export interface CodexToolCall {
   id: string;
   name: string;
   arguments: Record<string, unknown>;
+  /** Original validated custom-tool wire name used to preserve custom call/result ABI on replay. */
+  customWireName?: string;
   thoughtSignature?: string;
   /** MCP namespace (e.g. "mcp__context7") when this call targets a namespaced tool. */
   namespace?: string;
@@ -113,8 +115,12 @@ export interface CodexTool {
   namespace?: string;
   /** Freeform/custom tool (e.g. apply_patch): the model's call must be relayed as a custom_tool_call. */
   freeform?: boolean;
+  /** Validated Responses custom-tool input format, retained for ABI collision detection. */
+  customFormat?: { type: "text" } | { type: "grammar"; syntax: "lark" | "regex"; definition: string };
   /** Client-executed tool discovery (tool_search): the model's call must be relayed as a tool_search_call. */
   toolSearch?: boolean;
+  /** Tool definition restored from a prior tool_search output. */
+  loadedFromToolSearch?: boolean;
 }
 
 /**

--- a/tests/browser-login.test.ts
+++ b/tests/browser-login.test.ts
@@ -1,10 +1,105 @@
 import { expect, test } from "bun:test";
-import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { browserLoginStateExists, loginToChatGpt, loginVerificationMarkerPath } from "../src/browser-login";
-import { CHATGPT_TEMPORARY_CHAT_URL } from "../src/chatgpt-session";
+import { chromium } from "playwright-core";
+import {
+  browserLoginStateExists,
+  loginToChatGpt,
+  loginVerificationMarkerPath,
+  writeBrowserLoginVerificationMarker,
+} from "../src/browser-login";
+import {
+  CHATGPT_AUTHENTICATED_ACCOUNT_SELECTOR,
+  CHATGPT_COMPOSER_SELECTOR,
+  CHATGPT_EFFORT_CANONICAL_MENU_SELECTOR,
+  CHATGPT_EFFORT_CONTROL_SELECTOR,
+  CHATGPT_EFFORT_ITEM_SELECTOR,
+  CHATGPT_EFFORT_SLIDER_SELECTOR,
+  CHATGPT_TEMPORARY_CHAT_URL,
+} from "../src/chatgpt-session";
 import { defaultConfig } from "../src/config";
+
+function fakeChatGptPage(authenticated: boolean, observedSelectors: string[]) {
+  const makeLocator = (kind: string, itemIndex = 0) => {
+    const visible = kind === "composer" || kind === "account" || kind === "form"
+      || kind === "effort" || kind === "menu" || kind === "item";
+    const locator = {
+      filter: () => locator,
+      first: () => locator,
+      last: () => locator,
+      nth: (index: number) => makeLocator(kind, index),
+      count: async () => visible ? (kind === "item" ? 4 : 1) : 0,
+      isVisible: async () => visible,
+      waitFor: async () => {
+        if (kind === "slider") return await new Promise<void>(() => {});
+        if (!visible) throw new Error("not visible");
+      },
+      getAttribute: async (name: string) => {
+        if (kind === "effort" && name === "aria-expanded") return "true";
+        if (kind === "item" && name === "aria-checked") return itemIndex === 2 ? "true" : "false";
+        return null;
+      },
+      press: async () => {},
+      locator: (selector: string) => {
+        if (kind === "composer" && selector === "xpath=ancestor::form[1]") return makeLocator("form");
+        if (kind === "form" && selector === CHATGPT_EFFORT_CONTROL_SELECTOR) return makeLocator("effort");
+        if (kind === "menu" && selector === CHATGPT_EFFORT_ITEM_SELECTOR) return makeLocator("item");
+        if (kind === "menu" && selector === `${CHATGPT_EFFORT_ITEM_SELECTOR}, ${CHATGPT_EFFORT_SLIDER_SELECTOR}`) {
+          return makeLocator("item");
+        }
+        return makeLocator("missing");
+      },
+    };
+    return locator;
+  };
+  return {
+    goto: async () => {},
+    url: () => CHATGPT_TEMPORARY_CHAT_URL,
+    keyboard: { press: async () => {} },
+    locator: (selector: string) => {
+      observedSelectors.push(selector);
+      if (selector === CHATGPT_COMPOSER_SELECTOR) return makeLocator("composer");
+      if (selector === CHATGPT_AUTHENTICATED_ACCOUNT_SELECTOR) {
+        return makeLocator(authenticated ? "account" : "missing");
+      }
+      if (selector === CHATGPT_EFFORT_CANONICAL_MENU_SELECTOR) return makeLocator("menu");
+      if (selector === CHATGPT_EFFORT_SLIDER_SELECTOR) return makeLocator("slider");
+      return makeLocator("missing");
+    },
+  };
+}
+
+async function withFakeLoginBrowsers(
+  verifierAuthenticated: boolean,
+  run: (observedSelectors: string[]) => Promise<void>,
+): Promise<void> {
+  const originalPersistent = chromium.launchPersistentContext;
+  const originalLaunch = chromium.launch;
+  const observedSelectors: string[] = [];
+  const initialPage = fakeChatGptPage(true, observedSelectors);
+  const verifierPage = fakeChatGptPage(verifierAuthenticated, observedSelectors);
+  chromium.launchPersistentContext = (async () => ({
+    pages: () => [initialPage],
+    newPage: async () => initialPage,
+    storageState: async () => ({ cookies: [], origins: [] }),
+    close: async () => {},
+  })) as unknown as typeof chromium.launchPersistentContext;
+  chromium.launch = (async () => ({
+    newContext: async () => ({
+      newPage: async () => verifierPage,
+      close: async () => {},
+    }),
+    close: async () => {},
+  })) as unknown as typeof chromium.launch;
+  try {
+    await run(observedSelectors);
+  } finally {
+    chromium.launchPersistentContext = originalPersistent;
+    chromium.launch = originalLaunch;
+  }
+}
 
 test("login starts with normal Chrome and captures state in a headed Keychain-aware context", async () => {
   if (process.platform === "win32") return;
@@ -28,9 +123,67 @@ test("login starts with normal Chrome and captures state in a headed Keychain-aw
     expect(firstLaunch).toContain(CHATGPT_TEMPORARY_CHAT_URL);
     expect(firstLaunch).not.toContain("--remote-debugging-pipe");
     expect(launches[1]).not.toContain("--headless");
+    expect(existsSync(config.storageStatePath)).toBe(false);
+    expect(existsSync(loginVerificationMarkerPath(config.storageStatePath))).toBe(false);
   } finally {
     if (previousLog === undefined) delete process.env.CODEX_LOGIN_ARG_LOG;
     else process.env.CODEX_LOGIN_ARG_LOG = previousLog;
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("browser login verification uses the shared current composer selector in both stages", () => {
+  expect(CHATGPT_COMPOSER_SELECTOR.split(", ")).toContain("#prompt-textarea");
+
+  const source = readFileSync(join(import.meta.dir, "../src/browser-login.ts"), "utf8");
+  expect(source).toContain("page.locator(CHATGPT_COMPOSER_SELECTOR)");
+  expect(source.match(/waitForAuthenticatedComposer\(/g)).toHaveLength(3);
+  expect(source).not.toContain('getByRole("textbox", { name: "Chat with ChatGPT" })');
+  expect(source).not.toContain(
+    "page.locator('[data-testid=\"prompt-textarea\"], [contenteditable=\"true\"][data-lexical-editor=\"true\"]')",
+  );
+});
+
+test("login behavior verifies the current composer in both contexts and creates a state-bound marker", async () => {
+  if (process.platform === "win32") return;
+  const root = mkdtempSync(join(tmpdir(), "codex-chatgpt-web-login-behavior-"));
+  const executable = join(root, "fake-chrome");
+  writeFileSync(executable, "#!/bin/sh\nexit 0\n", { mode: 0o700 });
+  chmodSync(executable, 0o700);
+  try {
+    const config = defaultConfig("browser-only");
+    config.chromeExecutablePath = executable;
+    config.storageStatePath = join(root, "browser", "storage-state.json");
+    await withFakeLoginBrowsers(true, async observedSelectors => {
+      const result = await loginToChatGpt(config, { timeoutMs: 100 });
+      expect(result.solAvailable).toBe(true);
+      expect(observedSelectors.filter(selector => selector === CHATGPT_COMPOSER_SELECTOR).length)
+        .toBeGreaterThanOrEqual(4);
+      expect(observedSelectors).not.toContain('textarea[aria-label="Chat with ChatGPT"]');
+      expect(browserLoginStateExists(config)).toBe(true);
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a guest fresh verifier fails closed without writing state or marker", async () => {
+  if (process.platform === "win32") return;
+  const root = mkdtempSync(join(tmpdir(), "codex-chatgpt-web-login-guest-"));
+  const executable = join(root, "fake-chrome");
+  writeFileSync(executable, "#!/bin/sh\nexit 0\n", { mode: 0o700 });
+  chmodSync(executable, 0o700);
+  try {
+    const config = defaultConfig("browser-only");
+    config.chromeExecutablePath = executable;
+    config.storageStatePath = join(root, "browser", "storage-state.json");
+    await withFakeLoginBrowsers(false, async () => {
+      await expect(loginToChatGpt(config, { timeoutMs: 100 }))
+        .rejects.toThrow("no authenticated account control is present");
+    });
+    expect(existsSync(config.storageStatePath)).toBe(false);
+    expect(existsSync(loginVerificationMarkerPath(config.storageStatePath))).toBe(false);
+  } finally {
     rmSync(root, { recursive: true, force: true });
   }
 });
@@ -40,15 +193,45 @@ test("a storage-state file is not trusted without a verification marker", () => 
   try {
     const config = defaultConfig("browser-only");
     config.storageStatePath = join(root, "storage-state.json");
-    writeFileSync(config.storageStatePath, "{}\n", { mode: 0o600 });
+    const initialState = "{}\n";
+    writeFileSync(config.storageStatePath, initialState, { mode: 0o600 });
     expect(browserLoginStateExists(config)).toBe(false);
 
     writeFileSync(
       loginVerificationMarkerPath(config.storageStatePath),
-      `${JSON.stringify({ version: 1, authenticated: true, verifiedAt: "2026-07-26T00:00:00.000Z" })}\n`,
+      `${JSON.stringify({
+        version: 2,
+        authenticated: true,
+        verifiedAt: "2026-07-26T00:00:00.000Z",
+        storageStateSha256: createHash("sha256").update(initialState).digest("hex"),
+      })}\n`,
       { mode: 0o600 },
     );
     expect(browserLoginStateExists(config)).toBe(true);
+
+    writeFileSync(config.storageStatePath, '{"cookies":[]}\n', { mode: 0o600 });
+    expect(browserLoginStateExists(config)).toBe(false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("persisting a refreshed managed-browser state also refreshes its verification digest", () => {
+  const root = mkdtempSync(join(tmpdir(), "codex-chatgpt-web-login-refresh-"));
+  try {
+    const config = defaultConfig("browser-only");
+    config.storageStatePath = join(root, "storage-state.json");
+    writeFileSync(config.storageStatePath, '{"cookies":[{"name":"fresh"}]}\n', { mode: 0o600 });
+    expect(browserLoginStateExists(config)).toBe(false);
+
+    writeBrowserLoginVerificationMarker(config.storageStatePath, {
+      solAvailable: true,
+      proAvailable: false,
+    });
+    expect(browserLoginStateExists(config)).toBe(true);
+
+    writeFileSync(config.storageStatePath, '{"cookies":[{"name":"newer"}]}\n', { mode: 0o600 });
+    expect(browserLoginStateExists(config)).toBe(false);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -33,6 +33,14 @@ test("browser turn orchestration retains owned prompt insertion and semantic sub
   expect(runBrowserTurn.slice(finalEffortSelected, promptAttached)).toContain(
     "this.selectModelAndEffort(",
   );
+  const effortSelections = runBrowserTurn.split("this.selectModelAndEffort(").slice(1);
+  expect(effortSelections).toHaveLength(3);
+  for (const effortSelection of effortSelections) {
+    expect(effortSelection.slice(0, 800)).toContain(
+      "turn.abortSignal ? AbortSignal.any([stageSignal, turn.abortSignal]) : stageSignal",
+    );
+  }
+  expect(runBrowserTurn).toContain("writeBrowserLoginVerificationMarker(this.config.storageStatePath, capabilities)");
   expect(runBrowserTurn).not.toContain("userTurns.nth(initialUserTurnCount).waitFor");
   expect(workerSource).not.toMatch(/\bclipboard\b|pbcopy|pbpaste/i);
 });
@@ -896,13 +904,14 @@ test("image attachment readiness uses exact file tiles and not localized remove-
   ]);
 });
 
-test("effort selection uses structural menu and slider indices instead of localized labels", () => {
+test("effort selection uses bounded structural menu and slider indices with passive current-state recognition", () => {
   const workerSource = readFileSync(new URL("../src/adapters/chatgpt-web/browser-worker.ts", import.meta.url), "utf8");
   const sessionSource = readFileSync(new URL("../src/chatgpt-session.ts", import.meta.url), "utf8");
   expect(workerSource).toContain("mode.uiEffortIndex");
-  expect(workerSource).toContain("CHATGPT_EFFORT_MENU_SELECTOR");
+  expect(workerSource).toContain("resolveChatGptEffortMenu");
   expect(workerSource).toContain("CHATGPT_EFFORT_ITEM_SELECTOR");
-  expect(workerSource).toContain('timeout: 70_000');
+  expect(workerSource).toContain("Date.now() + 60_000");
+  expect(workerSource).toContain("stageSignal =>");
   expect(sessionSource).toContain('[role="menu"]:has([role="menuitemradio"], [data-model-reasoning-effort-slider])');
   expect(sessionSource).toContain('[role="group"]:has([role="menuitemradio"], [data-model-reasoning-effort-slider])');
   expect(sessionSource).toContain('[role="menuitemradio"]');
@@ -912,9 +921,9 @@ test("effort selection uses structural menu and slider indices instead of locali
   expect(workerSource).toContain('getAttribute("aria-checked")');
   expect(workerSource).toContain('getAttribute("aria-expanded")');
   expect(workerSource).toContain('getAttribute("aria-valuenow")');
-  expect(workerSource).toContain("sliderControl.press(key)");
-  expect(workerSource).not.toContain("currentLabel === targetLabel");
-  expect(workerSource).not.toContain("chatGptEffortLabelsMatch");
+  expect(workerSource).toContain("control.press(key");
+  expect(workerSource).toContain("chatGptEffortIndexFromControlLabel");
+  expect(workerSource).toContain("label === state.targetLabel");
   expect(workerSource).not.toMatch(/getByRole\("button", \{\s*name: "(?:Instant|Medium|High|Extra High|Pro)"/);
 });
 
@@ -950,6 +959,7 @@ test("Luna-only browser turns verify selector absence instead of opening an effo
       modelId: string,
       reasoning: string,
       capabilities: { localToolsEnabled: boolean; solAvailable: boolean; proAvailable: boolean },
+      signal: AbortSignal,
       captureDiagnostic: (checkpoint: string) => Promise<void>,
     ): Promise<{ displayLabel: string; uiEffortIndex: number | null }>;
   }).selectModelAndEffort;
@@ -962,7 +972,7 @@ test("Luna-only browser turns verify selector absence instead of opening an effo
     localToolsEnabled: true,
     solAvailable: false,
     proAvailable: false,
-  }, async checkpoint => { checkpoints.push(checkpoint); });
+  }, new AbortController().signal, async checkpoint => { checkpoints.push(checkpoint); });
 
   expect(mode).toMatchObject({ displayLabel: "Luna", uiEffortIndex: null });
   expect(checkpoints).toEqual(["luna-default-confirmed"]);
@@ -974,16 +984,16 @@ test("effort selection handles the known ChatGPT rate-limit dialog before backgr
   const selectionEnd = workerSource.indexOf("private async activeComposer", selectionStart);
   const selectionSource = workerSource.slice(selectionStart, selectionEnd);
   const guard = selectionSource.indexOf("throwIfChatGptRateLimitDialog(page)");
-  const activation = selectionSource.indexOf("currentEffort.click({ force: true })");
+  const activation = selectionSource.indexOf("control.click({ force: true");
 
   expect(workerSource).toContain("Too many requests");
   expect(workerSource).toContain("making requests too quickly");
   expect(guard).toBeGreaterThan(-1);
   expect(activation).toBeGreaterThan(guard);
-  expect(selectionSource).not.toContain('currentEffort.press("Enter")');
-  expect(selectionSource).not.toContain("currentEffort.evaluate(");
-  expect(selectionSource).toContain('effortChoice.press("Enter")');
-  expect(selectionSource).not.toContain("effortChoice.click(");
+  expect(selectionSource).not.toContain('control.press("Enter"');
+  expect(selectionSource).toContain("control.click({ force: true");
+  expect(selectionSource).toContain('choices.nth(desired).press("Enter"');
+  expect(selectionSource).not.toContain("choices.nth(desired).click(");
   expect(selectionSource).not.toContain("is unavailable");
 });
 
@@ -1167,8 +1177,9 @@ test.each([
 test("effort selection stops as soon as ChatGPT reports an expired session", async () => {
   const neverVisible = new Promise<void>(() => {});
   const effortControl = {
-    last() { return this; },
-    waitFor: async () => await neverVisible,
+    filter() { return this; },
+    count: async () => 0,
+    first() { return this; },
   };
   const composerForm = { locator: () => effortControl };
   const composer = { locator: () => composerForm };
@@ -1190,6 +1201,7 @@ test("effort selection stops as soon as ChatGPT reports an expired session", asy
       modelId: string,
       reasoning: string,
       capabilities: { localToolsEnabled: boolean; solAvailable: boolean; proAvailable: boolean },
+      abortSignal: AbortSignal,
     ): Promise<unknown>;
   }).selectModelAndEffort;
 
@@ -1201,7 +1213,7 @@ test("effort selection stops as soon as ChatGPT reports an expired session", asy
     localToolsEnabled: true,
     solAvailable: true,
     proAvailable: true,
-  });
+  }, new AbortController().signal);
   const result = await Promise.race([
     selection.catch(error => error),
     new Promise(resolve => setTimeout(() => resolve("still waiting"), 100)),
@@ -1218,8 +1230,9 @@ test("effort selection stops as soon as ChatGPT reports an expired session", asy
 test("effort menu waiting stops when ChatGPT reports an expired session", async () => {
   const neverVisible = new Promise<void>(() => {});
   const effortControl = {
-    last() { return this; },
-    waitFor: async () => {},
+    filter() { return this; },
+    count: async () => 1,
+    first() { return this; },
     getAttribute: async () => "true",
   };
   const composerForm = { locator: () => effortControl };
@@ -1254,6 +1267,7 @@ test("effort menu waiting stops when ChatGPT reports an expired session", async 
       modelId: string,
       reasoning: string,
       capabilities: { localToolsEnabled: boolean; solAvailable: boolean; proAvailable: boolean },
+      abortSignal: AbortSignal,
     ): Promise<unknown>;
   }).selectModelAndEffort;
 
@@ -1271,7 +1285,7 @@ test("effort menu waiting stops when ChatGPT reports an expired session", async 
     localToolsEnabled: true,
     solAvailable: true,
     proAvailable: true,
-  });
+  }, new AbortController().signal);
   const result = await Promise.race([
     selection.catch(error => error),
     new Promise(resolve => setTimeout(() => resolve("still waiting"), 400)),
@@ -1605,6 +1619,40 @@ test("routine browser diagnostics avoid screenshots unless full capture is reque
   expect(browserDiagnosticIncludesScreenshot("response-stalled-30s", false)).toBeTrue();
   expect(browserDiagnosticIncludesScreenshot("turn-failed", false)).toBeTrue();
   expect(browserDiagnosticIncludesScreenshot("send-ready", true)).toBeTrue();
+});
+
+test("browser stage diagnostics preserve every critical local checkpoint", () => {
+  const workerSource = readFileSync(new URL("../src/adapters/chatgpt-web/browser-worker.ts", import.meta.url), "utf8");
+  for (const checkpoint of [
+    "browser-page-acquired",
+    "temporary-chat-navigation-complete",
+    "composer-ready",
+    "session-verified",
+    "effort-control-ready",
+    "effort-menu-open-requested",
+    "effort-selected",
+    "connector-mention-triggered",
+    "connector-menu-visible",
+    "connector-menu-missing",
+    "connector-selected",
+    "prompt-attachment-complete",
+    "file-attachment-complete",
+    "send-ready",
+    "send-accepted",
+    "tool-confirmation-visible",
+    "response-visible",
+    "response-stalled-30s",
+    "turn-completed",
+    "turn-failed",
+  ]) {
+    expect(workerSource).toContain(`"${checkpoint}"`);
+  }
+  expect(workerSource).toContain('join(getConfigDir(), "diagnostics", "browser-turns")');
+  expect(workerSource).toContain("CHATGPT_BROWSER_DIAGNOSTIC_SCREENSHOT_TIMEOUT_MS = 1_000");
+  expect(workerSource).toContain('page.screenshot({');
+  expect(workerSource).toContain("effortSliders: rows(effortSliderSelector, 10)");
+  expect(workerSource).toContain("atomicWriteFile(join(this.directory, `${stem}.png`), screenshot)");
+  expect(workerSource).toContain("CHATGPT_BROWSER_DIAGNOSTIC_TRACE_LIMIT = 10");
 });
 
 test("visible DOM trace interleaves statuses and explicit intermediate commentary", () => {

--- a/tests/chatgpt-session.test.ts
+++ b/tests/chatgpt-session.test.ts
@@ -1,8 +1,12 @@
 import { expect, test } from "bun:test";
 import {
+  assertAuthenticatedChatGptPage,
+  CHATGPT_AUTHENTICATED_ACCOUNT_SELECTOR,
   CHATGPT_COMPOSER_SELECTOR,
+  CHATGPT_EFFORT_CANONICAL_MENU_SELECTOR,
   CHATGPT_EFFORT_CONTROL_SELECTOR,
   detectChatGptAccountCapabilities,
+  resolveChatGptEffortMenu,
 } from "../src/chatgpt-session";
 
 test("login keeps the established turn composer contract", () => {
@@ -14,15 +18,166 @@ test("login keeps the established turn composer contract", () => {
   expect(turnSelectors).not.toContain("form textarea[placeholder]");
 });
 
+type FakeNode = {
+  id?: string;
+  visible?: boolean;
+  semanticCount?: number;
+  attributes?: Record<string, string | null>;
+};
+
+function fakeLocator(nodes: FakeNode[]): any {
+  return {
+    filter: () => fakeLocator(nodes.filter(node => node.visible !== false)),
+    count: async () => nodes.length,
+    first: () => fakeLocator(nodes.slice(0, 1)),
+    getAttribute: async (name: string) => name === "id"
+      ? nodes[0]?.id ?? null
+      : nodes[0]?.attributes?.[name] ?? null,
+    locator: () => fakeLocator(Array.from(
+      { length: nodes[0]?.semanticCount ?? 0 },
+      () => ({ visible: true }),
+    )),
+  };
+}
+
+function effortMenuPage(entries: Record<string, FakeNode[]>): { page: any; selectors: string[] } {
+  const selectors: string[] = [];
+  return {
+    selectors,
+    page: {
+      locator(selector: string) {
+        selectors.push(selector);
+        return fakeLocator(entries[selector] ?? []);
+      },
+    },
+  };
+}
+
 test("the effort selector identifies the model slider instead of any composer menu button", () => {
   expect(CHATGPT_EFFORT_CONTROL_SELECTOR).toContain('[data-animated-slider-trigger="true"]');
   expect(CHATGPT_EFFORT_CONTROL_SELECTOR).toContain('[data-testid="model-switcher-dropdown-button"]');
   expect(CHATGPT_EFFORT_CONTROL_SELECTOR).not.toBe('button[aria-haspopup="menu"]');
 });
 
+test("current picker testid is resolved without consulting an unrelated global menu", async () => {
+  const target = { id: "current-picker", visible: true, semanticCount: 5 };
+  const unrelated = { id: "unrelated-menu", visible: true, semanticCount: 3 };
+  const { page, selectors } = effortMenuPage({
+    [CHATGPT_EFFORT_CANONICAL_MENU_SELECTOR]: [target],
+    '[role="menu"]': [unrelated],
+  });
+  const control = fakeLocator([{ attributes: {} }]);
+
+  const resolved = await resolveChatGptEffortMenu(page, control);
+  expect(await resolved?.getAttribute("id")).toBe("current-picker");
+  expect(selectors).toEqual([CHATGPT_EFFORT_CANONICAL_MENU_SELECTOR]);
+});
+
+test("legacy picker is accepted only through the effort control ownership relation", async () => {
+  const legacy = { id: "legacy-effort", visible: true, semanticCount: 3 };
+  const { page, selectors } = effortMenuPage({
+    '[id="legacy-effort"]': [legacy],
+  });
+  const control = fakeLocator([{ attributes: { "aria-controls": "legacy-effort" } }]);
+
+  const resolved = await resolveChatGptEffortMenu(page, control);
+  expect(await resolved?.getAttribute("id")).toBe("legacy-effort");
+  expect(selectors).toEqual(['[id="legacy-effort"]']);
+});
+
+test("unowned legacy and unrelated menus are ignored", async () => {
+  const unrelated = { id: "unrelated", visible: true, semanticCount: 3 };
+  const { page, selectors } = effortMenuPage({
+    '[role="menu"]': [unrelated],
+  });
+  const control = fakeLocator([{ attributes: {} }]);
+
+  expect(await resolveChatGptEffortMenu(page, control)).toBeUndefined();
+  expect(selectors).toEqual([CHATGPT_EFFORT_CANONICAL_MENU_SELECTOR]);
+});
+
+test("multiple canonical or owned effort menus fail closed", async () => {
+  const duplicatePage = effortMenuPage({
+    [CHATGPT_EFFORT_CANONICAL_MENU_SELECTOR]: [
+      { visible: true, semanticCount: 3 },
+      { visible: true, semanticCount: 3 },
+    ],
+  }).page;
+  await expect(resolveChatGptEffortMenu(duplicatePage, fakeLocator([{ attributes: {} }])))
+    .rejects.toThrow("ambiguous");
+
+  const ownedPage = effortMenuPage({}).page;
+  await expect(resolveChatGptEffortMenu(ownedPage, fakeLocator([{
+    attributes: { "aria-controls": "first second" },
+  }]))) .rejects.toThrow("owns multiple");
+});
+
+test("an owned node is not a picker until effort semantics hydrate", async () => {
+  const { page } = effortMenuPage({
+    '[id="hydrating-picker"]': [{ visible: true, semanticCount: 0 }],
+  });
+  const control = fakeLocator([{ attributes: { "aria-owns": "hydrating-picker" } }]);
+  expect(await resolveChatGptEffortMenu(page, control)).toBeUndefined();
+});
+
+test("authentication requires both the current composer and an authenticated account control", async () => {
+  expect(CHATGPT_COMPOSER_SELECTOR.split(", ")).toContain("#prompt-textarea");
+  expect(CHATGPT_AUTHENTICATED_ACCOUNT_SELECTOR.split(", "))
+    .toContain('[data-testid="accounts-profile-button"][role="button"]');
+  expect(CHATGPT_AUTHENTICATED_ACCOUNT_SELECTOR)
+    .not.toContain('button[data-testid="accounts-profile-button"]');
+
+  const observedSelectors: string[] = [];
+  const visiblePage = {
+    locator(selector: string) {
+      observedSelectors.push(selector);
+      return {
+        count: async () => selector === CHATGPT_COMPOSER_SELECTOR
+          || selector === CHATGPT_AUTHENTICATED_ACCOUNT_SELECTOR ? 1 : 0,
+        nth: () => ({ isVisible: async () => true }),
+      };
+    },
+  };
+  await expect(assertAuthenticatedChatGptPage(visiblePage as never)).resolves.toBeUndefined();
+  expect(observedSelectors).toEqual([
+    CHATGPT_COMPOSER_SELECTOR,
+    CHATGPT_AUTHENTICATED_ACCOUNT_SELECTOR,
+  ]);
+
+  const hiddenPage = {
+    locator: () => ({
+      count: async () => 1,
+      nth: () => ({ isVisible: async () => false }),
+    }),
+  };
+  await expect(assertAuthenticatedChatGptPage(hiddenPage as never))
+    .rejects.toThrow("no visible composer is present");
+
+  const missingPage = {
+    locator: () => ({
+      count: async () => 0,
+      nth: () => ({ isVisible: async () => false }),
+    }),
+  };
+  await expect(assertAuthenticatedChatGptPage(missingPage as never))
+    .rejects.toThrow("no visible composer is present");
+
+  const guestPage = {
+    locator: (selector: string) => ({
+      count: async () => selector === CHATGPT_COMPOSER_SELECTOR ? 1 : 0,
+      nth: () => ({ isVisible: async () => true }),
+    }),
+  };
+  await expect(assertAuthenticatedChatGptPage(guestPage as never))
+    .rejects.toThrow("no authenticated account control is present");
+});
+
 test("a complete authenticated composer with no effort selector is Luna-only", async () => {
   const effortButton = {
+    filter() { return this; },
+    first() { return this; },
     last() { return this; },
+    count: async () => 0,
     isVisible: async () => false,
   };
   const composerForm = {
@@ -31,6 +186,7 @@ test("a complete authenticated composer with no effort selector is Luna-only", a
   };
   const composer = {
     filter() { return this; },
+    first() { return this; },
     last() { return this; },
     count: async () => 1,
     isVisible: async () => true,
@@ -50,7 +206,13 @@ test("a complete authenticated composer with no effort selector is Luna-only", a
 test("a transient effort control does not turn a Luna-only account into Sol", async () => {
   let visibilityReads = 0;
   const effortButton = {
+    filter() { return this; },
+    first() { return this; },
     last() { return this; },
+    count: async () => {
+      visibilityReads += 1;
+      return visibilityReads === 1 ? 1 : 0;
+    },
     isVisible: async () => {
       visibilityReads += 1;
       return visibilityReads === 1;
@@ -62,6 +224,7 @@ test("a transient effort control does not turn a Luna-only account into Sol", as
   };
   const composers = {
     filter() { return this; },
+    first() { return this; },
     last() { return this; },
     count: async () => 1,
     locator: () => composerForm,

--- a/tests/chatgpt-web-harness.test.ts
+++ b/tests/chatgpt-web-harness.test.ts
@@ -2,7 +2,7 @@ import { afterAll, describe, expect, test } from "bun:test";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { buildResponseJSON } from "../src/bridge";
@@ -24,8 +24,12 @@ import { parseRequest } from "../src/responses/parser";
 import type { AdapterEvent, CodexParsedRequest, CodexProviderConfig, CodexTool } from "../src/types";
 
 const tempRoot = join(tmpdir(), `codex-chatgpt-web-harness-${process.pid}-${Date.now()}`);
+const brokerRoot = mkdtempSync(join(tmpdir(), "cgw-h-"));
 mkdirSync(tempRoot, { recursive: true });
-afterAll(() => rmSync(tempRoot, { recursive: true, force: true }));
+afterAll(() => {
+  rmSync(tempRoot, { recursive: true, force: true });
+  rmSync(brokerRoot, { recursive: true, force: true });
+});
 
 const tools: CodexTool[] = [
   { name: "exec", description: "Run nested Codex tools", parameters: {}, freeform: true },
@@ -46,7 +50,7 @@ const browserOnlyCapabilities = { localToolsEnabled: false, solAvailable: true, 
 function brokerTestEndpoint(name: string): string {
   return process.platform === "win32"
     ? defaultBrokerEndpoint(join(tmpdir(), name), "win32")
-    : join(tmpdir(), `${name}.sock`);
+    : join(brokerRoot, `${name}.sock`);
 }
 
 interface GatewayProgramCall {
@@ -54,27 +58,43 @@ interface GatewayProgramCall {
   input: unknown;
 }
 
+interface GatewayProgramOptions {
+  descriptions?: Record<string, string>;
+  invoke?: (name: string, input: unknown) => Promise<unknown>;
+  textOutput?: unknown[];
+}
+
+const escalationCapableExecDescription = `exec tool declaration:
+declare const tools: { exec_command(args: {
+  justification?: string;
+  sandbox_permissions?: "use_default" | "require_escalated";
+}): Promise<unknown>; };`;
+
 async function executeGatewayProgram(
   program: string,
   availableToolNames: string[],
   calls: GatewayProgramCall[],
+  options: GatewayProgramOptions = {},
 ): Promise<void> {
   const nestedTools = Object.fromEntries(availableToolNames.map(name => [
     name,
     async (input: unknown) => {
       calls.push({ name, input });
-      return { output: name, exit_code: 0 };
+      return options.invoke
+        ? await options.invoke(name, input)
+        : { output: name, exit_code: 0 };
     },
   ]));
   const AsyncFunction = Object.getPrototypeOf(async () => {}).constructor as new (
     ...args: string[]
   ) => (...values: unknown[]) => Promise<void>;
   const execute = new AsyncFunction("tools", "ALL_TOOLS", "text", "image", "audio", "generatedImage", program);
+  const emitText = (value: unknown): void => { options.textOutput?.push(value); };
   const ignoreOutput = (_value: unknown): void => {};
   await execute(
     nestedTools,
-    availableToolNames.map(name => ({ name, description: `${name} test tool` })),
-    ignoreOutput,
+    availableToolNames.map(name => ({ name, description: options.descriptions?.[name] ?? `${name} test tool` })),
+    emitText,
     ignoreOutput,
     ignoreOutput,
     ignoreOutput,
@@ -162,6 +182,109 @@ function toolResult(value: Record<string, unknown>): BrokerToolResult {
     content: [{ type: "text", text: JSON.stringify(value) }],
     structuredContent: value,
   };
+}
+
+function textToolResult(text: string, isError = false): BrokerToolResult {
+  return {
+    content: [{ type: "text", text }],
+    ...(isError ? { isError: true } : {}),
+  };
+}
+
+function pendingToolResult(cellId: string): BrokerToolResult {
+  return textToolResult(`Script running with cell ID ${cellId}\nWall time 0.1 seconds\nOutput:\n`);
+}
+
+function gatewayOuterResult(result: Record<string, unknown>): BrokerToolResult {
+  return textToolResult(
+    `Script completed\nWall time 0.1 seconds\nOutput:\n${JSON.stringify({
+      protocol: "codex_exec_gateway_result_v1",
+      result,
+    })}`,
+  );
+}
+
+function gatewayOuterFinalResult(result: Record<string, unknown>): BrokerToolResult {
+  return textToolResult(
+    `Script completed\nWall time 0.1 seconds\nProcess exited with code 0\nFinal output:\n${JSON.stringify({
+      protocol: "codex_exec_gateway_result_v1",
+      result,
+    })}`,
+  );
+}
+
+function gatewayCommandEnvironment(waitAvailable = true) {
+  const environment = extractChatGptTurnEnvironment(parsed(environmentXml));
+  environment.tools = [
+    { name: "exec", description: "Run nested Codex tools", parameters: {}, freeform: true },
+    ...(waitAvailable
+      ? [{ name: "wait", description: "Wait for an outer exec cell", parameters: { type: "object" } } satisfies CodexTool]
+      : []),
+  ];
+  return environment;
+}
+
+function directCommandEnvironment() {
+  const environment = extractChatGptTurnEnvironment(parsed(environmentXml));
+  environment.tools = [
+    { name: "exec_command", description: "Run command", parameters: { type: "object" } },
+    { name: "wait", description: "Wait for an outer exec cell", parameters: { type: "object" } },
+  ];
+  return environment;
+}
+
+function realAdditionalToolsEnvironment() {
+  const additionalTools = JSON.parse(readFileSync(
+    join(import.meta.dir, "fixtures/real-additional-tools.json"),
+    "utf8",
+  ));
+  const request = parseRequest({
+    model: CHATGPT_WEB_MODEL_ID,
+    instructions: environmentXml,
+    input: [additionalTools],
+  });
+  return extractChatGptTurnEnvironment(request);
+}
+
+async function openMcpHarness(
+  name: string,
+  environment = gatewayCommandEnvironment(),
+  ttlMs: number | undefined = 60_000,
+) {
+  const socketPath = brokerTestEndpoint(`${name}-${process.pid}-${Date.now()}`);
+  const broker = TurnBroker.forSocket(socketPath);
+  const token = await broker.register(environment, ttlMs);
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: ["src/cli.ts", "mcp", "--broker-socket", socketPath],
+    cwd: process.cwd(),
+    stderr: "pipe",
+  });
+  const client = new Client({ name: "codex-chatgpt-web-approval-result-test", version: "1.0.0" });
+  await client.connect(transport);
+  const call = (toolName: string, args: Record<string, unknown>, signal?: AbortSignal) => client.callTool(
+    { name: toolName, arguments: { turn_token: token, ...args } },
+    undefined,
+    signal ? { signal } : undefined,
+  );
+  return {
+    broker,
+    call,
+    client,
+    token,
+    close: async () => {
+      await client.close().catch(() => {});
+      broker.revoke(token);
+      await broker.close();
+    },
+  };
+}
+
+async function expectNoQueuedTool(broker: TurnBroker, token: string): Promise<void> {
+  const abort = new AbortController();
+  const waiting = broker.nextToolBatch(token, abort.signal);
+  setTimeout(() => abort.abort(), 25);
+  await expect(waiting).rejects.toThrow("aborted");
 }
 
 function canonicalJson(value: unknown): string {
@@ -1479,6 +1602,119 @@ describe("ChatGPT outer-native harness v4", () => {
     }
   });
 
+  test("delivers an outstanding native result before finalizing an already settled browser outcome", async () => {
+    const socketPath = brokerTestEndpoint(`cgw-v4-settled-race-${process.pid}-${Date.now()}`);
+    const provider: CodexProviderConfig = {
+      adapter: "chatgpt-web",
+      baseUrl: "browser://chatgpt-settled-race-test",
+      chatgptWeb: {
+        brokerSocketPath: socketPath,
+        turnTimeoutMs: 30_000,
+        localToolsEnabled: true,
+        solAvailable: true,
+        proAvailable: true,
+      },
+    };
+    const worker = ChatGptBrowserWorker.forProvider(provider);
+    const originalRun = worker.run.bind(worker);
+    let browserStarts = 0;
+    let nativeExecCalls = 0;
+    let releaseBrowser!: () => void;
+    let browserReturned!: () => void;
+    let settledTurnToken = "";
+    const browserRelease = new Promise<void>(resolveRelease => { releaseBrowser = resolveRelease; });
+    const browserFinished = new Promise<void>(resolveFinished => { browserReturned = resolveFinished; });
+    let nativeResultPromise: Promise<BrokerToolResult> | undefined;
+    (worker as unknown as { run: (turn: BrowserTurn) => Promise<string> }).run = async turn => {
+      browserStarts += 1;
+      const prepared = await turn.prepare();
+      try {
+        const token = prepared.text.match(/turn_token (turn_[A-Za-z0-9_-]+)/)?.[1];
+        if (!token) throw new Error("turn token missing from compiled prompt");
+        settledTurnToken = token;
+        const claimed = await callTurnBroker<{ bindingId: string }>(socketPath, { method: "claim", token });
+        nativeExecCalls += 1;
+        nativeResultPromise = callTurnBroker<BrokerToolResult>(socketPath, {
+          method: "invoke",
+          bindingId: claimed.bindingId,
+          wireName: "exec_command",
+          freeform: false,
+          arguments: { cmd: "pwd", workdir: tempRoot },
+        }, 30_000);
+        await browserRelease;
+        const answer = "Browser settled while the native result was outstanding.";
+        turn.onTextDelta(answer);
+        browserReturned();
+        return answer;
+      } finally {
+        prepared.release();
+      }
+    };
+
+    const adapter = createChatGptWebAdapter(provider);
+    const firstRequest = rawWireRequest(environmentXml);
+    const firstEvents: AdapterEvent[] = [];
+    try {
+      await adapter.runTurn!(firstRequest, { headers: new Headers() }, event => firstEvents.push(event));
+      const callStart = firstEvents.find(
+        (event): event is Extract<AdapterEvent, { type: "tool_call_start" }> => event.type === "tool_call_start",
+      );
+      expect(callStart?.name).toBe("exec_command");
+      expect(firstEvents.at(-1)).toMatchObject({ type: "done", stopReason: "tool_use", endTurn: false });
+      expect(browserStarts).toBe(1);
+
+      releaseBrowser();
+      await browserFinished;
+      await Bun.sleep(0);
+
+      const denial = {
+        role: "toolResult" as const,
+        toolCallId: callStart!.id,
+        toolName: "exec_command",
+        content: "Script failed\nWall time 0.1 seconds\nError: rejected by user",
+        isError: true,
+        timestamp: Date.now(),
+      };
+      const secondRequest = rawWireRequest(environmentXml);
+      secondRequest.context.messages.push({
+        role: "assistant",
+        content: [{ type: "toolCall", id: callStart!.id, name: "exec_command", arguments: { cmd: "pwd", workdir: tempRoot } }],
+        timestamp: denial.timestamp - 1,
+      }, denial);
+      ((secondRequest._rawBody as { input: unknown[] }).input).push(
+        {
+          type: "function_call",
+          call_id: callStart!.id,
+          name: "exec_command",
+          arguments: JSON.stringify({ cmd: "pwd", workdir: tempRoot }),
+        },
+        {
+          type: "function_call_output",
+          call_id: callStart!.id,
+          output: denial.content,
+        },
+      );
+
+      const secondEvents: AdapterEvent[] = [];
+      await adapter.runTurn!(secondRequest, { headers: new Headers() }, event => secondEvents.push(event));
+      expect(await nativeResultPromise).toMatchObject({ isError: true });
+      expect(nativeExecCalls).toBe(1);
+      expect(secondEvents.at(-1)).toMatchObject({ type: "done", stopReason: "stop", endTurn: true });
+      expect(secondEvents.some(event => event.type === "done" && event.stopReason === "tool_use")).toBe(false);
+      expect(browserStarts).toBe(1);
+      await expect(callTurnBroker(socketPath, { method: "claim", token: settledTurnToken }))
+        .rejects.toThrow("has already finished");
+
+      const replay: AdapterEvent[] = [];
+      await adapter.runTurn!(secondRequest, { headers: new Headers() }, event => replay.push(event));
+      expect(replay).toEqual(secondEvents);
+      expect(browserStarts).toBe(1);
+    } finally {
+      (worker as unknown as { run: (turn: BrowserTurn) => Promise<string> }).run = originalRun;
+      await TurnBroker.forSocket(socketPath).close();
+    }
+  }, 30_000);
+
   test("replaces the active browser response after Codex compacts mid-tool-loop", async () => {
     const socketPath = brokerTestEndpoint(`cgw-h3-adapter-${process.pid}-${Date.now()}`);
     const provider: CodexProviderConfig = {
@@ -1809,6 +2045,823 @@ describe("ChatGPT outer-native harness v4", () => {
     }
   });
 
+  test.each([
+    {
+      name: "success",
+      outer: toolResult({ output: tempRoot, exit_code: 0 }),
+      isError: false,
+    },
+    {
+      name: "isError denial",
+      outer: textToolResult("command rejected by user", true),
+      isError: true,
+    },
+    {
+      name: "failure",
+      outer: toolResult({ output: "failed", exit_code: 2 }),
+      isError: true,
+    },
+    {
+      name: "cancellation",
+      outer: { ...toolResult({ status: "cancelled", output: "cancelled" }) },
+      isError: true,
+    },
+    {
+      name: "valid session result",
+      outer: toolResult({ session_id: 42, output: "still running" }),
+      isError: false,
+    },
+    {
+      name: "pending-looking direct result",
+      outer: pendingToolResult("direct-cell"),
+      isError: true,
+    },
+    {
+      name: "gateway failure-looking direct text",
+      outer: textToolResult("Script failed\nWall time 0.1 seconds\nError: ordinary direct output"),
+      isError: true,
+    },
+  ])("keeps direct command path semantics for $name", async ({ outer, isError }) => {
+    const harness = await openMcpHarness("cgw-v4-direct-result", directCommandEnvironment());
+    try {
+      const execPromise = harness.call("codex_exec", { cmd: "pwd", workdir: tempRoot });
+      const requests = await harness.broker.nextToolBatch(harness.token);
+      expect(requests).toHaveLength(1);
+      expect(requests[0]).toMatchObject({ wireName: "exec_command", freeform: false });
+      harness.broker.completeTool(harness.token, requests[0]!.callId, outer);
+      const response = await execPromise;
+      expect(response.isError === true).toBe(isError);
+      await expectNoQueuedTool(harness.broker, harness.token);
+    } finally {
+      await harness.close();
+    }
+  }, 30_000);
+
+  test.each([
+    ["terminal plus session", { status: "completed", session_id: 42 }],
+    ["exit plus session", { exit_code: 0, session_id: 42 }],
+    ["pending cell plus session", { status: "running", cell_id: "cell-one", session_id: 42 }],
+    ["failure plus zero exit", { status: "failed", exit_code: 0 }],
+    ["conflicting terminal states", { status: "completed", state: "failed" }],
+  ])("fails closed on contradictory direct command state: %s", async (_name, state) => {
+    const harness = await openMcpHarness("cgw-v4-direct-malformed", directCommandEnvironment());
+    try {
+      const execPromise = harness.call("codex_exec", { cmd: "pwd" });
+      const [request] = await harness.broker.nextToolBatch(harness.token);
+      harness.broker.completeTool(harness.token, request!.callId, toolResult(state));
+      const response = await execPromise;
+      expect(response.isError).toBe(true);
+      expect(JSON.stringify(response.content)).toContain("UNRESOLVED_UNKNOWN_OUTCOME");
+      const alternate = await harness.call("codex_exec", { cmd: "git status --short" });
+      expect(alternate.isError).toBe(true);
+      expect(JSON.stringify(alternate.content)).toContain("already active");
+      await expectNoQueuedTool(harness.broker, harness.token);
+    } finally {
+      await harness.close();
+    }
+  }, 30_000);
+
+  test("rejects multiple advertised direct command ABIs before dispatch", async () => {
+    const environment = directCommandEnvironment();
+    environment.tools.push({ name: "shell_command", description: "Legacy command", parameters: { type: "object" } });
+    const harness = await openMcpHarness("cgw-v4-direct-ambiguous", environment);
+    try {
+      const response = await harness.call("codex_exec", { cmd: "pwd" });
+      expect(response.isError).toBe(true);
+      expect(JSON.stringify(response.content)).toContain("multiple native command tools");
+      await expectNoQueuedTool(harness.broker, harness.token);
+    } finally {
+      await harness.close();
+    }
+  }, 30_000);
+
+  test("rejects duplicate advertised direct command ABI before dispatch", async () => {
+    const environment = directCommandEnvironment();
+    environment.tools.push({ name: "exec_command", description: "Duplicate command", parameters: { type: "object" } });
+    const harness = await openMcpHarness("cgw-v4-direct-duplicate", environment);
+    try {
+      const response = await harness.call("codex_exec", { cmd: "pwd" });
+      expect(response.isError).toBe(true);
+      expect(JSON.stringify(response.content)).toContain("duplicate native tools: exec_command");
+      await expectNoQueuedTool(harness.broker, harness.token);
+    } finally {
+      await harness.close();
+    }
+  }, 30_000);
+
+  test("routes a parsed nested custom exec only through the dedicated command bridge", async () => {
+    const environment = realAdditionalToolsEnvironment();
+    environment.tools.push({
+      namespace: "shadow",
+      name: "exec",
+      description: "Namespaced command alias",
+      parameters: { type: "object" },
+      freeform: true,
+    });
+    environment.tools.push({
+      name: " exec ",
+      description: "Whitespace-padded command alias",
+      parameters: { type: "object" },
+      freeform: true,
+    });
+    for (const name of ["exec-command", "exec.command"]) {
+      environment.tools.push({
+        name,
+        description: "Normalized command alias",
+        parameters: { type: "object" },
+      });
+    }
+    const harness = await openMcpHarness("cgw-v4-parser-custom-exec", environment);
+    try {
+      expect(environment.tools.find(tool => tool.name === "exec" && !tool.namespace)).toMatchObject({
+        name: "exec",
+        freeform: true,
+      });
+
+      const execPromise = harness.call("codex_exec", { cmd: "pwd", workdir: tempRoot });
+      const [request] = await harness.broker.nextToolBatch(harness.token);
+      expect(request).toMatchObject({ wireName: "exec", freeform: true });
+      harness.broker.completeTool(
+        harness.token,
+        request!.callId,
+        gatewayOuterResult({ output: tempRoot, exit_code: 0 }),
+      );
+      expect((await execPromise).isError).not.toBe(true);
+
+      for (const wireName of ["exec", "shadow__exec"]) {
+        const generic = await harness.call("codex_tool_call", {
+          wire_name: wireName,
+          input: JSON.stringify({
+            cmd: "alternate execution",
+            sandbox_permissions: "require_escalated",
+            justification: "generic escalation injection",
+          }),
+        });
+        expect(generic.isError).toBe(true);
+        expect(JSON.stringify(generic.content)).toContain("reserved for codex_exec");
+      }
+      const dotAlias = await harness.call("codex_tool_call", {
+        wire_name: "shadow.exec",
+        input: "alternate execution",
+      });
+      expect(dotAlias.isError).toBe(true);
+      expect(JSON.stringify(dotAlias.content)).toContain("not available in this turn");
+      const paddedAlias = await harness.call("codex_tool_call", {
+        wire_name: " exec ",
+        input: "alternate execution",
+      });
+      expect(paddedAlias.isError).toBe(true);
+      expect(JSON.stringify(paddedAlias.content)).toContain("wire tool name must be canonical");
+      for (const wireName of ["exec-command", "exec.command"]) {
+        const normalizedAlias = await harness.call("codex_tool_call", {
+          wire_name: wireName,
+          arguments: {
+            sandbox_permissions: "require_escalated",
+            justification: "generic alias escalation injection",
+          },
+        });
+        expect(normalizedAlias.isError).toBe(true);
+        expect(JSON.stringify(normalizedAlias.content)).toContain("reserved for codex_exec");
+      }
+      await expectNoQueuedTool(harness.broker, harness.token);
+    } finally {
+      await harness.close();
+    }
+  }, 30_000);
+
+  test.each([
+    {
+      name: "success",
+      outer: gatewayOuterResult({ output: "/working", exit_code: 0 }),
+      isError: false,
+    },
+    {
+      name: "legacy wrapper success",
+      outer: gatewayOuterFinalResult({ output: "/working", exit_code: 0 }),
+      isError: false,
+    },
+    {
+      name: "denial",
+      outer: gatewayOuterResult({ status: "denied", output: "rejected by user" }),
+      isError: true,
+    },
+    {
+      name: "failure",
+      outer: gatewayOuterResult({ output: "failed", exit_code: 2 }),
+      isError: true,
+    },
+    {
+      name: "cancellation",
+      outer: gatewayOuterResult({ status: "cancelled", output: "cancelled" }),
+      isError: true,
+    },
+  ])("classifies initial gateway terminal $name without calling wait", async ({ outer, isError }) => {
+    const harness = await openMcpHarness("cgw-v4-gateway-initial");
+    try {
+      const execPromise = harness.call("codex_exec", { cmd: "pwd" });
+      const originalBatch = await harness.broker.nextToolBatch(harness.token);
+      expect(originalBatch).toHaveLength(1);
+      const original = originalBatch[0]!;
+      expect(original).toMatchObject({ wireName: "exec", freeform: true });
+      expect(original.input?.match(/await nativeCommand\(/g)).toHaveLength(1);
+      harness.broker.completeTool(harness.token, original.callId, outer);
+      const response = await execPromise;
+      expect(response.isError === true).toBe(isError);
+      await expectNoQueuedTool(harness.broker, harness.token);
+    } finally {
+      await harness.close();
+    }
+  }, 30_000);
+
+  test.each([
+    ["failure", "Script failed\nWall time 0.1 seconds\nError: outer wrapper failed"],
+    ["cancellation", "Script terminated\nWall time 0.1 seconds\nTermination requested"],
+  ])("quarantines an initial bare gateway wrapper %s without redispatch", async (_name, text) => {
+    const harness = await openMcpHarness("cgw-v4-gateway-initial-wrapper-unknown");
+    try {
+      const execPromise = harness.call("codex_exec", { cmd: "pwd" });
+      const [original] = await harness.broker.nextToolBatch(harness.token);
+      harness.broker.completeTool(harness.token, original!.callId, textToolResult(text, true));
+
+      const response = await execPromise;
+      expect(response.isError).toBe(true);
+      expect(JSON.stringify(response.content)).toContain("UNRESOLVED_UNKNOWN_OUTCOME");
+      const alternate = await harness.call("codex_exec", { cmd: "git status --short" });
+      expect(alternate.isError).toBe(true);
+      expect(JSON.stringify(alternate.content)).toContain("already active");
+      await expectNoQueuedTool(harness.broker, harness.token);
+    } finally {
+      await harness.close();
+    }
+  }, 30_000);
+
+  test("quarantines a sessionless initial UNKNOWN without redispatch or unrelated command overlap", async () => {
+    const harness = await openMcpHarness("cgw-v4-gateway-initial-unknown");
+    try {
+      const firstExec = harness.call("codex_exec", { cmd: "pwd" });
+      const [original] = await harness.broker.nextToolBatch(harness.token);
+      harness.broker.completeTool(
+        harness.token,
+        original!.callId,
+        gatewayOuterResult({ output: "/ambiguous-without-terminal-discriminant" }),
+      );
+
+      const firstResponse = await firstExec;
+      expect(firstResponse.isError).toBe(true);
+      expect(JSON.stringify(firstResponse.content)).toContain("UNRESOLVED_UNKNOWN_OUTCOME");
+      expect(JSON.stringify(firstResponse.content)).toContain("outcome remains UNKNOWN");
+      await expectNoQueuedTool(harness.broker, harness.token);
+
+      const retry = await harness.call("codex_exec", { cmd: "pwd" });
+      expect(retry.isError).toBe(true);
+      expect(JSON.stringify(retry.content)).toContain("outcome remains UNKNOWN");
+      await expectNoQueuedTool(harness.broker, harness.token);
+
+      const unrelatedExec = await harness.call("codex_exec", { cmd: "git status --short" });
+      expect(unrelatedExec.isError).toBe(true);
+      expect(JSON.stringify(unrelatedExec.content)).toContain("already active");
+      const generic = await harness.call("codex_tool_call", { wire_name: "exec", input: "alternate execution" });
+      expect(generic.isError).toBe(true);
+      expect(JSON.stringify(generic.content)).toContain("reserved for codex_exec");
+      await expectNoQueuedTool(harness.broker, harness.token);
+    } finally {
+      await harness.close();
+    }
+  }, 30_000);
+
+  test.each([
+    {
+      name: "success",
+      waited: gatewayOuterResult({ output: "/working", exit_code: 0 }),
+      isError: false,
+    },
+    {
+      name: "denial",
+      waited: gatewayOuterResult({ status: "denied", output: "rejected by user" }),
+      isError: true,
+    },
+    {
+      name: "failure",
+      waited: gatewayOuterResult({ status: "failed", output: "failed" }),
+      isError: true,
+    },
+    {
+      name: "cancellation",
+      waited: gatewayOuterResult({ status: "cancelled", output: "cancelled" }),
+      isError: true,
+    },
+  ])("awaits one gateway pending result through one wait and returns terminal $name", async ({ waited, isError }) => {
+    const harness = await openMcpHarness("cgw-v4-gateway-pending");
+    try {
+      const execPromise = harness.call("codex_exec", { cmd: "pwd" });
+      const originalBatch = await harness.broker.nextToolBatch(harness.token);
+      expect(originalBatch).toHaveLength(1);
+      const original = originalBatch[0]!;
+      harness.broker.completeTool(harness.token, original.callId, pendingToolResult("cell-pending"));
+
+      const waitBatch = await harness.broker.nextToolBatch(harness.token);
+      expect(waitBatch).toHaveLength(1);
+      const wait = waitBatch[0]!;
+      expect(wait).toMatchObject({ wireName: "wait", freeform: false, arguments: { cell_id: "cell-pending" } });
+      harness.broker.completeTool(harness.token, wait.callId, waited);
+
+      const response = await execPromise;
+      expect(response.isError === true).toBe(isError);
+      expect(original.input?.match(/await nativeCommand\(/g)).toHaveLength(1);
+      await expectNoQueuedTool(harness.broker, harness.token);
+    } finally {
+      await harness.close();
+    }
+  }, 30_000);
+
+  test.each([
+    ["failure", "Script failed\nWall time 0.2 seconds\nError: outer wait wrapper failed"],
+    ["cancellation", "Script terminated\nWall time 0.2 seconds\nTermination requested"],
+  ])("keeps a gateway command quarantined after bare wait wrapper %s", async (_name, text) => {
+    const harness = await openMcpHarness("cgw-v4-gateway-wait-wrapper-unknown");
+    try {
+      const execPromise = harness.call("codex_exec", { cmd: "pwd" });
+      const [original] = await harness.broker.nextToolBatch(harness.token);
+      harness.broker.completeTool(harness.token, original!.callId, pendingToolResult("cell-wrapper-unknown"));
+      const [wait] = await harness.broker.nextToolBatch(harness.token);
+      harness.broker.completeTool(harness.token, wait!.callId, textToolResult(text, true));
+
+      const response = await execPromise;
+      expect(response.isError).toBe(true);
+      expect(JSON.stringify(response.content)).toContain("UNRESOLVED_UNKNOWN_OUTCOME");
+      const alternate = await harness.call("codex_exec", { cmd: "git status --short" });
+      expect(alternate.isError).toBe(true);
+      expect(JSON.stringify(alternate.content)).toContain("already active");
+      await expectNoQueuedTool(harness.broker, harness.token);
+    } finally {
+      await harness.close();
+    }
+  }, 30_000);
+
+  test("rejects duplicate and alternate native execution while the first gateway command is pending", async () => {
+    const environment = gatewayCommandEnvironment();
+    environment.tools.push({ name: "view_image", description: "View an image", parameters: { type: "object" } });
+    const harness = await openMcpHarness("cgw-v4-gateway-operation-lock", environment);
+    try {
+      const firstExec = harness.call("codex_exec", { cmd: "pwd" });
+      const [original] = await harness.broker.nextToolBatch(harness.token);
+      harness.broker.completeTool(harness.token, original!.callId, pendingToolResult("cell-operation-lock"));
+
+      const [wait] = await harness.broker.nextToolBatch(harness.token);
+      expect(wait).toMatchObject({ wireName: "wait", freeform: false, arguments: { cell_id: "cell-operation-lock" } });
+
+      const duplicate = harness.call("codex_exec", { cmd: "pwd" });
+      await expectNoQueuedTool(harness.broker, harness.token);
+      const alternate = await harness.call("codex_exec", { cmd: "git status --short" });
+      expect(alternate.isError).toBe(true);
+      expect(JSON.stringify(alternate.content)).toContain("codex_exec operation is already active");
+      const genericCommand = await harness.call("codex_tool_call", { wire_name: "exec", input: "alternate execution" });
+      expect(genericCommand.isError).toBe(true);
+      expect(JSON.stringify(genericCommand.content)).toContain("reserved for codex_exec");
+      environment.tools.push({
+        namespace: "functions",
+        name: "write_stdin",
+        description: "Continue a command",
+        parameters: { type: "object" },
+      });
+      const namespacedContinuation = await harness.call("codex_tool_call", {
+        wire_name: "functions__write_stdin",
+        arguments: { session_id: 1 },
+      });
+      expect(namespacedContinuation.isError).toBe(true);
+      expect(JSON.stringify(namespacedContinuation.content)).toContain("reserved for codex_exec");
+      const alternateNativeTool = await harness.call("codex_view_image", { path: "/tmp/nonexistent.png" });
+      expect(alternateNativeTool.isError).toBe(true);
+      expect(JSON.stringify(alternateNativeTool.content)).toContain("protected broker operation is already active");
+      await expectNoQueuedTool(harness.broker, harness.token);
+
+      harness.broker.completeTool(
+        harness.token,
+        wait!.callId,
+        gatewayOuterResult({ output: "/working", exit_code: 0 }),
+      );
+      const firstResponse = await firstExec;
+      expect(firstResponse.isError).not.toBe(true);
+      expect((await duplicate).isError).not.toBe(true);
+
+      const afterTerminal = await harness.call("codex_exec", { cmd: "pwd" });
+      expect(afterTerminal.isError).toBe(true);
+      expect(JSON.stringify(afterTerminal.content)).toContain("already been terminalized");
+      await expectNoQueuedTool(harness.broker, harness.token);
+
+      const unrelated = harness.call("codex_exec", { cmd: "git status --short" });
+      const [unrelatedRequest] = await harness.broker.nextToolBatch(harness.token);
+      harness.broker.completeTool(
+        harness.token,
+        unrelatedRequest!.callId,
+        gatewayOuterResult({ output: "", exit_code: 0 }),
+      );
+      expect((await unrelated).isError).not.toBe(true);
+    } finally {
+      await harness.close();
+    }
+  }, 30_000);
+
+  test("fails closed after an MCP process restart while a gateway operation is pending", async () => {
+    const harness = await openMcpHarness("cgw-v4-gateway-process-restart");
+    let replacementClient: Client | undefined;
+    try {
+      const escalationArgs = {
+        cmd: "pwd",
+        sandbox_permissions: "require_escalated",
+        justification: "Approve the same pending operation only",
+      };
+      const interruptedExec = harness.call("codex_exec", escalationArgs);
+      const interruptedSettlement = interruptedExec.catch(() => undefined);
+      const [original] = await harness.broker.nextToolBatch(harness.token);
+      expect(original?.input?.match(/await nativeCommand\(/g)).toHaveLength(1);
+      expect(original?.input).toContain('"sandbox_permissions":"require_escalated"');
+      harness.broker.completeTool(harness.token, original!.callId, pendingToolResult("cell-process-restart"));
+      const [wait] = await harness.broker.nextToolBatch(harness.token);
+      expect(wait).toMatchObject({ wireName: "wait", arguments: { cell_id: "cell-process-restart" } });
+
+      await harness.client.close();
+      await interruptedSettlement;
+
+      const replacementTransport = new StdioClientTransport({
+        command: process.execPath,
+        args: ["src/cli.ts", "mcp", "--broker-socket", harness.broker.socketPath],
+        cwd: process.cwd(),
+        stderr: "pipe",
+      });
+      replacementClient = new Client({ name: "codex-chatgpt-web-restart-test", version: "1.0.0" });
+      await replacementClient.connect(replacementTransport);
+      const resumedExec = replacementClient.callTool({
+        name: "codex_exec",
+        arguments: { turn_token: harness.token, ...escalationArgs },
+      });
+      await expectNoQueuedTool(harness.broker, harness.token);
+
+      harness.broker.completeTool(
+        harness.token,
+        wait!.callId,
+        gatewayOuterResult({ output: "/working", exit_code: 0 }),
+      );
+      expect((await resumedExec).isError).not.toBe(true);
+      const afterTerminalWithoutResponse = await replacementClient.callTool({
+        name: "codex_exec",
+        arguments: { turn_token: harness.token, ...escalationArgs },
+      });
+      expect(afterTerminalWithoutResponse.isError).toBe(true);
+      expect(JSON.stringify(afterTerminalWithoutResponse.content)).toContain(
+        "already been terminalized",
+      );
+      await expectNoQueuedTool(harness.broker, harness.token);
+
+      const unrelatedAfterLoss = replacementClient.callTool({
+        name: "codex_exec",
+        arguments: { turn_token: harness.token, cmd: "git status --short" },
+      });
+      const [unrelatedRequest] = await harness.broker.nextToolBatch(harness.token);
+      harness.broker.completeTool(
+        harness.token,
+        unrelatedRequest!.callId,
+        gatewayOuterResult({ output: "", exit_code: 0 }),
+      );
+      expect((await unrelatedAfterLoss).isError).not.toBe(true);
+    } finally {
+      await replacementClient?.close().catch(() => {});
+      await harness.close();
+    }
+  }, 30_000);
+
+  test("replays a terminal result after process restart without dispatching the command again", async () => {
+    const harness = await openMcpHarness("cgw-v4-gateway-terminal-process-restart");
+    let replacementClient: Client | undefined;
+    try {
+      const firstExec = harness.call("codex_exec", { cmd: "pwd" });
+      const [firstRequest] = await harness.broker.nextToolBatch(harness.token);
+      harness.broker.completeTool(harness.token, firstRequest!.callId, gatewayOuterResult({ output: "/first", exit_code: 0 }));
+      expect(JSON.stringify((await firstExec).content)).toContain("/first");
+
+      await harness.client.close();
+      const replacementTransport = new StdioClientTransport({
+        command: process.execPath,
+        args: ["src/cli.ts", "mcp", "--broker-socket", harness.broker.socketPath],
+        cwd: process.cwd(),
+        stderr: "pipe",
+      });
+      replacementClient = new Client({ name: "codex-chatgpt-web-fresh-restart-test", version: "1.0.0" });
+      await replacementClient.connect(replacementTransport);
+      const freshExec = await replacementClient.callTool({
+        name: "codex_exec",
+        arguments: { turn_token: harness.token, cmd: "pwd" },
+      });
+      expect(freshExec.isError).not.toBe(true);
+      expect(JSON.stringify(freshExec.content)).toContain("/first");
+      await expectNoQueuedTool(harness.broker, harness.token);
+
+      const repeatedAgain = await replacementClient.callTool({
+        name: "codex_exec",
+        arguments: { turn_token: harness.token, cmd: "pwd" },
+      });
+      expect(repeatedAgain.isError).toBe(true);
+      expect(JSON.stringify(repeatedAgain.content)).toContain("already been terminalized");
+      await expectNoQueuedTool(harness.broker, harness.token);
+    } finally {
+      await replacementClient?.close().catch(() => {});
+      await harness.close();
+    }
+  }, 30_000);
+
+  test.each([
+    ["substring", "prefix Script running with cell ID fake"],
+    ["incomplete envelope", "Script running with cell ID fake\nOutput without wall time"],
+    ["duplicated handle", "Script running with cell ID first\nScript running with cell ID second"],
+    ["unrelated text", "The report says Script running but no command exists"],
+    ["untagged current outer envelope", "Script completed\nWall time 0.1 seconds\nOutput:\n{\"output\":\"/working\",\"exit_code\":0}"],
+  ])("rejects malformed gateway pending text: %s", async (_name, text) => {
+    const harness = await openMcpHarness("cgw-v4-gateway-malformed-text");
+    try {
+      const execPromise = harness.call("codex_exec", { cmd: "pwd" });
+      const [original] = await harness.broker.nextToolBatch(harness.token);
+      harness.broker.completeTool(harness.token, original!.callId, textToolResult(text));
+      const response = await execPromise;
+      expect(response.isError).toBe(true);
+      expect(JSON.stringify(response.content)).toContain("unknown command state");
+      await expectNoQueuedTool(harness.broker, harness.token);
+    } finally {
+      await harness.close();
+    }
+  }, 30_000);
+
+  test.each([
+    ["missing cell", { status: "running" }],
+    ["conflicting state", { status: "running", state: "completed", cell_id: "cell-conflict" }],
+    ["alternate handle", { status: "running", cell_id: "cell-one", cellId: "cell-two" }],
+    ["invalid handle", { status: "running", cell_id: "cell with spaces" }],
+  ])("rejects malformed structured gateway pending: %s", async (_name, structuredContent) => {
+    const harness = await openMcpHarness("cgw-v4-gateway-malformed-structured");
+    try {
+      const execPromise = harness.call("codex_exec", { cmd: "pwd" });
+      const [original] = await harness.broker.nextToolBatch(harness.token);
+      harness.broker.completeTool(harness.token, original!.callId, {
+        content: [{ type: "text", text: "structured command state" }],
+        structuredContent,
+      });
+      const response = await execPromise;
+      expect(response.isError).toBe(true);
+      expect(JSON.stringify(response.content)).toContain("unknown command state");
+      await expectNoQueuedTool(harness.broker, harness.token);
+    } finally {
+      await harness.close();
+    }
+  }, 30_000);
+
+  test("rejects conflicting structured and text pending handles", async () => {
+    const harness = await openMcpHarness("cgw-v4-gateway-conflicting-handles");
+    try {
+      const execPromise = harness.call("codex_exec", { cmd: "pwd" });
+      const [original] = await harness.broker.nextToolBatch(harness.token);
+      harness.broker.completeTool(harness.token, original!.callId, {
+        content: pendingToolResult("cell-two").content,
+        structuredContent: { status: "running", cell_id: "cell-one" },
+      });
+      const response = await execPromise;
+      expect(response.isError).toBe(true);
+      expect(JSON.stringify(response.content)).toContain("unknown command state");
+      await expectNoQueuedTool(harness.broker, harness.token);
+    } finally {
+      await harness.close();
+    }
+  }, 30_000);
+
+  test("quarantines an isError result that contradicts a pending command state", async () => {
+    const harness = await openMcpHarness("cgw-v4-gateway-iserror-pending");
+    try {
+      const execPromise = harness.call("codex_exec", { cmd: "pwd" });
+      const [original] = await harness.broker.nextToolBatch(harness.token);
+      harness.broker.completeTool(harness.token, original!.callId, {
+        ...pendingToolResult("cell-iserror-pending"),
+        isError: true,
+      });
+      const response = await execPromise;
+      expect(response.isError).toBe(true);
+      expect(JSON.stringify(response.content)).toContain("UNRESOLVED_UNKNOWN_OUTCOME");
+      const alternate = await harness.call("codex_exec", { cmd: "git status --short" });
+      expect(alternate.isError).toBe(true);
+      expect(JSON.stringify(alternate.content)).toContain("already active");
+      await expectNoQueuedTool(harness.broker, harness.token);
+    } finally {
+      await harness.close();
+    }
+  }, 30_000);
+
+  test("fails closed when gateway pending has no advertised wait tool", async () => {
+    const harness = await openMcpHarness("cgw-v4-gateway-no-wait", gatewayCommandEnvironment(false));
+    try {
+      const execPromise = harness.call("codex_exec", { cmd: "pwd" });
+      const [original] = await harness.broker.nextToolBatch(harness.token);
+      harness.broker.completeTool(harness.token, original!.callId, pendingToolResult("cell-no-wait"));
+      const response = await execPromise;
+      expect(response.isError).toBe(true);
+      expect(JSON.stringify(response.content)).toContain("outer wait tool is unavailable");
+      const alternate = await harness.call("codex_exec", { cmd: "git status --short" });
+      expect(alternate.isError).toBe(true);
+      expect(JSON.stringify(alternate.content)).toContain("already active");
+      await expectNoQueuedTool(harness.broker, harness.token);
+    } finally {
+      await harness.close();
+    }
+  }, 30_000);
+
+  test("keeps a gateway wait and command slot active across the turn deadline until terminal evidence", async () => {
+    const harness = await openMcpHarness("cgw-v4-gateway-timeout", gatewayCommandEnvironment(), 1_500);
+    try {
+      const execPromise = harness.call("codex_exec", { cmd: "pwd" });
+      const [original] = await harness.broker.nextToolBatch(harness.token);
+      harness.broker.completeTool(harness.token, original!.callId, pendingToolResult("cell-timeout"));
+      const [wait] = await harness.broker.nextToolBatch(harness.token);
+      expect(wait).toMatchObject({ wireName: "wait", arguments: { cell_id: "cell-timeout" } });
+      await Bun.sleep(1_600);
+      const alternate = await harness.call("codex_exec", { cmd: "git status --short" });
+      expect(alternate.isError).toBe(true);
+      expect(JSON.stringify(alternate.content)).toContain("already active");
+      harness.broker.completeTool(
+        harness.token,
+        wait!.callId,
+        gatewayOuterResult({ output: "/working", exit_code: 0 }),
+      );
+      expect((await execPromise).isError).not.toBe(true);
+    } finally {
+      await harness.close();
+    }
+  }, 30_000);
+
+  test("detaches lifecycle cleanup after caller abort and still dispatches exactly one wait", async () => {
+    const harness = await openMcpHarness("cgw-v4-gateway-abort-before-wait");
+    const abort = new AbortController();
+    try {
+      const execPromise = harness.call("codex_exec", { cmd: "pwd" }, abort.signal);
+      const [original] = await harness.broker.nextToolBatch(harness.token);
+      harness.broker.completeTool(harness.token, original!.callId, pendingToolResult("cell-abort-before"));
+      abort.abort();
+      await expect(execPromise).rejects.toThrow();
+      const [wait] = await harness.broker.nextToolBatch(harness.token);
+      expect(wait).toMatchObject({ wireName: "wait", arguments: { cell_id: "cell-abort-before" } });
+      await expectNoQueuedTool(harness.broker, harness.token);
+      harness.broker.completeTool(
+        harness.token,
+        wait!.callId,
+        gatewayOuterResult({ output: "/working", exit_code: 0 }),
+      );
+      await Bun.sleep(25);
+      const duplicate = await harness.call("codex_exec", { cmd: "pwd" });
+      expect(duplicate.isError).toBe(true);
+      expect(JSON.stringify(duplicate.content)).toContain("already been terminalized");
+      await expectNoQueuedTool(harness.broker, harness.token);
+    } finally {
+      await harness.close();
+    }
+  }, 30_000);
+
+  test("aborts an active gateway wait without orphaning its delivered broker invocation", async () => {
+    const harness = await openMcpHarness("cgw-v4-gateway-abort-during-wait");
+    const abort = new AbortController();
+    try {
+      const execPromise = harness.call("codex_exec", { cmd: "pwd" }, abort.signal);
+      const [original] = await harness.broker.nextToolBatch(harness.token);
+      harness.broker.completeTool(harness.token, original!.callId, pendingToolResult("cell-abort-during"));
+      const [wait] = await harness.broker.nextToolBatch(harness.token);
+      abort.abort();
+      await expect(execPromise).rejects.toThrow();
+      const duplicate = harness.call("codex_exec", { cmd: "pwd" });
+      await expectNoQueuedTool(harness.broker, harness.token);
+      expect(() => harness.broker.completeTool(
+        harness.token,
+        wait!.callId,
+        gatewayOuterResult({ output: "late", exit_code: 0 }),
+      )).not.toThrow();
+      expect((await duplicate).isError).not.toBe(true);
+      await Bun.sleep(25);
+      const afterLateTerminal = await harness.call("codex_exec", { cmd: "pwd" });
+      expect(afterLateTerminal.isError).toBe(true);
+      expect(JSON.stringify(afterLateTerminal.content)).toContain("already been terminalized");
+      await expectNoQueuedTool(harness.broker, harness.token);
+    } finally {
+      await harness.close();
+    }
+  }, 30_000);
+
+  test.each([
+    ["changed handle", pendingToolResult("cell-changed"), "different pending command handle"],
+    ["same handle second pending", pendingToolResult("cell-original"), "did not return a terminal command state"],
+    [
+      "changed terminal handle",
+      gatewayOuterResult({ status: "completed", cell_id: "cell-changed" }),
+      "different command handle",
+    ],
+  ])("fails closed on gateway wait contract violation: %s", async (_name, waited, expected) => {
+    const harness = await openMcpHarness("cgw-v4-gateway-wait-contract");
+    try {
+      const execPromise = harness.call("codex_exec", { cmd: "pwd" });
+      const [original] = await harness.broker.nextToolBatch(harness.token);
+      harness.broker.completeTool(harness.token, original!.callId, pendingToolResult("cell-original"));
+      const waitBatch = await harness.broker.nextToolBatch(harness.token);
+      expect(waitBatch).toHaveLength(1);
+      const wait = waitBatch[0]!;
+      harness.broker.completeTool(harness.token, wait.callId, waited as BrokerToolResult);
+      const response = await execPromise;
+      expect(response.isError).toBe(true);
+      expect(JSON.stringify(response.content)).toContain(expected);
+      expect(original!.input?.match(/await nativeCommand\(/g)).toHaveLength(1);
+      const alternate = await harness.call("codex_exec", { cmd: "git status --short" });
+      expect(alternate.isError).toBe(true);
+      expect(JSON.stringify(alternate.content)).toContain("already active");
+      await expectNoQueuedTool(harness.broker, harness.token);
+    } finally {
+      await harness.close();
+    }
+  }, 30_000);
+
+  test("exposes only the formal exec_command escalation ABI and fails closed before fallback", async () => {
+    const harness = await openMcpHarness("cgw-v4-explicit-escalation");
+    try {
+      const justification = "Approve this exact read-only cwd verification";
+      const execPromise = harness.call("codex_exec", {
+        cmd: "pwd",
+        workdir: tempRoot,
+        sandbox_permissions: "require_escalated",
+        justification,
+      });
+      const [outerRequest] = await harness.broker.nextToolBatch(harness.token);
+      expect(outerRequest).toMatchObject({ wireName: "exec", freeform: true });
+      expect(outerRequest?.input).toContain(JSON.stringify({
+        cmd: "pwd",
+        workdir: tempRoot,
+        sandbox_permissions: "require_escalated",
+        justification,
+      }));
+      expect(outerRequest?.input).not.toContain("prefix_rule");
+
+      const approvalCalls: GatewayProgramCall[] = [];
+      await executeGatewayProgram(outerRequest!.input!, ["exec_command"], approvalCalls, {
+        descriptions: { exec_command: escalationCapableExecDescription },
+      });
+      expect(approvalCalls).toEqual([{
+        name: "exec_command",
+        input: {
+          cmd: "pwd",
+          workdir: tempRoot,
+          sandbox_permissions: "require_escalated",
+          justification,
+        },
+      }]);
+
+      const unavailableCalls: GatewayProgramCall[] = [];
+      await expect(executeGatewayProgram(outerRequest!.input!, ["exec_command"], unavailableCalls))
+        .rejects.toThrow("Native exec_command escalation ABI is unavailable");
+      expect(unavailableCalls).toEqual([]);
+
+      const fallbackCalls: GatewayProgramCall[] = [];
+      await expect(executeGatewayProgram(outerRequest!.input!, ["shell_command"], fallbackCalls))
+        .rejects.toThrow("Expected exactly one native command tool");
+      expect(fallbackCalls).toEqual([]);
+
+      let processStarts = 0;
+      const rejectionCalls: GatewayProgramCall[] = [];
+      const rejectionOutput: unknown[] = [];
+      await expect(executeGatewayProgram(outerRequest!.input!, ["exec_command"], rejectionCalls, {
+        descriptions: { exec_command: escalationCapableExecDescription },
+        invoke: async () => {
+          throw new Error("approval rejected by user");
+        },
+        textOutput: rejectionOutput,
+      })).rejects.toThrow("approval rejected by user");
+      expect(rejectionCalls).toHaveLength(1);
+      expect(processStarts).toBe(0);
+      expect(rejectionOutput).toEqual([]);
+
+      harness.broker.completeTool(
+        harness.token,
+        outerRequest!.callId,
+        gatewayOuterResult({ status: "denied" }),
+      );
+      const denied = await execPromise;
+      expect(denied.isError).toBe(true);
+      const denialText = ((denied.content as Array<{ text: string }>)[0]).text;
+      expect(denialText).toContain('"status":"denied"');
+      expect(denialText).not.toContain('"output"');
+
+      const replay = await harness.call("codex_exec", {
+        cmd: "pwd",
+        workdir: tempRoot,
+        sandbox_permissions: "require_escalated",
+        justification,
+      });
+      expect(replay.isError).toBe(true);
+      expect(JSON.stringify(replay.content)).toContain("already been terminalized");
+      await expectNoQueuedTool(harness.broker, harness.token);
+    } finally {
+      await harness.close();
+    }
+  }, 30_000);
+
   test("serves the complete outer-native bridge contract over MCP stdio", async () => {
     const socketPath = brokerTestEndpoint(`cgw-h3-mcp-${process.pid}-${Date.now()}`);
     const broker = TurnBroker.forSocket(socketPath);
@@ -1864,7 +2917,10 @@ describe("ChatGPT outer-native harness v4", () => {
       // ChatGPT caches the complete tools/list contract under a connector identity.
       // An intentional hash change therefore requires an explicit connector refresh or identity migration.
       expect(createHash("sha256").update(canonicalJson(publicConnectorAbi)).digest("hex"))
-        .toBe("5cb59b378c7d1939e260a2b4a60f58e22da31208fe09c2cc17a2cf31eb5ff3ad");
+        .toBe("e806fb7e66b0822ed9460ab6b6734ca34fc1e9c5c99e0e6e8583d749b9153745");
+      const execProperties = listed.tools.find(tool => tool.name === "codex_exec")?.inputSchema.properties as Record<string, unknown>;
+      expect(execProperties.sandbox_permissions).toEqual({ const: "require_escalated", type: "string" });
+      expect(execProperties.justification).toEqual({ type: "string", minLength: 1, maxLength: 4_000 });
       for (const tool of listed.tools) {
         const properties = tool.inputSchema.properties as Record<string, unknown>;
         expect(properties.turn_token).toEqual({ type: "string", minLength: 20, maxLength: 256 });
@@ -1916,9 +2972,8 @@ describe("ChatGPT outer-native harness v4", () => {
         max_output_tokens: 1_234,
         tty: true,
       });
-      const secondExec = call("codex_exec", { turn_token: token, cmd: "git status --short", workdir: tempRoot });
       const execRequests = await broker.nextToolBatch(token);
-      expect(execRequests).toHaveLength(2);
+      expect(execRequests).toHaveLength(1);
       expect(execRequests.every(request => request.wireName === "exec" && request.freeform)).toBe(true);
       expect(execRequests.some(request => request.input?.includes(JSON.stringify({
         cmd: "pwd",
@@ -1927,13 +2982,12 @@ describe("ChatGPT outer-native harness v4", () => {
         max_output_tokens: 1_234,
         tty: true,
       })))).toBe(true);
-      expect(execRequests.some(request => request.input?.includes(JSON.stringify({ cmd: "git status --short", workdir: tempRoot })))).toBe(true);
       for (const request of execRequests) {
         expect(request.input).toContain("ALL_TOOLS");
         expect(request.input).toContain('"exec_command"');
         expect(request.input).toContain('"shell_command"');
         const output = request.input?.includes('git status --short') ? "clean" : tempRoot;
-        broker.completeTool(token, request.callId, toolResult({ output, exit_code: 0 }));
+        broker.completeTool(token, request.callId, gatewayOuterResult({ output, exit_code: 0 }));
       }
       const pwdRequest = execRequests.find(request => request.input?.includes('"cmd":"pwd"'));
       expect(pwdRequest?.input).toBeString();
@@ -1955,29 +3009,31 @@ describe("ChatGPT outer-native harness v4", () => {
         name: "shell_command",
         input: { command: "pwd", workdir: tempRoot, timeout_ms: 2_000 },
       }]);
-      for (const ambiguousInventory of [[], ["exec_command", "shell_command"]]) {
+      for (const ambiguousInventory of [
+        [],
+        ["exec_command", "shell_command"],
+        ["exec_command", "exec_command"],
+        ["exec_command", "exec-command"],
+      ]) {
         const rejectedCalls: GatewayProgramCall[] = [];
         await expect(executeGatewayProgram(pwdRequest!.input!, ambiguousInventory, rejectedCalls))
           .rejects.toThrow("Expected exactly one native command tool");
         expect(rejectedCalls).toEqual([]);
       }
-      expect((await firstExec).structuredContent).toEqual({ output: tempRoot, exit_code: 0 });
-      expect((await secondExec).structuredContent).toEqual({ output: "clean", exit_code: 0 });
+      expect(JSON.stringify((await firstExec).content)).toContain(tempRoot);
 
-      const waitPromise = call("codex_tool_call", {
+      const secondExec = call("codex_exec", { turn_token: token, cmd: "git status --short", workdir: tempRoot });
+      const [secondRequest] = await broker.nextToolBatch(token);
+      broker.completeTool(token, secondRequest!.callId, gatewayOuterResult({ output: "", exit_code: 0 }));
+      expect((await secondExec).isError).not.toBe(true);
+
+      const waitAttempt = await call("codex_tool_call", {
         turn_token: token,
         wire_name: "wait",
         arguments: { cell_id: "cell_test", yield_time_ms: 10_000 },
       });
-      const [waitRequest] = await broker.nextToolBatch(token);
-      expect(waitRequest).toMatchObject({
-        wireName: "wait",
-        freeform: false,
-        arguments: { cell_id: "cell_test", yield_time_ms: 10_000 },
-      });
-      expect(waitRequest?.input).toBeUndefined();
-      broker.completeTool(token, waitRequest!.callId, toolResult({ output: "completed" }));
-      expect((await waitPromise).structuredContent).toEqual({ output: "completed" });
+      expect(waitAttempt.isError).toBe(true);
+      expect(JSON.stringify(waitAttempt.content)).toContain("reserved for codex_exec");
 
       const agentInventory = await call("codex_tool_inventory", {
         turn_token: token,
@@ -2044,9 +3100,18 @@ describe("ChatGPT outer-native harness v4", () => {
     });
     const client = new Client({ name: "codex-chatgpt-web-direct-tools-test", version: "1.0.0" });
     const call = (name: string, args: Record<string, unknown>) => client.callTool({ name, arguments: args });
+    const reconnectTransport = new StdioClientTransport({
+      command: process.execPath,
+      args: ["src/cli.ts", "mcp", "--broker-socket", socketPath],
+      cwd: process.cwd(),
+      stderr: "pipe",
+    });
+    let reconnectClient = new Client({ name: "codex-chatgpt-web-direct-tools-reconnect-test", version: "1.0.0" });
+    const reconnectCall = (name: string, args: Record<string, unknown>) => reconnectClient.callTool({ name, arguments: args });
 
     try {
       await client.connect(transport);
+      await reconnectClient.connect(reconnectTransport);
 
       const inventory = await call("codex_tool_inventory", {
         turn_token: token,
@@ -2058,51 +3123,6 @@ describe("ChatGPT outer-native harness v4", () => {
         tools: [{ wire_name: "exec_command", kind: "function" }],
       });
       expect(JSON.stringify(inventory)).not.toContain("binding_");
-
-      const exec = call("codex_exec", {
-        turn_token: token,
-        cmd: "pwd",
-        workdir: tempRoot,
-        yield_time_ms: 2_000,
-        max_output_tokens: 4_000,
-        tty: false,
-      });
-      const [execRequest] = await broker.nextToolBatch(token);
-      expect(execRequest).toEqual(expect.objectContaining({
-        wireName: "exec_command",
-        freeform: false,
-        arguments: {
-          cmd: "pwd",
-          workdir: tempRoot,
-          yield_time_ms: 2_000,
-          max_output_tokens: 4_000,
-          tty: false,
-        },
-      }));
-      expect(execRequest?.input).toBeUndefined();
-      broker.completeTool(token, execRequest!.callId, toolResult({ output: tempRoot, exit_code: 0, session_id: 42 }));
-      expect((await exec).structuredContent).toMatchObject({ session_id: 42 });
-
-      const write = call("codex_write_stdin", {
-        turn_token: token,
-        session_id: 42,
-        chars: "y\n",
-        yield_time_ms: 5_000,
-        max_output_tokens: 2_000,
-      });
-      const [writeRequest] = await broker.nextToolBatch(token);
-      expect(writeRequest).toEqual(expect.objectContaining({
-        wireName: "write_stdin",
-        freeform: false,
-        arguments: {
-          session_id: 42,
-          chars: "y\n",
-          yield_time_ms: 5_000,
-          max_output_tokens: 2_000,
-        },
-      }));
-      broker.completeTool(token, writeRequest!.callId, toolResult({ output: "continued" }));
-      expect((await write).structuredContent).toEqual({ output: "continued" });
 
       const patch = "*** Begin Patch\n*** Add File: direct-token.txt\n+ok\n*** End Patch";
       const apply = call("codex_apply_patch", { turn_token: token, patch });
@@ -2125,14 +3145,289 @@ describe("ChatGPT outer-native harness v4", () => {
       }));
       broker.completeTool(token, viewRequest!.callId, toolResult({ output: "image-ready" }));
       expect((await view).structuredContent).toEqual({ output: "image-ready" });
+
+      const exec = call("codex_exec", {
+        turn_token: token,
+        cmd: "pwd",
+        workdir: tempRoot,
+        yield_time_ms: 2_000,
+        max_output_tokens: 4_000,
+        tty: false,
+      });
+      const [execRequest] = await broker.nextToolBatch(token);
+      expect(execRequest).toEqual(expect.objectContaining({
+        wireName: "exec_command",
+        freeform: false,
+        arguments: {
+          cmd: "pwd",
+          workdir: tempRoot,
+          yield_time_ms: 2_000,
+          max_output_tokens: 4_000,
+          tty: false,
+        },
+      }));
+      expect(execRequest?.input).toBeUndefined();
+      broker.completeTool(token, execRequest!.callId, toolResult({ output: tempRoot, session_id: 42 }));
+      const execResponse = await exec;
+      expect(execResponse.structuredContent).toMatchObject({ session_id: 42 });
+      const firstContinuationToken = (execResponse.structuredContent as { continuation_token?: string }).continuation_token;
+      expect(firstContinuationToken).toMatch(/^continuation_/);
+
+      const replayedExec = await reconnectCall("codex_exec", {
+        turn_token: token,
+        cmd: "pwd",
+        workdir: tempRoot,
+        yield_time_ms: 2_000,
+        max_output_tokens: 4_000,
+        tty: false,
+      });
+      expect(replayedExec.structuredContent).toMatchObject({
+        session_id: 42,
+        continuation_token: firstContinuationToken,
+      });
+      await expectNoQueuedTool(broker, token);
+
+      const write = call("codex_write_stdin", {
+        turn_token: token,
+        session_id: 42,
+        continuation_token: firstContinuationToken,
+        chars: "y\n",
+        yield_time_ms: 5_000,
+        max_output_tokens: 2_000,
+      });
+      const [writeRequest] = await broker.nextToolBatch(token);
+      expect(writeRequest).toEqual(expect.objectContaining({
+        wireName: "write_stdin",
+        freeform: false,
+        arguments: {
+          session_id: 42,
+          chars: "y\n",
+          yield_time_ms: 5_000,
+          max_output_tokens: 2_000,
+        },
+      }));
+      const concurrentWrite = await reconnectCall("codex_write_stdin", {
+        turn_token: token,
+        session_id: 42,
+        continuation_token: firstContinuationToken,
+        chars: "z\n",
+      });
+      expect(concurrentWrite.isError).toBe(true);
+      expect(JSON.stringify(concurrentWrite.content)).toContain("reused with a different request");
+      broker.completeTool(token, writeRequest!.callId, toolResult({ output: "continued", session_id: 42 }));
+      const writeResponse = await write;
+      expect(writeResponse.structuredContent).toMatchObject({ output: "continued", session_id: 42 });
+      const nextContinuationToken = (writeResponse.structuredContent as { continuation_token?: string }).continuation_token;
+      expect(nextContinuationToken).toMatch(/^continuation_/);
+      expect(nextContinuationToken).not.toBe(firstContinuationToken);
+      const peerResumedExec = await reconnectCall("codex_exec", {
+        turn_token: token,
+        cmd: "pwd",
+        workdir: tempRoot,
+        yield_time_ms: 2_000,
+        max_output_tokens: 4_000,
+        tty: false,
+      });
+      expect(peerResumedExec.structuredContent).toMatchObject({
+        session_id: 42,
+        continuation_token: nextContinuationToken,
+      });
+      await expectNoQueuedTool(broker, token);
+      const sameProcessResumedExec = await call("codex_exec", {
+        turn_token: token,
+        cmd: "pwd",
+        workdir: tempRoot,
+        yield_time_ms: 2_000,
+        max_output_tokens: 4_000,
+        tty: false,
+      });
+      expect(sameProcessResumedExec.structuredContent).toMatchObject({
+        session_id: 42,
+        continuation_token: nextContinuationToken,
+      });
+      await expectNoQueuedTool(broker, token);
+      await reconnectClient.close();
+      reconnectClient = new Client({ name: "codex-chatgpt-web-direct-tools-response-loss-test", version: "1.0.0" });
+      await reconnectClient.connect(new StdioClientTransport({
+        command: process.execPath,
+        args: ["src/cli.ts", "mcp", "--broker-socket", socketPath],
+        cwd: process.cwd(),
+        stderr: "pipe",
+      }));
+      const resumedExec = await reconnectCall("codex_exec", {
+        turn_token: token,
+        cmd: "pwd",
+        workdir: tempRoot,
+        yield_time_ms: 2_000,
+        max_output_tokens: 4_000,
+        tty: false,
+      });
+      expect(resumedExec.structuredContent).toMatchObject({
+        session_id: 42,
+        continuation_token: nextContinuationToken,
+      });
+      await expectNoQueuedTool(broker, token);
+
+      const wrongWrite = await call("codex_write_stdin", {
+        turn_token: token,
+        session_id: 43,
+        continuation_token: nextContinuationToken,
+      });
+      expect(wrongWrite.isError).toBe(true);
+      expect(JSON.stringify(wrongWrite.content)).toContain("does not match the active codex_exec session");
+
+      const changedSession = call("codex_write_stdin", {
+        turn_token: token,
+        session_id: 42,
+        continuation_token: nextContinuationToken,
+      });
+      const [changedSessionRequest] = await broker.nextToolBatch(token);
+      broker.completeTool(token, changedSessionRequest!.callId, toolResult({ output: "changed", session_id: 43 }));
+      const changedSessionResponse = await changedSession;
+      expect(changedSessionResponse.isError).toBe(true);
+      expect(JSON.stringify(changedSessionResponse.content)).toContain("UNRESOLVED_UNKNOWN_OUTCOME");
+
+      const replayedUnknown = await reconnectCall("codex_write_stdin", {
+        turn_token: token,
+        session_id: 42,
+        continuation_token: nextContinuationToken,
+      });
+      expect(replayedUnknown.isError).toBe(true);
+      expect(JSON.stringify(replayedUnknown.content)).toContain("UNRESOLVED_UNKNOWN_OUTCOME");
+      const changedUnknownRetry = await reconnectCall("codex_write_stdin", {
+        turn_token: token,
+        session_id: 42,
+        continuation_token: nextContinuationToken,
+        chars: "different\n",
+      });
+      expect(changedUnknownRetry.isError).toBe(true);
+      await expectNoQueuedTool(broker, token);
+
+      const unrelatedExec = await call("codex_exec", {
+        turn_token: token,
+        cmd: "git status --short",
+        workdir: tempRoot,
+      });
+      expect(unrelatedExec.isError).toBe(true);
+      expect(JSON.stringify(unrelatedExec.content)).toContain("already active");
+      await expectNoQueuedTool(broker, token);
+
     } finally {
+      await reconnectClient.close().catch(() => {});
       await client.close().catch(() => {});
       broker.revoke(token);
       await broker.close();
     }
   }, 30_000);
 
-  test("keeps simultaneous direct-token MCP actions isolated by outer Codex turn", async () => {
+  test("reconciles a terminalized session across concurrent MCP replay and process restart", async () => {
+    const socketPath = brokerTestEndpoint(`cgw-h4-terminal-session-replay-${process.pid}-${Date.now()}`);
+    const broker = TurnBroker.forSocket(socketPath);
+    const environment = directCommandEnvironment();
+    environment.tools.push({ name: "write_stdin", description: "Continue command", parameters: { type: "object" } });
+    const token = await broker.register(environment, 60_000);
+    const connect = async (name: string) => {
+      const client = new Client({ name, version: "1.0.0" });
+      await client.connect(new StdioClientTransport({
+        command: process.execPath,
+        args: ["src/cli.ts", "mcp", "--broker-socket", socketPath],
+        cwd: process.cwd(),
+        stderr: "pipe",
+      }));
+      return client;
+    };
+    const args = {
+      turn_token: token,
+      cmd: "pwd",
+      workdir: tempRoot,
+    };
+    const first = await connect("terminal-session-first");
+    let second: Client | undefined;
+    let third: Client | undefined;
+    try {
+      const exec = first.callTool({ name: "codex_exec", arguments: args });
+      const [execRequest] = await broker.nextToolBatch(token);
+      broker.completeTool(token, execRequest!.callId, toolResult({ output: tempRoot, session_id: 42 }));
+      const execResponse = await exec;
+      const continuationToken = (execResponse.structuredContent as { continuation_token?: string }).continuation_token!;
+
+      second = await connect("terminal-session-peer");
+      const peerSession = await second.callTool({ name: "codex_exec", arguments: args });
+      expect(peerSession.structuredContent).toMatchObject({ session_id: 42, continuation_token: continuationToken });
+      await expectNoQueuedTool(broker, token);
+
+      const write = first.callTool({
+        name: "codex_write_stdin",
+        arguments: { turn_token: token, session_id: 42, continuation_token: continuationToken },
+      });
+      const [writeRequest] = await broker.nextToolBatch(token);
+      broker.completeTool(token, writeRequest!.callId, toolResult({ output: "done", exit_code: 0 }));
+      expect((await write).isError).not.toBe(true);
+
+      const sameProcessReplay = await first.callTool({ name: "codex_exec", arguments: args });
+      expect(sameProcessReplay.isError).toBe(true);
+      expect(JSON.stringify(sameProcessReplay.content)).toContain("already been terminalized");
+      await expectNoQueuedTool(broker, token);
+
+      const peerCommands = [
+        second.callTool({
+          name: "codex_exec",
+          arguments: { turn_token: token, cmd: "git status --short", workdir: tempRoot },
+        }),
+        second.callTool({
+          name: "codex_exec",
+          arguments: { turn_token: token, cmd: "git diff --stat", workdir: tempRoot },
+        }),
+      ];
+      const blockedPeer = await Promise.race(peerCommands);
+      expect(blockedPeer.isError).toBe(true);
+      expect(JSON.stringify(blockedPeer.content)).toContain("already active under a different request identity");
+      const [peerRequest] = await broker.nextToolBatch(token);
+      broker.completeTool(token, peerRequest!.callId, toolResult({ output: "peer", exit_code: 0 }));
+      const peerResults = await Promise.all(peerCommands);
+      expect(peerResults.filter(result => result.isError !== true)).toHaveLength(1);
+      await expectNoQueuedTool(broker, token);
+
+      const peerReuse = second.callTool({
+        name: "codex_exec",
+        arguments: { turn_token: token, cmd: "git log -1 --oneline", workdir: tempRoot },
+      });
+      const [peerReuseRequest] = await broker.nextToolBatch(token);
+      broker.completeTool(token, peerReuseRequest!.callId, toolResult({ output: "reused", exit_code: 0 }));
+      expect((await peerReuse).isError).not.toBe(true);
+
+      const peerReplay = await second.callTool({ name: "codex_exec", arguments: args });
+      expect(peerReplay.isError).toBe(true);
+      expect(JSON.stringify(peerReplay.content)).toContain("already been terminalized");
+      expect(JSON.stringify(peerReplay.content)).not.toContain("UNRESOLVED_UNKNOWN_OUTCOME");
+      await expectNoQueuedTool(broker, token);
+
+      await second.close();
+      second = undefined;
+      third = await connect("terminal-session-restarted");
+      const restartedReplay = await third.callTool({ name: "codex_exec", arguments: args });
+      expect(restartedReplay.isError).toBe(true);
+      expect(JSON.stringify(restartedReplay.content)).toContain("already been terminalized");
+      expect(JSON.stringify(restartedReplay.content)).not.toContain("UNRESOLVED_UNKNOWN_OUTCOME");
+      await expectNoQueuedTool(broker, token);
+
+      const unrelated = third.callTool({
+        name: "codex_exec",
+        arguments: { turn_token: token, cmd: "git branch --show-current", workdir: tempRoot },
+      });
+      const [unrelatedRequest] = await broker.nextToolBatch(token);
+      broker.completeTool(token, unrelatedRequest!.callId, toolResult({ output: "", exit_code: 0 }));
+      expect((await unrelated).isError).not.toBe(true);
+    } finally {
+      await first.close().catch(() => {});
+      await second?.close().catch(() => {});
+      await third?.close().catch(() => {});
+      broker.revoke(token);
+      await broker.close();
+    }
+  }, 30_000);
+
+  test("serializes direct-token MCP commands across outer Codex turns", async () => {
     const socketPath = brokerTestEndpoint(`cgw-h4-mcp-isolation-${process.pid}-${Date.now()}`);
     const broker = TurnBroker.forSocket(socketPath);
     const firstEnvironment = extractChatGptTurnEnvironment(parsed(environmentXml));
@@ -2165,32 +3460,36 @@ describe("ChatGPT outer-native harness v4", () => {
         name: "codex_exec",
         arguments: { turn_token: firstToken, cmd: "pwd", workdir: firstEnvironment.cwd, yield_time_ms: 1_000 },
       });
-      const secondCall = client.callTool({
+      const [firstRequest] = await broker.nextToolBatch(firstToken);
+      const blockedSecond = await client.callTool({
         name: "codex_exec",
         arguments: { turn_token: secondToken, cmd: "pwd", workdir: secondEnvironment.cwd, yield_time_ms: 2_000 },
       });
-      const [[firstRequest], [secondRequest]] = await Promise.all([
-        broker.nextToolBatch(firstToken),
-        broker.nextToolBatch(secondToken),
-      ]);
+      expect(blockedSecond.isError).toBe(true);
+      expect(JSON.stringify(blockedSecond.content)).toContain("already active");
 
       expect(firstRequest).toMatchObject({
         wireName: "exec_command",
         arguments: { cmd: "pwd", workdir: "/workspace/first", yield_time_ms: 1_000 },
       });
+      expect(JSON.stringify(firstRequest)).not.toContain(firstToken);
+      expect(JSON.stringify(firstRequest)).not.toContain(secondToken);
+
+      broker.completeTool(firstToken, firstRequest!.callId, toolResult({ output: "first", exit_code: 0 }));
+      expect((await firstCall).structuredContent).toEqual({ output: "first", exit_code: 0 });
+      const secondCall = client.callTool({
+        name: "codex_exec",
+        arguments: { turn_token: secondToken, cmd: "pwd", workdir: secondEnvironment.cwd, yield_time_ms: 2_000 },
+      });
+      const [secondRequest] = await broker.nextToolBatch(secondToken);
       expect(secondRequest).toMatchObject({
         wireName: "shell_command",
         arguments: { command: "pwd", workdir: "/workspace/second", timeout_ms: 2_000 },
       });
-      expect(JSON.stringify(firstRequest)).not.toContain(firstToken);
-      expect(JSON.stringify(firstRequest)).not.toContain(secondToken);
       expect(JSON.stringify(secondRequest)).not.toContain(firstToken);
       expect(JSON.stringify(secondRequest)).not.toContain(secondToken);
-
-      broker.completeTool(firstToken, firstRequest!.callId, toolResult({ output: "first" }));
-      broker.completeTool(secondToken, secondRequest!.callId, toolResult({ output: "second" }));
-      expect((await firstCall).structuredContent).toEqual({ output: "first" });
-      expect((await secondCall).structuredContent).toEqual({ output: "second" });
+      broker.completeTool(secondToken, secondRequest!.callId, toolResult({ output: "second", exit_code: 0 }));
+      expect((await secondCall).structuredContent).toEqual({ output: "second", exit_code: 0 });
     } finally {
       await client.close().catch(() => {});
       broker.revoke(firstToken);
@@ -2239,8 +3538,8 @@ describe("ChatGPT outer-native harness v4", () => {
       expect(execRequest?.input).toContain('"exec_command"');
       expect(execRequest?.input).toContain('"shell_command"');
       expect(execRequest?.input).toContain(JSON.stringify({ cmd: "pwd", workdir: tempRoot }));
-      broker.completeTool(token, execRequest!.callId, toolResult({ output: tempRoot, exit_code: 0 }));
-      expect((await execPromise).structuredContent).toEqual({ output: tempRoot, exit_code: 0 });
+      broker.completeTool(token, execRequest!.callId, gatewayOuterResult({ output: tempRoot, exit_code: 0 }));
+      expect(JSON.stringify((await execPromise).content)).toContain(tempRoot);
     } finally {
       await client.close().catch(() => {});
       broker.revoke(token);

--- a/tests/command-observability.test.ts
+++ b/tests/command-observability.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import {
+  COMMAND_OBSERVATION_PREFIX,
+  observeCommandInvocation,
+  PLATFORM_HTTP_ENDPOINT_NOT_OBSERVABLE,
+  summarizeCommandObservabilityLog,
+} from "../src/adapters/chatgpt-web/command-observability";
+
+describe("command observability", () => {
+  test("emits only sanitized connector correlation and terminal classes", async () => {
+    const lines: string[] = [];
+    const original = console.error;
+    console.error = (line?: unknown) => { lines.push(String(line)); };
+    try {
+      await observeCommandInvocation("codex_exec", {
+        requestId: "raw-request-secret",
+        sessionId: "raw-session-secret",
+        _meta: { "openai/session": "raw-platform-session-secret" },
+      }, async () => ({ structuredContent: { output: "ok", exit_code: 0 } }));
+    } finally {
+      console.error = original;
+    }
+
+    expect(lines).toHaveLength(2);
+    expect(lines.every(line => line.startsWith(COMMAND_OBSERVATION_PREFIX))).toBe(true);
+    const joined = lines.join("\n");
+    expect(joined).not.toContain("raw-request-secret");
+    expect(joined).not.toContain("raw-session-secret");
+    expect(joined).not.toContain("raw-platform-session-secret");
+    expect(joined).toContain('"terminal_class":"success"');
+  });
+
+  test("summarizes a bounded tunnel-to-connector window without exposing raw IDs", () => {
+    const log = [
+      JSON.stringify({ time: "2026-08-22T10:00:00Z", level: "INFO", msg: "dispatcher forwarded command to MCP server", request_id: "raw-tunnel-request", cmd_request_id: "raw-command-request" }),
+      `${COMMAND_OBSERVATION_PREFIX}${JSON.stringify({ event: "connector_invocation_start", correlation: "connector-fingerprint" })}`,
+      `${COMMAND_OBSERVATION_PREFIX}${JSON.stringify({ event: "connector_invocation_terminal", correlation: "connector-fingerprint", terminal_class: "terminal_error", remote_failure_class: "connector_result_error_unattributed" })}`,
+      JSON.stringify({ time: "2026-08-22T10:00:01Z", level: "INFO", msg: "posted response to control-plane", request_id: "raw-tunnel-request" }),
+    ].join("\n");
+    const summary = summarizeCommandObservabilityLog(log, {
+      since: "2026-08-22T09:59:59Z",
+      until: "2026-08-22T10:00:02Z",
+    });
+    const serialized = JSON.stringify(summary);
+
+    expect(summary).toMatchObject({
+      platform_http_endpoint: PLATFORM_HTTP_ENDPOINT_NOT_OBSERVABLE,
+      candidate_poll_arrival: true,
+      candidate_response_post: true,
+      connector_invocation_start: true,
+      connector_terminal_classes: ["terminal_error"],
+      remote_failure_classes: ["connector_result_error_unattributed"],
+      sanitized_correlation: {
+        temporal_singleton_candidate: true,
+        status: "INCONCLUSIVE_NO_SHARED_IDENTIFIER",
+      },
+    });
+    expect(serialized).not.toContain("raw-tunnel-request");
+    expect(serialized).not.toContain("raw-command-request");
+  });
+
+  test("reports absent stages and inconclusive correlation explicitly", () => {
+    expect(summarizeCommandObservabilityLog("")).toMatchObject({
+      platform_http_endpoint: PLATFORM_HTTP_ENDPOINT_NOT_OBSERVABLE,
+      candidate_poll_arrival: false,
+      candidate_response_post: false,
+      connector_invocation_start: false,
+      sanitized_correlation: { status: "INCONCLUSIVE_NO_SHARED_IDENTIFIER" },
+    });
+  });
+
+  test("does not correlate unrelated response posts or an unbounded singleton", () => {
+    const log = [
+      JSON.stringify({ time: "2026-08-22T10:00:00Z", level: "INFO", msg: "dispatcher forwarded command to MCP server", request_id: "request-a" }),
+      `${COMMAND_OBSERVATION_PREFIX}${JSON.stringify({ event: "connector_invocation_start", correlation: "connector-a" })}`,
+      JSON.stringify({ time: "2026-08-22T10:00:01Z", level: "INFO", msg: "posted response to control-plane", request_id: "request-b" }),
+    ].join("\n");
+    expect(summarizeCommandObservabilityLog(log)).toMatchObject({
+      candidate_poll_arrival: true,
+      candidate_response_post: false,
+      unmatched_response_post_count: 1,
+      sanitized_correlation: {
+        temporal_singleton_candidate: false,
+        status: "INCONCLUSIVE_NO_SHARED_IDENTIFIER",
+      },
+    });
+  });
+});

--- a/tests/effort-selection.test.ts
+++ b/tests/effort-selection.test.ts
@@ -1,0 +1,249 @@
+import { expect, test } from "bun:test";
+import {
+  chatGptEffortIndexFromControlLabel,
+  ChatGptEffortStaleDomError,
+  ensureChatGptEffortSelection,
+  type ChatGptEffortIndex,
+  type ChatGptEffortOpenState,
+  type ChatGptEffortSelectionDriver,
+} from "../src/adapters/chatgpt-web/effort-selection";
+
+interface Scenario {
+  passive?: number;
+  open: ChatGptEffortOpenState | Error;
+  actual?: number;
+  changed?: boolean;
+  staleOnce?: boolean;
+  replaceOnTransition?: boolean;
+  acknowledgementDelayMs?: number;
+}
+
+function scenarioDriver(scenario: Scenario) {
+  const ledger: string[] = [];
+  let stale = scenario.staleOnce === true;
+  let generation = 0;
+  const driver: ChatGptEffortSelectionDriver = {
+    async readCurrent() {
+      ledger.push("read-current");
+      return scenario.passive;
+    },
+    async openAndRead() {
+      ledger.push(`open:${generation}`);
+      if (stale) {
+        stale = false;
+        generation += 1;
+        throw new ChatGptEffortStaleDomError();
+      }
+      if (scenario.open instanceof Error) throw scenario.open;
+      return scenario.open;
+    },
+    async transition() {
+      ledger.push(`transition:${generation}`);
+      if (scenario.replaceOnTransition) generation += 1;
+      return { changed: scenario.changed ?? true };
+    },
+    async readActual(_state, _target, signal) {
+      ledger.push(`verify:${generation}`);
+      if (scenario.acknowledgementDelayMs) {
+        await new Promise<void>((resolve, reject) => {
+          const timer = setTimeout(resolve, scenario.acknowledgementDelayMs);
+          signal.addEventListener("abort", () => {
+            clearTimeout(timer);
+            reject(new DOMException("aborted", "AbortError"));
+          }, { once: true });
+        });
+      }
+      return scenario.actual;
+    },
+    async close() {
+      ledger.push("close");
+    },
+  };
+  return { driver, ledger };
+}
+
+const signal = () => new AbortController().signal;
+
+test("already High is proven without opening or interacting", async () => {
+  const { driver, ledger } = scenarioDriver({
+    passive: 2,
+    open: new Error("must not open"),
+  });
+  expect(await ensureChatGptEffortSelection(driver, 2, signal())).toEqual({ changed: false, transitions: 0 });
+  expect(ledger).toEqual(["read-current"]);
+});
+
+for (const [name, current] of [["Low", 0], ["Medium", 1]] as const) {
+  test(`${name} performs one logical transition to High and verifies actual state`, async () => {
+    const { driver, ledger } = scenarioDriver({
+      passive: current,
+      open: { kind: "menu", optionCount: 5, currentIndex: current, targetLabel: "High" },
+      actual: 2,
+    });
+    expect(await ensureChatGptEffortSelection(driver, 2, signal())).toEqual({ changed: true, transitions: 1 });
+    expect(ledger.filter(entry => entry.startsWith("transition"))).toHaveLength(1);
+    expect(ledger.at(-1)).toBe("close");
+  });
+}
+
+test("changed=false passes when authoritative actual state is High", async () => {
+  const { driver, ledger } = scenarioDriver({
+    passive: 1,
+    open: { kind: "menu", optionCount: 5, currentIndex: 1, targetLabel: "High" },
+    changed: false,
+    actual: 2,
+  });
+  expect(await ensureChatGptEffortSelection(driver, 2, signal())).toEqual({ changed: false, transitions: 1 });
+  expect(ledger).toContain("verify:0");
+});
+
+for (const shape of ["legacy-menu", "observed-group-radio"] as const) {
+  test(`${shape} uses structural checked index and one High transition`, async () => {
+    const { driver, ledger } = scenarioDriver({
+      open: { kind: "menu", optionCount: 5, currentIndex: 0, targetLabel: "High" },
+      actual: 2,
+    });
+    await expect(ensureChatGptEffortSelection(driver, 2, signal())).resolves.toMatchObject({ transitions: 1 });
+    expect(ledger.filter(entry => entry.startsWith("transition"))).toHaveLength(1);
+  });
+}
+
+test("previous slider shape transitions by structural range and verifies High", async () => {
+  const { driver, ledger } = scenarioDriver({
+    open: { kind: "slider", min: 0, max: 4, value: 0 },
+    actual: 2,
+  });
+  await expect(ensureChatGptEffortSelection(driver, 2, signal())).resolves.toMatchObject({ transitions: 1 });
+  expect(ledger).toEqual(["read-current", "open:0", "transition:0", "verify:0", "close"]);
+});
+
+test("selector absence fails closed without a transition", async () => {
+  const { driver, ledger } = scenarioDriver({ open: new Error("ChatGPT effort control is absent") });
+  await expect(ensureChatGptEffortSelection(driver, 2, signal())).rejects.toThrow("absent");
+  expect(ledger.some(entry => entry.startsWith("transition"))).toBe(false);
+});
+
+test("multiple ambiguous selectors fail closed without a transition", async () => {
+  const { driver, ledger } = scenarioDriver({ open: new Error("ChatGPT effort menu is ambiguous (visibleCount=2)") });
+  await expect(ensureChatGptEffortSelection(driver, 2, signal())).rejects.toThrow("ambiguous");
+  expect(ledger.some(entry => entry.startsWith("transition"))).toBe(false);
+});
+
+test("a stale element receives exactly one bounded DOM re-resolution", async () => {
+  const { driver, ledger } = scenarioDriver({
+    staleOnce: true,
+    open: { kind: "menu", optionCount: 5, currentIndex: 0, targetLabel: "High" },
+    actual: 2,
+  });
+  await expect(ensureChatGptEffortSelection(driver, 2, signal())).resolves.toMatchObject({ transitions: 1 });
+  expect(ledger.filter(entry => entry.startsWith("open"))).toEqual(["open:0", "open:1"]);
+  expect(ledger.filter(entry => entry.startsWith("transition"))).toHaveLength(1);
+});
+
+test("a second stale element failure is not retried", async () => {
+  let opens = 0;
+  const driver = scenarioDriver({
+    open: new ChatGptEffortStaleDomError(),
+  });
+  driver.driver.openAndRead = async () => {
+    opens += 1;
+    throw new ChatGptEffortStaleDomError();
+  };
+  await expect(ensureChatGptEffortSelection(driver.driver, 2, signal())).rejects.toBeInstanceOf(ChatGptEffortStaleDomError);
+  expect(opens).toBe(2);
+});
+
+test("delayed acknowledgement is awaited before PASS", async () => {
+  const { driver, ledger } = scenarioDriver({
+    open: { kind: "menu", optionCount: 5, currentIndex: 1, targetLabel: "High" },
+    actual: 2,
+    acknowledgementDelayMs: 20,
+  });
+  await expect(ensureChatGptEffortSelection(driver, 2, signal())).resolves.toMatchObject({ transitions: 1 });
+  expect(ledger.at(-1)).toBe("close");
+});
+
+test("interaction followed by a non-High final state fails closed", async () => {
+  const { driver, ledger } = scenarioDriver({
+    open: { kind: "menu", optionCount: 5, currentIndex: 0, targetLabel: "High" },
+    actual: 1,
+  });
+  await expect(ensureChatGptEffortSelection(driver, 2, signal())).rejects.toThrow("actual=1");
+  expect(ledger).not.toContain("close");
+});
+
+test("model-specific option variation rejects unavailable target", async () => {
+  const { driver, ledger } = scenarioDriver({
+    open: { kind: "slider", min: 0, max: 2, value: 0 },
+    actual: 4,
+  });
+  await expect(ensureChatGptEffortSelection(driver, 4, signal())).rejects.toThrow("optionCount=3");
+  expect(ledger.some(entry => entry.startsWith("transition"))).toBe(false);
+});
+
+test("an unexpected sixth menu option fails closed before interaction", async () => {
+  const { driver, ledger } = scenarioDriver({
+    open: { kind: "menu", optionCount: 6, currentIndex: 0, targetLabel: "High" },
+    actual: 2,
+  });
+  await expect(ensureChatGptEffortSelection(driver, 2, signal())).rejects.toThrow("optionCount=6");
+  expect(ledger.some(entry => entry.startsWith("transition"))).toBe(false);
+});
+
+test("timeout aborts acknowledgement and never repeats the transition", async () => {
+  const controller = new AbortController();
+  const { driver, ledger } = scenarioDriver({
+    open: { kind: "menu", optionCount: 5, currentIndex: 0, targetLabel: "High" },
+    actual: 2,
+    acknowledgementDelayMs: 500,
+  });
+  setTimeout(() => controller.abort(), 10);
+  await expect(ensureChatGptEffortSelection(driver, 2, controller.signal)).rejects.toThrow("aborted");
+  expect(ledger.filter(entry => entry.startsWith("transition"))).toHaveLength(1);
+});
+
+test("DOM replacement during transition is verified from the new generation", async () => {
+  const { driver, ledger } = scenarioDriver({
+    open: { kind: "menu", optionCount: 5, currentIndex: 0, targetLabel: "High" },
+    actual: 2,
+    replaceOnTransition: true,
+  });
+  await expect(ensureChatGptEffortSelection(driver, 2, signal())).resolves.toMatchObject({ transitions: 1 });
+  expect(ledger).toContain("verify:1");
+});
+
+test("all transitions are target-scoped and unrelated interaction remains zero", async () => {
+  const { driver, ledger } = scenarioDriver({
+    open: { kind: "menu", optionCount: 5, currentIndex: 0, targetLabel: "High" },
+    actual: 2,
+  });
+  await ensureChatGptEffortSelection(driver, 2, signal());
+  expect(ledger.filter(entry => entry.includes("unrelated"))).toHaveLength(0);
+  expect(ledger.filter(entry => entry.startsWith("transition"))).toHaveLength(1);
+});
+
+test("current-state labels are read without opening the selector", () => {
+  expect(chatGptEffortIndexFromControlLabel("High")).toBe(2);
+  expect(chatGptEffortIndexFromControlLabel(" 高い ")).toBe(2);
+  expect(chatGptEffortIndexFromControlLabel("Medium")).toBe(1);
+  expect(chatGptEffortIndexFromControlLabel("not an effort")).toBeUndefined();
+});
+
+test("already-selected open state performs no logical transition", async () => {
+  const { driver, ledger } = scenarioDriver({
+    open: { kind: "slider", min: 0, max: 4, value: 2 },
+    actual: 2,
+  });
+  expect(await ensureChatGptEffortSelection(driver, 2, signal())).toEqual({ changed: false, transitions: 0 });
+  expect(ledger.some(entry => entry.startsWith("transition"))).toBe(false);
+});
+
+test("every supported target index remains structurally bounded", async () => {
+  for (const target of [0, 1, 2, 3, 4] as ChatGptEffortIndex[]) {
+    const { driver } = scenarioDriver({
+      open: { kind: "menu", optionCount: 5, currentIndex: target === 0 ? 1 : 0, targetLabel: `target-${target}` },
+      actual: target,
+    });
+    await expect(ensureChatGptEffortSelection(driver, target, signal())).resolves.toMatchObject({ transitions: 1 });
+  }
+});

--- a/tests/fixtures/real-additional-tools.json
+++ b/tests/fixtures/real-additional-tools.json
@@ -1,0 +1,72 @@
+{
+  "type": "additional_tools",
+  "role": "developer",
+  "tools": [
+    {
+      "type": "namespace",
+      "name": "functions",
+      "description": "",
+      "tools": [
+        {
+          "type": "custom",
+          "name": "exec",
+          "description": "Run JavaScript code to orchestrate and compose tool calls.",
+          "format": {
+            "type": "grammar",
+            "syntax": "lark",
+            "definition": "start: source\nsource: /[\\s\\S]+/"
+          }
+        },
+        {
+          "type": "function",
+          "name": "wait",
+          "description": "Wait on a yielded exec cell.",
+          "strict": false,
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "cell_id": { "type": "string" }
+            },
+            "required": ["cell_id"]
+          }
+        },
+        {
+          "type": "function",
+          "name": "request_user_input",
+          "description": "Request short user input.",
+          "strict": false,
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "questions": { "type": "array" }
+            },
+            "required": ["questions"]
+          }
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "top_function",
+      "description": "A top-level function tool.",
+      "strict": true,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "value": { "type": "string" }
+        },
+        "required": ["value"]
+      }
+    },
+    {
+      "type": "custom",
+      "name": "top_custom",
+      "description": "A top-level custom tool.",
+      "format": {
+        "type": "grammar",
+        "syntax": "lark",
+        "definition": "start: /.+/"
+      }
+    }
+  ]
+}

--- a/tests/responses-lite-tools.test.ts
+++ b/tests/responses-lite-tools.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "bun:test";
 import { defaultConfig } from "../src/config";
 import { parseRequest } from "../src/responses/parser";
 import { responseRequest } from "../src/server";
+import { namespacedToolName } from "../src/types";
 
 const freeformFormat = {
   type: "grammar",
@@ -37,7 +38,7 @@ function responsesLiteTools() {
   }];
 }
 
-test("Responses Lite exposes native exec from the default functions namespace only", () => {
+test("Responses Lite keeps native exec bare and preserves non-default custom namespaces", () => {
   const parsed = parseRequest({
     model: "chatgpt-web/luna",
     input: [{ type: "additional_tools", role: "developer", tools: responsesLiteTools() }],
@@ -50,7 +51,15 @@ test("Responses Lite exposes native exec from the default functions namespace on
   const waitTool = parsed.context.tools?.find(tool => tool.name === "wait");
   expect(waitTool).toEqual(expect.objectContaining({ name: "wait" }));
   expect(waitTool).not.toHaveProperty("namespace");
-  expect(parsed.context.tools?.some(tool => tool.name === "run_script")).toBe(false);
+  const runScript = parsed.context.tools?.find(tool => tool.name === "run_script");
+  expect(runScript).toEqual(expect.objectContaining({
+    name: "run_script",
+    namespace: "mcp__python",
+    freeform: true,
+    customFormat: freeformFormat,
+  }));
+  expect(namespacedToolName(runScript?.namespace, runScript?.name ?? "")).toBe("mcp__python__run_script");
+  expect(parsed.context.tools?.some(tool => tool.name === "run_script" && !tool.namespace)).toBe(false);
 });
 
 test("Responses Lite native exec survives a complete server request as one custom call", async () => {
@@ -96,4 +105,54 @@ test("Responses Lite native exec survives a complete server request as one custo
     name: "exec",
     input: "text('ok')",
   })]);
+});
+
+test("Responses Lite returns a namespaced custom tool with its original ABI", async () => {
+  const config = defaultConfig("full");
+  config.solAvailable = false;
+  config.proAvailable = false;
+  const turnId = "turn_responses_lite_namespaced_custom";
+  const response = await responseRequest(new Request("http://127.0.0.1:17841/v1/responses", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      model: "chatgpt-web/luna",
+      stream: false,
+      metadata: { turn_id: turnId, thread_id: "thread_responses_lite_namespaced_custom" },
+      input: [{
+        type: "additional_tools",
+        role: "developer",
+        tools: responsesLiteTools(),
+      }, {
+        type: "message",
+        id: "msg_responses_lite_namespaced_custom",
+        role: "user",
+        content: [{ type: "input_text", text: "Use the namespaced custom tool" }],
+        internal_chat_message_metadata_passthrough: { turn_id: turnId },
+      }],
+    }),
+  }), config, () => ({
+    name: "responses-lite-namespaced-custom-regression",
+    async runTurn(parsed, _incoming, emit) {
+      expect(parsed.context.tools).toContainEqual(expect.objectContaining({
+        name: "run_script",
+        namespace: "mcp__python",
+        freeform: true,
+      }));
+      emit({ type: "tool_call_start", id: "call_run_script", name: "mcp__python__run_script" });
+      emit({ type: "tool_call_delta", arguments: JSON.stringify({ input: "print(1)" }) });
+      emit({ type: "tool_call_end" });
+      emit({ type: "done", endTurn: false });
+    },
+  }));
+
+  expect(response.status).toBe(200);
+  const body = await response.json() as { output: Array<Record<string, unknown>> };
+  expect(body.output.filter(item => item.type === "custom_tool_call")).toEqual([expect.objectContaining({
+    call_id: "call_run_script",
+    name: "run_script",
+    namespace: "mcp__python",
+    input: "print(1)",
+  })]);
+  expect(body.output.some(item => item.type === "function_call" && item.call_id === "call_run_script")).toBe(false);
 });

--- a/tests/responses-parser-tools.test.ts
+++ b/tests/responses-parser-tools.test.ts
@@ -1,0 +1,318 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { bridgeToResponsesSSE, buildResponseJSON } from "../src/bridge";
+import { compileChatGptWebPrompt } from "../src/adapters/chatgpt-web/prompt";
+import { CHATGPT_WEB_MODEL_ID } from "../src/adapters/chatgpt-web/model";
+import { parseRequest } from "../src/responses/parser";
+import { toolBridgeMaps } from "../src/server";
+import { namespacedToolName } from "../src/types";
+
+type AdditionalToolsFixture = {
+  type: "additional_tools";
+  role: "developer";
+  tools: Array<Record<string, unknown>>;
+};
+
+function fixture(): AdditionalToolsFixture {
+  return JSON.parse(readFileSync(join(import.meta.dir, "fixtures/real-additional-tools.json"), "utf8"));
+}
+
+function fixtureWithSyntheticNamespaceCollisions(): AdditionalToolsFixture {
+  const additionalTools = fixture();
+  const functions = additionalTools.tools[0] as { tools: Array<Record<string, unknown>> };
+  functions.tools.splice(1, 0,
+    {
+      type: "custom",
+      name: "inspect",
+      description: "A normal namespaced custom tool.",
+      format: { type: "grammar", syntax: "lark", definition: "start: /.+/" },
+    },
+  );
+  additionalTools.tools.splice(1, 0, {
+    type: "namespace",
+    name: "audit",
+    description: "",
+    tools: [
+      {
+        type: "custom",
+        name: "inspect",
+        description: "A same-leaf custom in another namespace.",
+        format: { type: "grammar", syntax: "lark", definition: "start: /.+/" },
+      },
+      {
+        type: "function",
+        name: "read",
+        description: "A normal function in a non-default namespace.",
+        parameters: { type: "object", properties: {} },
+      },
+    ],
+  });
+  return additionalTools;
+}
+
+function parseAdditionalTools(additionalTools = fixture()) {
+  return parseRequest({
+    model: "chatgpt-web/high",
+    input: [additionalTools],
+  });
+}
+
+describe("Responses additional_tools parser ABI", () => {
+  test("preserves the real nested custom exec and both nested function tools", () => {
+    const parsed = parseAdditionalTools();
+    const tools = parsed.context.tools ?? [];
+    const wireNames = tools.map(tool => namespacedToolName(tool.namespace, tool.name));
+
+    expect(wireNames).toEqual([
+      "exec",
+      "wait",
+      "request_user_input",
+      "top_function",
+      "top_custom",
+    ]);
+    expect(tools.find(tool => tool.name === "exec")).toMatchObject({
+      name: "exec",
+      freeform: true,
+      parameters: {
+        type: "object",
+        properties: { input: { type: "string" } },
+        required: ["input"],
+      },
+    });
+    expect(tools.find(tool => tool.name === "exec")?.namespace).toBeUndefined();
+  });
+
+  test("preserves namespace for ordinary nested custom tools with duplicate leaf names", () => {
+    const tools = parseAdditionalTools(fixtureWithSyntheticNamespaceCollisions()).context.tools ?? [];
+
+    expect(tools.find(tool => tool.name === "inspect" && tool.namespace === "functions")).toMatchObject({
+      namespace: "functions",
+      name: "inspect",
+      freeform: true,
+    });
+    expect(tools.find(tool => tool.name === "inspect" && tool.namespace === "audit")).toMatchObject({
+      namespace: "audit",
+      name: "inspect",
+      freeform: true,
+    });
+  });
+
+  test("keeps top-level and namespaced function contracts backward compatible", () => {
+    const tools = parseAdditionalTools().context.tools ?? [];
+
+    expect(tools.find(tool => tool.name === "wait")).toEqual({
+      name: "wait",
+      description: "Wait on a yielded exec cell.",
+      strict: false,
+      parameters: {
+        type: "object",
+        properties: { cell_id: { type: "string" } },
+        required: ["cell_id"],
+      },
+      loadedFromToolSearch: true,
+    });
+    expect(tools.find(tool => tool.name === "top_function")).toMatchObject({
+      name: "top_function",
+      description: "A top-level function tool.",
+      strict: true,
+      parameters: {
+        type: "object",
+        properties: { value: { type: "string" } },
+        required: ["value"],
+      },
+    });
+    expect(tools.find(tool => tool.name === "top_custom")).toMatchObject({
+      name: "top_custom",
+      freeform: true,
+    });
+  });
+
+  test("fails closed when custom tools collide after namespace flattening", () => {
+    const additionalTools = fixture();
+    additionalTools.tools.push({ type: "custom", name: "exec", description: "collision" });
+
+    expect(() => parseAdditionalTools(additionalTools)).toThrow("duplicate Codex tool wire name: exec");
+
+    const nestedFunctionCollision = fixture();
+    const functions = nestedFunctionCollision.tools[0] as { tools: Array<Record<string, unknown>> };
+    functions.tools.splice(1, 0, {
+      type: "function",
+      name: "exec",
+      description: "A default-namespace function sharing the custom command wire name.",
+      parameters: { type: "object", properties: {} },
+    });
+    expect(() => parseAdditionalTools(nestedFunctionCollision)).toThrow("duplicate Codex tool wire name: exec");
+  });
+
+  test("fails closed on a malformed nested custom entry", () => {
+    const additionalTools = fixture();
+    const namespace = additionalTools.tools[0] as { tools: Array<Record<string, unknown>> };
+    namespace.tools[0] = { type: "custom", description: "missing name" };
+
+    expect(() => parseAdditionalTools(additionalTools)).toThrow("invalid custom tool name");
+  });
+
+  test("fails closed on a malformed custom grammar", () => {
+    const additionalTools = fixture();
+    const namespace = additionalTools.tools[0] as { tools: Array<Record<string, unknown>> };
+    namespace.tools[0] = {
+      type: "custom",
+      name: "exec",
+      format: { type: "grammar", syntax: "lark" },
+    };
+
+    expect(() => parseAdditionalTools(additionalTools)).toThrow("invalid custom tool grammar format");
+  });
+
+  test("fails closed on unknown custom format types and grammar syntaxes", () => {
+    const unknownType = fixture();
+    unknownType.tools.push({ type: "custom", name: "bad_type", format: { type: "bogus" } });
+    expect(() => parseAdditionalTools(unknownType)).toThrow("invalid custom tool format type");
+
+    const unknownSyntax = fixture();
+    unknownSyntax.tools.push({
+      type: "custom",
+      name: "bad_syntax",
+      format: { type: "grammar", syntax: "bogus", definition: "start: /.+/" },
+    });
+    expect(() => parseAdditionalTools(unknownSyntax)).toThrow("invalid custom tool grammar format");
+  });
+
+  test("rejects whitespace-padded command aliases before they enter the catalog", () => {
+    const additionalTools = fixture();
+    additionalTools.tools.push({ type: "custom", name: " exec ", description: "padded alias" });
+
+    expect(() => parseAdditionalTools(additionalTools)).toThrow("invalid custom tool name");
+  });
+
+  test("deduplicates identical definitions but rejects conflicting definitions", () => {
+    const identical = fixture();
+    identical.tools.push(structuredClone(identical.tools.at(-1)!));
+    expect(parseAdditionalTools(identical).context.tools?.filter(tool => tool.name === "top_custom")).toHaveLength(1);
+
+    const conflicting = fixture();
+    conflicting.tools.push({ type: "custom", name: "top_custom", description: "different" });
+    expect(() => parseAdditionalTools(conflicting)).toThrow("duplicate Codex tool wire name: top_custom");
+
+    const grammarConflict = fixture();
+    grammarConflict.tools.push({
+      ...structuredClone(grammarConflict.tools.at(-1)!),
+      format: { type: "grammar", syntax: "lark", definition: "start: /DIFFERENT/" },
+    });
+    expect(() => parseAdditionalTools(grammarConflict)).toThrow("duplicate Codex tool wire name: top_custom");
+  });
+
+  test("keeps the explicit computer-use compatibility ABI but drops hosted and unknown types", () => {
+    const additionalTools = fixture();
+    additionalTools.tools.push(
+      { type: "computer_use_preview", name: "computer", description: "Client computer tool", parameters: {} },
+      { type: "web_search", name: "hosted_search", description: "Hosted" },
+      { type: "future_server_side_tool", name: "must_not_execute", description: "Unknown" },
+    );
+
+    const tools = parseAdditionalTools(additionalTools).context.tools ?? [];
+    expect(tools.find(tool => tool.name === "computer")).toMatchObject({ name: "computer" });
+    expect(tools.some(tool => tool.name === "hosted_search")).toBe(false);
+    expect(tools.some(tool => tool.name === "must_not_execute")).toBe(false);
+  });
+
+  test("uses the active parser catalog for tool_search exact-name guidance", () => {
+    const loaded = fixture().tools;
+    const parsed = parseRequest({
+      model: "chatgpt-web/high",
+      input: [
+        { type: "tool_search_call", call_id: "search_1", arguments: { query: "command" } },
+        { type: "tool_search_output", call_id: "search_1", status: "completed", tools: loaded },
+      ],
+    });
+    const result = parsed.context.messages.find(message => message.role === "toolResult");
+    const content = result?.content;
+    const expectedWireNames = (parsed.context.tools ?? [])
+      .map(tool => namespacedToolName(tool.namespace, tool.name));
+
+    expect(content).toBe(`Tool search loaded these tools — they are now in your available tools. Call one by its EXACT name: ${expectedWireNames.join(", ")}.`);
+  });
+
+  test("round-trips custom namespace through history and both bridge modes", async () => {
+    const parsed = parseRequest({
+      model: "chatgpt-web/high",
+      input: [
+        { type: "custom_tool_call", call_id: "custom_1", name: "inspect", namespace: "audit", input: "record" },
+        { type: "custom_tool_call_output", call_id: "custom_1", output: "ok" },
+        { type: "custom_tool_call", call_id: "exec_1", name: "exec", namespace: "functions", input: "text('ok')" },
+        { type: "custom_tool_call_output", call_id: "exec_1", output: "ok" },
+        fixtureWithSyntheticNamespaceCollisions(),
+      ],
+    });
+    const historyCall = parsed.context.messages
+      .flatMap(message => message.role === "assistant" ? message.content : [])
+      .find(part => part.type === "toolCall" && part.id === "custom_1");
+    const historyResult = parsed.context.messages.find(message => message.role === "toolResult" && message.toolCallId === "custom_1");
+    expect(historyCall).toMatchObject({ name: "inspect", namespace: "audit", customWireName: "inspect" });
+    expect(historyResult).toMatchObject({ toolName: "inspect", toolNamespace: "audit" });
+    const historicalExec = parsed.context.messages
+      .flatMap(message => message.role === "assistant" ? message.content : [])
+      .find(part => part.type === "toolCall" && part.id === "exec_1");
+    expect(historicalExec).toMatchObject({ name: "exec", customWireName: "exec" });
+    expect(historicalExec).not.toHaveProperty("namespace");
+    parsed.modelId = CHATGPT_WEB_MODEL_ID;
+    const compiled = compileChatGptWebPrompt(
+      parsed,
+      { localToolsEnabled: true, solAvailable: true, proAvailable: true },
+      "turn_12345678901234567890123456789012",
+    );
+    expect(compiled.text).toContain('"name":"audit__inspect"');
+    expect(compiled.text).toContain('"tool_name":"audit__inspect"');
+
+    const maps = toolBridgeMaps(parsed);
+    const events = [
+      { type: "tool_call_start" as const, id: "call_fn", name: "audit__read" },
+      { type: "tool_call_delta" as const, id: "call_fn", arguments: "{}" },
+      { type: "tool_call_start" as const, id: "call_custom", name: "audit__inspect" },
+      { type: "tool_call_delta" as const, id: "call_custom", arguments: '{"input":"record"}' },
+      { type: "done" as const, stopReason: "tool_use", endTurn: false },
+    ];
+    const response = buildResponseJSON(events, "chatgpt-web/high", maps) as { output: Array<Record<string, unknown>> };
+    expect(response.output.find(item => item.call_id === "call_fn")).toMatchObject({
+      type: "function_call", name: "read", namespace: "audit",
+    });
+    expect(response.output.find(item => item.call_id === "call_custom")).toMatchObject({
+      type: "custom_tool_call", name: "inspect", namespace: "audit", input: "record",
+    });
+
+    async function* streamEvents() { yield* events; }
+    const stream = bridgeToResponsesSSE(
+      streamEvents(),
+      "chatgpt-web/high",
+      maps.toolNsMap,
+      maps.freeformToolNames,
+      maps.toolSearchToolNames,
+    );
+    const sse = await new Response(stream).text();
+    const payloads = sse.split("\n")
+      .filter(line => line.startsWith("data: ") && line !== "data: [DONE]")
+      .map(line => JSON.parse(line.slice(6)) as Record<string, unknown>);
+    const doneItems = payloads
+      .filter(payload => payload.type === "response.output_item.done")
+      .map(payload => payload.item as Record<string, unknown>);
+    expect(doneItems.find(item => item.call_id === "call_fn")).toMatchObject({
+      type: "function_call", name: "read", namespace: "audit",
+    });
+    expect(doneItems.find(item => item.call_id === "call_custom")).toMatchObject({
+      type: "custom_tool_call", name: "inspect", namespace: "audit", input: "record",
+    });
+  });
+
+  test("does not turn an unknown named tool type into an executable tool", () => {
+    const additionalTools = fixture();
+    additionalTools.tools.push({
+      type: "future_server_side_tool",
+      name: "must_not_execute",
+      description: "Unknown tool kinds are not client executable by default.",
+    });
+
+    const tools = parseAdditionalTools(additionalTools).context.tools ?? [];
+    expect(tools.some(tool => tool.name === "must_not_execute")).toBe(false);
+  });
+});

--- a/tests/turn-broker-lifecycle.test.ts
+++ b/tests/turn-broker-lifecycle.test.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "bun:test";
 import { ChatGptTextFeed, ChatGptTraceFeed, ChatGptTurnSessions } from "../src/adapters/chatgpt-web/turn-execution";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync } from "node:fs";
-import { createServer, type Socket } from "node:net";
+import { createConnection, createServer, type Socket } from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { callTurnBroker, TurnBroker } from "../src/adapters/chatgpt-web/turn-broker";
+import { callTurnBroker, TurnBroker, type BrokerToolResult } from "../src/adapters/chatgpt-web/turn-broker";
 import { defaultBrokerEndpoint, isWindowsPipeEndpoint } from "../src/config";
 
 test("explicit browser-turn cancellation aborts and removes every registered session", async () => {
@@ -85,6 +85,29 @@ test("session cache expiry never cancels a still-active long browser turn", asyn
   })).toBe(active);
   expect(cancelled).toBe(0);
   sessions.clear();
+});
+
+test("a settled browser session remains active until every delivered native result is recorded", async () => {
+  const sessions = new ChatGptTurnSessions();
+  const session = sessions.getOrCreate("settled-with-native-work", () => ({
+    mode: "tools",
+    token: Promise.resolve("turn-test-active-drain"),
+    browser: Promise.resolve("done"),
+    trace: new ChatGptTraceFeed(),
+    text: new ChatGptTextFeed(),
+    cancel: () => {},
+  }));
+  session.setOutstanding([{
+    callId: "call-active-drain",
+    wireName: "exec_command",
+    freeform: false,
+    arguments: { cmd: "pwd" },
+  }]);
+  await session.browserOutcome;
+
+  expect(sessions.activeCount()).toBe(1);
+  session.markResultDelivered("call-active-drain");
+  expect(sessions.activeCount()).toBe(0);
 });
 
 test("five active turns coexist and a sixth fails closed", () => {
@@ -296,6 +319,589 @@ test("turn broker names the finished turn that owns a replayed handle", async ()
     });
     expect(unknownBinding).toBe("internal Codex turn binding is invalid or expired");
   } finally {
+    await broker.close();
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("aborting a broker client removes invocation work before the adapter can claim it", async () => {
+  const root = mkdtempSync(join(tmpdir(), "cgw-broker-abort-"));
+  const socketPath = defaultBrokerEndpoint(root);
+  const broker = TurnBroker.forSocket(socketPath);
+  try {
+    const token = await broker.register({
+      cwd: root,
+      roots: [root],
+      writableRoots: [root],
+      sandboxPolicy: { type: "workspaceWrite", writableRoots: [root], networkAccess: false },
+      tools: [{ name: "exec_command", description: "Run command", parameters: { type: "object" } }],
+    }, 10_000);
+    const claimed = await callTurnBroker<{ bindingId: string }>(socketPath, { method: "claim", token });
+    const abort = new AbortController();
+    const invocation = callTurnBroker<BrokerToolResult>(socketPath, {
+      method: "invoke",
+      bindingId: claimed.bindingId,
+      wireName: "exec_command",
+      freeform: false,
+      arguments: { cmd: "pwd" },
+    }, 10_000, abort.signal);
+    await Bun.sleep(25);
+    abort.abort();
+    await expect(invocation).rejects.toThrow("aborted");
+    await Bun.sleep(25);
+
+    const noWork = new AbortController();
+    const pending = broker.nextToolBatch(token, noWork.signal);
+    setTimeout(() => noWork.abort(), 25);
+    await expect(pending).rejects.toThrow("aborted");
+  } finally {
+    await broker.close();
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("disconnecting a broker socket removes queued executable work", async () => {
+  const root = mkdtempSync(join(tmpdir(), "cgw-broker-disconnect-"));
+  const socketPath = defaultBrokerEndpoint(root);
+  const broker = TurnBroker.forSocket(socketPath);
+  try {
+    const token = await broker.register({
+      cwd: root,
+      roots: [root],
+      writableRoots: [root],
+      sandboxPolicy: { type: "workspaceWrite", writableRoots: [root], networkAccess: false },
+      tools: [{ name: "exec_command", description: "Run command", parameters: { type: "object" } }],
+    }, 10_000);
+    const claimed = await callTurnBroker<{ bindingId: string }>(socketPath, { method: "claim", token });
+    const socket = createConnection(socketPath);
+    await new Promise<void>((resolveConnected, rejectConnected) => {
+      socket.once("connect", resolveConnected);
+      socket.once("error", rejectConnected);
+    });
+    socket.write(`${JSON.stringify({
+      id: "disconnect-request",
+      method: "invoke",
+      bindingId: claimed.bindingId,
+      wireName: "exec_command",
+      freeform: false,
+      arguments: { cmd: "pwd" },
+    })}\n`);
+    await Bun.sleep(25);
+    socket.destroy();
+    await Bun.sleep(25);
+
+    const noWork = new AbortController();
+    const pending = broker.nextToolBatch(token, noWork.signal);
+    setTimeout(() => noWork.abort(), 25);
+    await expect(pending).rejects.toThrow("aborted");
+  } finally {
+    await broker.close();
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("disconnecting an external owner wait cannot consume a later tool batch", async () => {
+  const root = mkdtempSync(join(tmpdir(), "cgw-broker-owner-disconnect-"));
+  const socketPath = defaultBrokerEndpoint(root);
+  const broker = TurnBroker.forSocket(socketPath);
+  try {
+    const token = await broker.register({
+      cwd: root,
+      roots: [root],
+      writableRoots: [root],
+      sandboxPolicy: { type: "workspaceWrite", writableRoots: [root], networkAccess: false },
+      tools: [{ name: "exec_command", description: "Run command", parameters: { type: "object" } }],
+    }, 10_000);
+    const claimed = await callTurnBroker<{ bindingId: string }>(socketPath, { method: "claim", token });
+    const abandonedOwner = createConnection(socketPath);
+    await new Promise<void>((resolveConnected, rejectConnected) => {
+      abandonedOwner.once("connect", resolveConnected);
+      abandonedOwner.once("error", rejectConnected);
+    });
+    abandonedOwner.write(`${JSON.stringify({
+      id: "abandoned-owner-next",
+      method: "owner_next",
+      token,
+    })}\n`);
+    await Bun.sleep(25);
+    abandonedOwner.destroy();
+    await Bun.sleep(25);
+
+    const invocation = callTurnBroker<BrokerToolResult>(socketPath, {
+      method: "invoke",
+      bindingId: claimed.bindingId,
+      wireName: "exec_command",
+      freeform: false,
+      arguments: { cmd: "pwd" },
+    }, 10_000);
+    const next = new AbortController();
+    const timer = setTimeout(() => next.abort(), 1_000);
+    const [request] = await broker.nextToolBatch(token, next.signal);
+    clearTimeout(timer);
+    expect(request?.wireName).toBe("exec_command");
+    broker.completeTool(token, request!.callId, {
+      content: [{ type: "text", text: "completed" }],
+    });
+    expect(await invocation).toMatchObject({ content: [{ type: "text", text: "completed" }] });
+  } finally {
+    await broker.close();
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("disconnecting after delivery preserves the invocation until its terminal result", async () => {
+  const root = mkdtempSync(join(tmpdir(), "cgw-broker-delivered-disconnect-"));
+  const socketPath = defaultBrokerEndpoint(root);
+  const broker = TurnBroker.forSocket(socketPath);
+  try {
+    const token = await broker.register({
+      cwd: root,
+      roots: [root],
+      writableRoots: [root],
+      sandboxPolicy: { type: "workspaceWrite", writableRoots: [root], networkAccess: false },
+      tools: [{ name: "exec_command", description: "Run command", parameters: { type: "object" } }],
+    }, 10_000);
+    const claimed = await callTurnBroker<{ bindingId: string }>(socketPath, { method: "claim", token });
+    const socket = createConnection(socketPath);
+    await new Promise<void>((resolveConnected, rejectConnected) => {
+      socket.once("connect", resolveConnected);
+      socket.once("error", rejectConnected);
+    });
+    socket.write(`${JSON.stringify({
+      id: "delivered-disconnect-request",
+      method: "invoke",
+      bindingId: claimed.bindingId,
+      invocationKey: "same-delivered-command",
+      wireName: "exec_command",
+      freeform: false,
+      arguments: { cmd: "pwd" },
+    })}\n`);
+    const [request] = await broker.nextToolBatch(token);
+    expect(request?.wireName).toBe("exec_command");
+
+    socket.destroy();
+    await Bun.sleep(25);
+
+    const replay = callTurnBroker<BrokerToolResult>(socketPath, {
+      method: "invoke",
+      bindingId: claimed.bindingId,
+      invocationKey: "same-delivered-command",
+      wireName: "exec_command",
+      freeform: false,
+      arguments: { cmd: "pwd" },
+    }, 10_000);
+    const ambiguousRetry = callTurnBroker<BrokerToolResult>(socketPath, {
+      method: "invoke",
+      bindingId: claimed.bindingId,
+      invocationKey: "different-request-same-command",
+      wireName: "exec_command",
+      freeform: false,
+      arguments: { cmd: "pwd" },
+    }, 10_000);
+    await expect(ambiguousRetry).rejects.toThrow("equivalent broker invocation is already executing");
+
+    const noWork = new AbortController();
+    const pending = broker.nextToolBatch(token, noWork.signal);
+    setTimeout(() => noWork.abort(), 25);
+    await expect(pending).rejects.toThrow("aborted");
+
+    const terminal = { content: [{ type: "text", text: "done" }] };
+    expect(() => broker.completeTool(token, request.callId, terminal)).not.toThrow();
+    expect(await replay).toEqual(terminal);
+
+    const deliberateSecondCall = callTurnBroker<BrokerToolResult>(socketPath, {
+      method: "invoke",
+      bindingId: claimed.bindingId,
+      invocationKey: "new-logical-request-after-terminal",
+      wireName: "exec_command",
+      freeform: false,
+      arguments: { cmd: "pwd" },
+    }, 10_000);
+    const [secondRequest] = await broker.nextToolBatch(token);
+    expect(secondRequest.callId).not.toBe(request.callId);
+    broker.completeTool(token, secondRequest.callId, terminal);
+    expect(await deliberateSecondCall).toEqual(terminal);
+  } finally {
+    await broker.close();
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("broker operation identity survives caller restart and a queued continuation abort", async () => {
+  const root = mkdtempSync(join(tmpdir(), "cgw-broker-operation-identity-"));
+  const socketPath = defaultBrokerEndpoint(root);
+  const broker = TurnBroker.forSocket(socketPath);
+  try {
+    const token = await broker.register({
+      cwd: root,
+      roots: [root],
+      writableRoots: [root],
+      sandboxPolicy: { type: "workspaceWrite", writableRoots: [root], networkAccess: false },
+      tools: [{ name: "exec_command", description: "Run command", parameters: { type: "object" } }],
+    }, 10_000);
+    const claimed = await callTurnBroker<{ bindingId: string }>(socketPath, { method: "claim", token });
+    const operationKey = "semantic-pwd-operation";
+    const firstRequestKey = "logical-request-one";
+    const first = callTurnBroker<BrokerToolResult>(socketPath, {
+      method: "invoke",
+      bindingId: claimed.bindingId,
+      invocationKey: "logical-request-one-invocation",
+      operationKey,
+      operationRequestKey: firstRequestKey,
+      wireName: "exec_command",
+      freeform: false,
+      arguments: { cmd: "pwd" },
+    }, 10_000);
+    const [request] = await broker.nextToolBatch(token);
+    const pending: BrokerToolResult = {
+      content: [{ type: "text", text: "Script running with cell ID operation-cell\nWall time 0.1 seconds\nOutput:\n" }],
+    };
+    broker.completeTool(token, request!.callId, pending);
+    expect(await first).toEqual(pending);
+
+    const restartedReplay = callTurnBroker<BrokerToolResult>(socketPath, {
+      method: "invoke",
+      bindingId: claimed.bindingId,
+      invocationKey: "logical-request-one-invocation",
+      operationKey,
+      operationRequestKey: firstRequestKey,
+      wireName: "exec_command",
+      freeform: false,
+      arguments: { cmd: "pwd" },
+    }, 10_000);
+    expect(await restartedReplay).toEqual(pending);
+
+    await expect(callTurnBroker(socketPath, {
+      method: "invoke",
+      bindingId: claimed.bindingId,
+      invocationKey: "logical-request-two-invocation",
+      operationKey,
+      operationRequestKey: "logical-request-two",
+      wireName: "exec_command",
+      freeform: false,
+      arguments: { cmd: "pwd" },
+    }, 10_000)).rejects.toThrow("operation is already active under a different request identity");
+
+    const continuationAbort = new AbortController();
+    const abortedContinuation = callTurnBroker<BrokerToolResult>(socketPath, {
+      method: "invoke",
+      bindingId: claimed.bindingId,
+      invocationKey: "aborted-pending-continuation",
+      operationKey,
+      operationRequestKey: firstRequestKey,
+      wireName: "wait",
+      freeform: false,
+      arguments: { cell_id: "operation-cell" },
+    }, 10_000, continuationAbort.signal);
+    await Bun.sleep(25);
+    continuationAbort.abort();
+    await expect(abortedContinuation).rejects.toThrow("aborted");
+
+    await expect(callTurnBroker(socketPath, {
+      method: "invoke",
+      bindingId: claimed.bindingId,
+      invocationKey: "logical-request-two-invocation",
+      operationKey,
+      operationRequestKey: "logical-request-two",
+      wireName: "exec_command",
+      freeform: false,
+      arguments: { cmd: "pwd" },
+    }, 10_000)).rejects.toThrow("operation is already active under a different request identity");
+
+    const terminalContinuation = callTurnBroker<BrokerToolResult>(socketPath, {
+      method: "invoke",
+      bindingId: claimed.bindingId,
+      invocationKey: "terminal-pending-continuation",
+      operationKey,
+      operationRequestKey: firstRequestKey,
+      wireName: "wait",
+      freeform: false,
+      arguments: { cell_id: "operation-cell" },
+    }, 10_000);
+    const [continuationRequest] = await broker.nextToolBatch(token);
+    expect(continuationRequest).toMatchObject({ wireName: "wait", arguments: { cell_id: "operation-cell" } });
+    const terminal: BrokerToolResult = { content: [{ type: "text", text: "done" }] };
+    broker.completeTool(token, continuationRequest!.callId, terminal);
+    expect(await terminalContinuation).toEqual(terminal);
+
+    expect(await callTurnBroker<{ terminalized: boolean; pending: boolean }>(socketPath, {
+      method: "terminalize",
+      bindingId: claimed.bindingId,
+      operationKey,
+      operationRequestKey: firstRequestKey,
+    }, 10_000)).toEqual({ terminalized: true, pending: false });
+
+    await expect(callTurnBroker(socketPath, {
+      method: "invoke",
+      bindingId: claimed.bindingId,
+      invocationKey: "same-command-after-terminal",
+      operationKey,
+      operationRequestKey: "logical-request-after-terminal",
+      wireName: "exec_command",
+      freeform: false,
+      arguments: { cmd: "pwd" },
+    }, 10_000)).rejects.toThrow("operation invocation has already been terminalized");
+
+    const unrelated = callTurnBroker<BrokerToolResult>(socketPath, {
+      method: "invoke",
+      bindingId: claimed.bindingId,
+      invocationKey: "logical-request-after-terminal",
+      operationKey,
+      operationRequestKey: "logical-request-after-terminal",
+      wireName: "exec_command",
+      freeform: false,
+      arguments: { cmd: "git status --short" },
+    }, 10_000);
+    const [unrelatedRequest] = await broker.nextToolBatch(token);
+    broker.completeTool(token, unrelatedRequest!.callId, terminal);
+    expect(await unrelated).toEqual(terminal);
+  } finally {
+    await broker.close();
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("delivered command quarantine survives expiry, revoke, cross-channel calls, and broker restart", async () => {
+  const root = mkdtempSync(join(tmpdir(), "cgw-broker-command-quarantine-"));
+  const socketPath = defaultBrokerEndpoint(root);
+  const broker = TurnBroker.forSocket(socketPath);
+  let restarted: TurnBroker | undefined;
+  try {
+    const environment = {
+      cwd: root,
+      roots: [root],
+      writableRoots: [root],
+      sandboxPolicy: { type: "workspaceWrite" as const, writableRoots: [root], networkAccess: false },
+      tools: [{ name: "exec_command", description: "Run command", parameters: { type: "object" } }],
+    };
+    const firstToken = await broker.register(environment, 40, "quarantined-turn");
+    const secondToken = await broker.register(environment, 60_000, "unrelated-turn");
+    const firstBinding = await callTurnBroker<{ bindingId: string }>(socketPath, { method: "claim", token: firstToken });
+    const secondBinding = await callTurnBroker<{ bindingId: string }>(socketPath, { method: "claim", token: secondToken });
+    const operationKey = "global-command-operation";
+    const operationRequestKey = "first-command-request";
+    const first = callTurnBroker<BrokerToolResult>(socketPath, {
+      method: "invoke",
+      bindingId: firstBinding.bindingId,
+      invocationKey: "first-command-invocation",
+      operationKey,
+      operationRequestKey,
+      wireName: "exec_command",
+      freeform: false,
+      arguments: { cmd: "pwd" },
+    }, 10_000);
+    const [request] = await broker.nextToolBatch(firstToken);
+    const pending: BrokerToolResult = {
+      content: [{ type: "text", text: "Script running with cell ID quarantined-cell\nWall time 0.1 seconds\nOutput:\n" }],
+    };
+    broker.completeTool(firstToken, request!.callId, pending);
+    expect(await first).toEqual(pending);
+
+    await Bun.sleep(50);
+    await expect(callTurnBroker(socketPath, {
+      method: "invoke",
+      bindingId: secondBinding.bindingId,
+      invocationKey: "second-command-invocation",
+      operationKey,
+      operationRequestKey: "second-command-request",
+      wireName: "exec_command",
+      freeform: false,
+      arguments: { cmd: "git status --short" },
+    }, 10_000)).rejects.toThrow("protected broker operation is already active");
+    await expect(callTurnBroker(socketPath, {
+      method: "invoke",
+      bindingId: secondBinding.bindingId,
+      invocationKey: "generic-bypass-invocation",
+      wireName: "view_image",
+      freeform: false,
+      arguments: { path: "/tmp/nonexistent.png" },
+    }, 10_000)).rejects.toThrow("protected broker operation is already active");
+
+    broker.revoke(firstToken);
+    expect(await callTurnBroker<BrokerToolResult>(socketPath, {
+      method: "invoke",
+      bindingId: firstBinding.bindingId,
+      invocationKey: "first-command-invocation",
+      operationKey,
+      operationRequestKey,
+      wireName: "exec_command",
+      freeform: false,
+      arguments: { cmd: "pwd" },
+    }, 10_000)).toEqual(pending);
+
+    await broker.close();
+    restarted = TurnBroker.forSocket(socketPath);
+    const restartedToken = await restarted.register(environment, 60_000, "restarted-turn");
+    const restartedBinding = await callTurnBroker<{ bindingId: string }>(socketPath, {
+      method: "claim",
+      token: restartedToken,
+    });
+    await expect(callTurnBroker(socketPath, {
+      method: "invoke",
+      bindingId: restartedBinding.bindingId,
+      invocationKey: "post-restart-command",
+      operationKey,
+      operationRequestKey: "post-restart-request",
+      wireName: "exec_command",
+      freeform: false,
+      arguments: { cmd: "pwd" },
+    }, 10_000)).rejects.toThrow("unresolved command quarantine");
+  } finally {
+    await restarted?.close().catch(() => {});
+    await broker.close().catch(() => {});
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("an undelivered protected command abort releases quarantine before any execution can start", async () => {
+  const root = mkdtempSync(join(tmpdir(), "cgw-broker-undelivered-command-"));
+  const socketPath = defaultBrokerEndpoint(root);
+  const broker = TurnBroker.forSocket(socketPath);
+  try {
+    const token = await broker.register({
+      cwd: root,
+      roots: [root],
+      writableRoots: [root],
+      sandboxPolicy: { type: "workspaceWrite", writableRoots: [root], networkAccess: false },
+      tools: [{ name: "exec_command", description: "Run command", parameters: { type: "object" } }],
+    }, 60_000);
+    const claimed = await callTurnBroker<{ bindingId: string }>(socketPath, { method: "claim", token });
+    const abort = new AbortController();
+    const abandoned = callTurnBroker(socketPath, {
+      method: "invoke",
+      bindingId: claimed.bindingId,
+      invocationKey: "undelivered-command",
+      operationKey: "global-command-operation",
+      operationRequestKey: "undelivered-request",
+      wireName: "exec_command",
+      freeform: false,
+      arguments: { cmd: "pwd" },
+    }, 10_000, abort.signal);
+    await Bun.sleep(25);
+    abort.abort();
+    await expect(abandoned).rejects.toThrow("aborted");
+    await Bun.sleep(50);
+
+    const next = callTurnBroker<BrokerToolResult>(socketPath, {
+      method: "invoke",
+      bindingId: claimed.bindingId,
+      invocationKey: "safe-next-command",
+      operationKey: "global-command-operation",
+      operationRequestKey: "safe-next-request",
+      wireName: "exec_command",
+      freeform: false,
+      arguments: { cmd: "git status --short" },
+    }, 10_000);
+    const [request] = await broker.nextToolBatch(token);
+    const terminal: BrokerToolResult = { content: [{ type: "text", text: "done" }] };
+    broker.completeTool(token, request!.callId, terminal);
+    expect(await next).toEqual(terminal);
+    expect(await callTurnBroker<{ terminalized: boolean; pending: boolean }>(socketPath, {
+      method: "terminalize",
+      bindingId: claimed.bindingId,
+      operationKey: "global-command-operation",
+      operationRequestKey: "safe-next-request",
+    }, 10_000)).toEqual({ terminalized: true, pending: false });
+  } finally {
+    await broker.close().catch(() => {});
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("broker replay cache fails closed on an oversized result without permitting redispatch", async () => {
+  const root = mkdtempSync(join(tmpdir(), "cgw-broker-replay-cap-"));
+  const socketPath = defaultBrokerEndpoint(root);
+  const broker = TurnBroker.forSocket(socketPath);
+  try {
+    const token = await broker.register({
+      cwd: root,
+      roots: [root],
+      writableRoots: [root],
+      sandboxPolicy: { type: "workspaceWrite", writableRoots: [root], networkAccess: false },
+      tools: [{ name: "view_image", description: "Read an image", parameters: { type: "object" } }],
+    }, 60_000);
+    const claimed = await callTurnBroker<{ bindingId: string }>(socketPath, { method: "claim", token });
+    const oversized = callTurnBroker<BrokerToolResult>(socketPath, {
+      method: "invoke",
+      bindingId: claimed.bindingId,
+      invocationKey: "oversized-replay-result",
+      wireName: "view_image",
+      freeform: false,
+      arguments: { path: "/tmp/oversized.png" },
+    }, 30_000);
+    const [request] = await broker.nextToolBatch(token);
+    broker.completeTool(token, request!.callId, {
+      content: [{ type: "text", text: "x".repeat(8_400_000) }],
+    });
+    const bounded = await oversized;
+    expect(bounded.isError).toBe(true);
+    expect(JSON.stringify(bounded.content)).toContain("UNRESOLVED_BROKER_RESULT_TOO_LARGE");
+
+    expect(await callTurnBroker<BrokerToolResult>(socketPath, {
+      method: "invoke",
+      bindingId: claimed.bindingId,
+      invocationKey: "oversized-replay-result",
+      wireName: "view_image",
+      freeform: false,
+      arguments: { path: "/tmp/oversized.png" },
+    }, 10_000)).toEqual(bounded);
+    await expect(callTurnBroker(socketPath, {
+      method: "invoke",
+      bindingId: claimed.bindingId,
+      invocationKey: "new-dispatch-after-replay-cap",
+      wireName: "view_image",
+      freeform: false,
+      arguments: { path: "/tmp/new.png" },
+    }, 10_000)).rejects.toThrow("replay cache is exhausted");
+  } finally {
+    await broker.close();
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("broker logs use digests instead of raw capability and call handles", async () => {
+  const root = mkdtempSync(join(tmpdir(), "cgw-broker-log-redaction-"));
+  const socketPath = defaultBrokerEndpoint(root);
+  const broker = TurnBroker.forSocket(socketPath);
+  const messages: string[] = [];
+  const originalInfo = console.info;
+  const originalError = console.error;
+  console.info = (...values: unknown[]) => { messages.push(values.map(String).join(" ")); };
+  console.error = (...values: unknown[]) => { messages.push(values.map(String).join(" ")); };
+  try {
+    const token = await broker.register({
+      cwd: root,
+      roots: [root],
+      writableRoots: [root],
+      sandboxPolicy: { type: "workspaceWrite", writableRoots: [root], networkAccess: false },
+      tools: [{ name: "exec_command", description: "Run command", parameters: { type: "object" } }],
+    }, 10_000, "trace-redaction");
+    const claimed = await callTurnBroker<{ bindingId: string }>(socketPath, { method: "claim", token });
+    const invocation = callTurnBroker<BrokerToolResult>(socketPath, {
+      method: "invoke",
+      bindingId: claimed.bindingId,
+      wireName: "exec_command",
+      arguments: { cmd: "pwd" },
+    }, 10_000);
+    const [request] = await broker.nextToolBatch(token);
+    broker.completeTool(token, request!.callId, { content: [{ type: "text", text: "ok" }] });
+    await invocation;
+    broker.revoke(token);
+    await callTurnBroker(socketPath, {
+      method: "invoke",
+      bindingId: claimed.bindingId,
+      wireName: "exec_command",
+    }).catch(() => {});
+
+    const joined = messages.join("\n");
+    expect(joined).not.toContain(token);
+    expect(joined).not.toContain(claimed.bindingId);
+    expect(joined).not.toContain(request!.callId);
+    expect(joined).toContain("callHash=");
+    expect(joined).toContain("bindingHash=");
+  } finally {
+    console.info = originalInfo;
+    console.error = originalError;
     await broker.close();
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

This integrates the Full Harness hardening work on top of the current upstream `main`.

Key areas:

- hardens command at-most-once / UNKNOWN / replay lifecycle handling
- preserves terminal evidence before releasing protected operations
- prevents reconnect and response-loss duplicate dispatch
- hardens dedicated command routing and generic/normalized alias rejection
- fixes nested custom-tool / additional-tools ABI parsing
- adds explicit escalation schema and fail-closed forwarding
- improves secret-safe command observability
- hardens ChatGPT effort selection with bounded, abort-aware state verification
- expands regression coverage for broker, command, parser, browser, session, and escalation behavior

## Integration

FINAL12 was originally developed from an older common parent and was integrated onto the current upstream `main` using an isolated integration branch.

Integration commit:

`b02844c721d7b27669a2f4932ce5eb4fd2f28850`

The integration resolved conflicts against newer upstream launcher/browser architecture while preserving both upstream behavior and the FINAL12 lifecycle/security invariants.

## Verification

Post-integration verification:

- targeted lifecycle/parser/browser/session/observability: 241/241 PASS
- recursive Bun tests: 669/669 PASS
- pinned Bun 1.4.0 verify root tests: 480/480 PASS
- launcher tests: 189/189 PASS
- root typecheck: PASS
- launcher typecheck: PASS
- `bun run verify`: PASS, exit 0
- `bun run build`: PASS
- `bun run smoke`: `RELOCATABLE_RUNTIME_SMOKE_OK`
- `bun run audit`: 0 vulnerabilities across 106 packages
- `git diff --check`: PASS
- conflict markers: 0
- working tree/index: clean

Independent reviews:

- CRITICAL: 0
- HIGH: 0
- MEDIUM blockers: 0

## Security / lifecycle invariants

Regression coverage verifies:

- command dispatch is at-most-once
- durable UNKNOWN quarantine
- no protected-operation release without terminal evidence
- reconnect / replay / response-loss duplicate-dispatch prevention
- collision-safe nested custom-tool namespace handling
- generic and normalized dedicated-command alias rejection
- explicit escalation forwarding
- unsupported escalation fails closed
- no escalation fallback to normal execution
- bounded, abort-aware effort selection
- secret-safe observability

## Known live-evidence boundary

The following are intentionally **not** claimed as verified:

- `LIVE_DENIAL_VERIFIED=INCONCLUSIVE`
- `HUMAN_REJECTION_PROPAGATION_LIVE_EVIDENCE=NOT_OBTAINED`
- `ACCEPT_DECISION_ORIGIN=UNKNOWN`
- latest explicit escalation trial was blocked by a platform pre-dispatch safety layer before the human approval UI

These are live/platform evidence limitations, not promoted to implementation guarantees by this PR.

## Notes

No production deployment is included in this PR.
