### PR TITLE
fix(launcher): keep hidden turn viewports operational

### DIFF
--- a/launcher/electron/browser-host.cjs
+++ b/launcher/electron/browser-host.cjs
@@ -333,7 +333,8 @@ class BrowserHost {
     this.turnTabs.set(id, tab);
     this.window.contentView.addChildView(view);
     view.setBounds(this.hiddenTurnBounds());
-    view.setVisible(false);
+    // Start running turns with a real renderer viewport even before the first visibility sync.
+    view.setVisible(true);
     view.webContents.setZoomFactor(this.state.zoomFactor);
     this.bindShellZoomShortcuts(view.webContents);
     this.bindTurnContents(tab);
@@ -805,11 +806,16 @@ class BrowserHost {
 
   hiddenTurnBounds() {
     const [contentWidth, contentHeight] = this.window.getContentSize();
+    const width = Math.max(HIDDEN_TURN_VIEWPORT.width, Math.round(contentWidth || 0));
+    const height = Math.max(HIDDEN_TURN_VIEWPORT.height, Math.round(contentHeight || 0));
     return {
-      x: 0,
-      y: 0,
-      width: Math.max(HIDDEN_TURN_VIEWPORT.width, Math.round(contentWidth || 0)),
-      height: Math.max(HIDDEN_TURN_VIEWPORT.height, Math.round(contentHeight || 0)),
+      // Electron collapses a hidden WebContentsView's renderer viewport to 0x0. Keep running
+      // turn views visible to Chromium and move them wholly outside the launcher content area so
+      // Playwright retains a real viewport without exposing the task to the user.
+      x: Math.max(width, Math.round(contentWidth || 0)) + 1,
+      y: Math.max(height, Math.round(contentHeight || 0)) + 1,
+      width,
+      height,
     };
   }
 
@@ -828,7 +834,9 @@ class BrowserHost {
     for (const tab of this.turnTabs.values()) {
       const tabVisible = visible && !this.authView && selected?.id === tab.id;
       tab.view.setBounds(tabVisible ? this.bounds : this.hiddenTurnBounds());
-      tab.view.setVisible(tabVisible);
+      // A running hidden turn must remain composited; setVisible(false) gives Electron a zero
+      // width renderer viewport and makes otherwise valid Playwright actions fail as out of view.
+      tab.view.setVisible(tabVisible || tab.status === "running");
     }
     this.authView?.setVisible(visible);
   }

--- a/launcher/tests/browser-host.test.cjs
+++ b/launcher/tests/browser-host.test.cjs
@@ -212,10 +212,11 @@ test("browser surface reactivation preserves its last measured bounds", () => {
   assert.equal(fixture.boundsReady, true);
 });
 
-test("hidden turn tabs retain an operational viewport without revealing the browser surface", () => {
+test("hidden turn tabs keep an operational offscreen viewport", () => {
   const events = [];
   const tab = {
     id: "tab-hidden-viewport",
+    status: "running",
     view: {
       setBounds: bounds => events.push(["bounds", bounds]),
       setVisible: visible => events.push(["visible", visible]),
@@ -237,8 +238,8 @@ test("hidden turn tabs retain an operational viewport without revealing the brow
 
   assert.deepEqual(events, [
     ["home", false],
-    ["bounds", { x: 0, y: 0, width: 1120, height: 720 }],
-    ["visible", false],
+    ["bounds", { x: 1121, y: 721, width: 1120, height: 720 }],
+    ["visible", true],
   ]);
 });
 
@@ -1123,8 +1124,8 @@ test("selecting a task tab shows and focuses its owned Playwright surface", () =
     setVisible: (visible) => visibility.push([id, visible]),
     webContents: { focus: () => focused.push(id) },
   });
-  const first = { id: "tab-first", view: makeView("first") };
-  const second = { id: "tab-second", view: makeView("second") };
+  const first = { id: "tab-first", status: "running", view: makeView("first") };
+  const second = { id: "tab-second", status: "running", view: makeView("second") };
   const fixture = Object.assign(Object.create(BrowserHost.prototype), {
     view: makeView("home"),
     turnTabs: new Map([[first.id, first], [second.id, second]]),
@@ -1145,7 +1146,7 @@ test("selecting a task tab shows and focuses its owned Playwright surface", () =
   assert.equal(fixture.selectedTabId, second.id);
   assert.deepEqual(visibility, [
     ["home", false],
-    ["first", false],
+    ["first", true],
     ["second", true],
   ]);
   assert.deepEqual(focused, ["second"]);


### PR DESCRIPTION
Fixes #168

@miuuyy, I traced the repeated reconnect loop to the launcher losing the renderer viewport for hidden running turn tabs.

The exported diagnostics show the same turn failing during effort selection with:

`locator.click: Element is outside of the viewport`

The locator resolves to the ChatGPT model/effort control. The immediately following screenshot attempt also reports a `0 width` page, after which the launcher releases the tab, starts a fresh tab, and retries the same action. This repeats until the retry limit is reached.

The launcher was hiding non-selected `WebContentsView` instances with `setVisible(false)` while moving them to hidden bounds. Running turns now remain composited with a real 800x600-or-larger renderer viewport, and non-selected views are moved fully outside the launcher content area so they remain invisible to the user. Selected task views keep the existing on-screen behavior.

Added regression coverage for the offscreen running-tab behavior and for keeping other running tabs operational while a task tab is selected.

Verification:

- Root and launcher dependencies installed with Bun 1.4.0.
- Root typecheck and audit passed.
- Launcher typecheck passed.
- Launcher tests: 188 passed, 1 platform-specific test skipped.
- Launcher production build passed.
- Runtime bundle, third-party notices, and release smoke test passed.
- The root test suite passed 366 tests; one unrelated existing Windows test (`installed launcher discovery has explicit platform candidates`) is environment-dependent on the installed launcher registry entry on this machine.
