### PR TITLE
fix: detect Japanese ChatGPT rate limit dialog

### DIFF
--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -152,15 +152,15 @@ export class ChatGptPromptAttachmentIntegrityError extends ChatGptWebAdapterErro
 }
 
 const chatGptRateLimitDialog = (page: Page): Locator => page.locator('[role="dialog"]')
-  .filter({ hasText: /Too many requests|太多要求|太多请求/i })
-  .filter({ hasText: /making requests too quickly|過於頻繁|过于频繁/i })
+  .filter({ hasText: /Too many requests|太多要求|太多请求|リクエストが多すぎます/i })
+  .filter({ hasText: /making requests too quickly|過於頻繁|过于频繁|リクエストの頻度が高すぎます/i })
   .last();
 
 export async function throwIfChatGptRateLimitDialog(page: Page): Promise<void> {
   const dialog = chatGptRateLimitDialog(page);
   if (!await dialog.isVisible().catch(() => false)) return;
 
-  const acknowledge = dialog.getByRole("button", { name: /^(Got it|知道了)$/ }).last();
+  const acknowledge = dialog.getByRole("button", { name: /^(Got it|知道了|了解)$/ }).last();
   if (await acknowledge.isVisible().catch(() => false)) {
     try {
       await acknowledge.press("Enter");

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -1112,6 +1112,22 @@ test("the Simplified Chinese ChatGPT rate-limit dialog is acknowledged and retur
   expect(fixture.pressed).toEqual(["Enter"]);
 });
 
+test("the Japanese ChatGPT rate-limit dialog is acknowledged and returns a structured 429", async () => {
+  const fixture = dialogPage(
+    "リクエストが多すぎます リクエストの頻度が高すぎます。お客様のデータを保護するため、会話へのアクセスを一時的に制限しています。 数分待ってから、もう一度お試しください。",
+    "了解",
+  );
+
+  await expect(throwIfChatGptRateLimitDialog(fixture.page)).rejects.toMatchObject({
+    name: "ChatGptWebAdapterError",
+    status: 429,
+    errorType: "rate_limit_error",
+    code: "rate_limit_exceeded",
+    retryable: true,
+  });
+  expect(fixture.pressed).toEqual(["Enter"]);
+});
+
 test("unrelated ChatGPT dialogs are left untouched", async () => {
   const fixture = dialogPage("Confirm another action");
 


### PR DESCRIPTION
## Problem

ChatGPT can show the browser-side rate-limit dialog in Japanese. In v3.0.3 the detector recognizes the English, Traditional Chinese, and Simplified Chinese variants, but not the Japanese text or its acknowledgement button.

When the Japanese dialog appears, the adapter therefore misses a known retryable rate-limit condition instead of converting it into the same structured 429 used for the other supported locales.

## What this changes

- Extends the existing rate-limit dialog locator to recognize the Japanese title `リクエストが多すぎます`.
- Recognizes the Japanese explanatory text `リクエストの頻度が高すぎます` in the same dialog.
- Recognizes the Japanese acknowledgement button `了解` in addition to the existing `Got it` / `知道了` variants.
- Keeps the existing behavior after detection: dismiss the dialog and return a retryable `ChatGptWebAdapterError` with:
  - HTTP status `429`
  - `errorType: "rate_limit_error"`
  - `code: "rate_limit_exceeded"`
  - `retryable: true`

## Why this is intentionally small

This does not add a new rate-limit path or change retry semantics. It only extends the locale coverage of the existing detector, so English and Chinese behavior remains unchanged. The locator still requires both the known rate-limit heading and the known request-frequency message, which avoids treating unrelated Japanese dialogs as rate limits.

## Tests

Adds a regression case using the Japanese dialog text and verifies that:

- the dialog is detected;
- the `了解` button is acknowledged with Enter;
- the adapter returns the same structured retryable 429 as the existing locale variants;
- unrelated dialogs remain untouched by the existing coverage.

## Verification

- main test suite: 368 passed, 0 failed
- launcher test suite: 189 passed, 0 failed
- launcher production build passed
- `bun audit`: no vulnerabilities

An earlier full `bun run verify` reached the final browser smoke step; at that time the verification machine did not yet have Google Chrome at the expected path. The code-level and launcher suites above completed successfully.
