### PR TITLE
fix: detect ChatGPT unusual activity blocks

### DIFF
--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -234,6 +234,18 @@ export async function throwIfChatGptTerminalErrorAlert(scope: ChatGptTextScope):
   );
 }
 
+const chatGptUnusualActivityAlert = (scope: ChatGptTextScope): Locator => scope
+  .getByText(/Unusual activity has been detected from your device\.[\s\S]*Try again later\.(?:\s*\([^)]+\))?/i)
+  .last();
+
+export async function throwIfChatGptUnusualActivityAlert(scope: ChatGptTextScope): Promise<void> {
+  if (!await chatGptUnusualActivityAlert(scope).isVisible().catch(() => false)) return;
+  throw new ChatGptWebAdapterError(
+    "ChatGPT temporarily blocked the turn after detecting unusual activity from this device. Retry later.",
+    { status: 429, errorType: "rate_limit_error", code: "unusual_activity_detected", retryable: true },
+  );
+}
+
 export async function resolveChatGptToolConfirmation(
   page: Page,
   appName: string,
@@ -1428,6 +1440,7 @@ export class ChatGptBrowserWorker {
       if (signal?.aborted) throw new DOMException("ChatGPT web turn aborted", "AbortError");
       await throwIfChatGptSessionFailureAlert(page);
       await throwIfChatGptTerminalErrorAlert(baseline.responseTurns.last());
+      await throwIfChatGptUnusualActivityAlert(baseline.responseTurns.last());
       const evidence = await this.currentSubmissionEvidence(page, baseline);
       if (evidence) return evidence;
       await new Promise(resolveSleep => setTimeout(resolveSleep, 50));
@@ -2647,6 +2660,7 @@ export class ChatGptBrowserWorker {
 
         await throwIfChatGptSessionFailureAlert(page);
         await throwIfChatGptTerminalErrorAlert(responseTurn);
+        await throwIfChatGptUnusualActivityAlert(responseTurn);
 
         if (mode.localTools && await resolveChatGptToolConfirmation(
           page,

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import type { Page } from "playwright-core";
-import { CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_STOPPED_THINKING_GRACE_MS, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, assertChatGptWebMultipartInputWithinLimits, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptNewTurnIdentity, chatGptSubmissionEvidence, dismissChatGptTemporaryChatOnboarding, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, resolveChatGptWebMultipartStagingMode, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert } from "../src/adapters/chatgpt-web/browser-worker";
+import { CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_STOPPED_THINKING_GRACE_MS, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, assertChatGptWebMultipartInputWithinLimits, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptNewTurnIdentity, chatGptSubmissionEvidence, dismissChatGptTemporaryChatOnboarding, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, resolveChatGptWebMultipartStagingMode, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert, throwIfChatGptUnusualActivityAlert } from "../src/adapters/chatgpt-web/browser-worker";
 import { chatGptStoppedThinkingError } from "../src/adapters/chatgpt-web/adapter-error";
 import { CHATGPT_WEB_MODEL_ID } from "../src/adapters/chatgpt-web/model";
 import { CHATGPT_CONNECTOR_NAME, DEV_CHATGPT_CONNECTOR_NAME, defaultChromeExecutable, legacyChatGptConnectorMigrationMessage } from "../src/config";
@@ -1129,6 +1129,21 @@ test("the known terminal ChatGPT error alert returns a structured retryable fail
     status: 502,
     errorType: "server_error",
     code: "upstream_server_error",
+    retryable: true,
+  });
+  expect(fixture.pressed).toEqual([]);
+});
+
+test("the unusual-activity ChatGPT error returns a structured retryable 429", async () => {
+  const fixture = dialogPage(
+    "Unusual activity has been detected from your device. Try again later. (b2d7fe20-47dd-41a9-b862-15d14e17368d)",
+  );
+
+  await expect(throwIfChatGptUnusualActivityAlert(fixture.page)).rejects.toMatchObject({
+    name: "ChatGptWebAdapterError",
+    status: 429,
+    errorType: "rate_limit_error",
+    code: "unusual_activity_detected",
     retryable: true,
   });
   expect(fixture.pressed).toEqual([]);


### PR DESCRIPTION
## Problem

ChatGPT sometimes terminates a browser turn with a visible message like:

> Unusual activity has been detected from your device. Try again later. (...)

In v3.0.3 this terminal state is not classified by the browser adapter. Because it is neither the generic `Something went wrong` alert nor a normal completed response, the worker can continue waiting until a generic browser timeout instead of returning the real cause promptly.

## What this changes

- Adds a dedicated detector for the `Unusual activity has been detected from your device` terminal alert.
- Accepts the optional parenthesized request/incident identifier that ChatGPT may append to the message.
- Checks for this state in both places where the turn can otherwise remain pending:
  - while waiting for ChatGPT to accept the submitted prompt;
  - while polling the active assistant response.
- Converts the alert into a structured retryable adapter error:
  - HTTP status `429`
  - `errorType: "rate_limit_error"`
  - `code: "unusual_activity_detected"`
  - `retryable: true`

## Why 429 / retryable

The UI explicitly asks the user to try again later and represents a temporary request block rather than an authentication failure, malformed request, or permanent connector error. Classifying it separately also preserves the original cause instead of collapsing it into a generic timeout or upstream 502.

## Scope and safety

The matcher is intentionally narrow: it requires the known `Unusual activity...` sentence followed by `Try again later.`. Existing handling for session failures, subscription failures, generic terminal errors, and normal responses is unchanged.

No automatic retry loop is added here; this PR only makes the terminal condition observable to the existing outer retry/error handling.

## Tests

Adds a contract test using the real alert shape, including a parenthesized identifier, and verifies the exact structured error classification.

The orchestration changes are also covered by source-level contract checks to ensure the detector is called during both submission acceptance and response polling.

## Verification

- `bun test tests/browser-worker-contract.test.ts` — 71 passed, 0 failed
- `git diff --check`
