### PR TITLE
fix: tolerate markerless ChatGPT completions

### DIFF
--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -102,6 +102,7 @@ export const CHATGPT_RESPONSE_DOM_GRACE_MS = 60_000;
 export const CHATGPT_EMPTY_RESPONSE_GRACE_MS = 10_000;
 export const CHATGPT_COMPLETION_ACTION_GRACE_MS = 60_000;
 export const CHATGPT_COMPLETION_SETTLE_MS = 2_000;
+export const CHATGPT_MARKERLESS_COMPLETION_SETTLE_MS = 5_000;
 export const CHATGPT_TOOL_CONFIRMATION_TIMEOUT_MS = 60_000;
 export const MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS = 3;
 const CHATGPT_SMOKE_TEXT = "Reply with exactly: CODEX WEB GPT READY";
@@ -505,8 +506,7 @@ export function chatGptTurnIsComplete(state: {
 }): boolean {
   return state.responsePresent
     && !state.running
-    && state.currentText.length > 0
-    && state.completionActionVisible;
+    && state.currentText.length > 0;
 }
 
 export type ChatGptSubmissionEvidence = "user_turn" | "assistant_turn" | "generation_running";
@@ -539,7 +539,10 @@ export function chatGptNewTurnIdentity(
 export class ChatGptCompletionTracker {
   private candidate?: { signature: string; since: number };
 
-  constructor(private readonly stableMs = CHATGPT_COMPLETION_SETTLE_MS) {}
+  constructor(
+    private readonly stableMs = CHATGPT_COMPLETION_SETTLE_MS,
+    private readonly markerlessStableMs = CHATGPT_MARKERLESS_COMPLETION_SETTLE_MS,
+  ) {}
 
   update(state: Parameters<typeof chatGptTurnIsComplete>[0], now = Date.now()): boolean {
     if (!chatGptTurnIsComplete(state)) {
@@ -551,7 +554,10 @@ export class ChatGptCompletionTracker {
       this.candidate = { signature, since: now };
       return false;
     }
-    return now - this.candidate.since >= this.stableMs;
+    const requiredStableMs = state.completionActionVisible
+      ? this.stableMs
+      : this.markerlessStableMs;
+    return now - this.candidate.since >= requiredStableMs;
   }
 }
 

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import type { Page } from "playwright-core";
-import { CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_STOPPED_THINKING_GRACE_MS, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, assertChatGptWebMultipartInputWithinLimits, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptNewTurnIdentity, chatGptSubmissionEvidence, dismissChatGptTemporaryChatOnboarding, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, resolveChatGptWebMultipartStagingMode, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert } from "../src/adapters/chatgpt-web/browser-worker";
+import { CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_STOPPED_THINKING_GRACE_MS, ChatGptBrowserWorker, ChatGptCompletionTracker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, assertChatGptWebMultipartInputWithinLimits, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptNewTurnIdentity, chatGptSubmissionEvidence, dismissChatGptTemporaryChatOnboarding, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, resolveChatGptWebMultipartStagingMode, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert } from "../src/adapters/chatgpt-web/browser-worker";
 import { chatGptStoppedThinkingError } from "../src/adapters/chatgpt-web/adapter-error";
 import { CHATGPT_WEB_MODEL_ID } from "../src/adapters/chatgpt-web/model";
 import { CHATGPT_CONNECTOR_NAME, DEV_CHATGPT_CONNECTOR_NAME, defaultChromeExecutable, legacyChatGptConnectorMigrationMessage } from "../src/config";
@@ -1853,6 +1853,51 @@ test("browser DOM health fails closed on a vanished or empty ChatGPT response", 
   expect(missingCompletionAction.update(completedWithoutMarker, 1_750)).toContain("DOM may have changed");
 });
 
+test("browser completion accepts a stable final answer when ChatGPT omits the copy action", () => {
+  const completion = new ChatGptCompletionTracker(200, 500);
+  const markerless = {
+    responsePresent: true,
+    running: false,
+    currentText: "complete answer",
+    currentHtml: "<p>complete answer</p>",
+    completionActionVisible: false,
+  };
+  expect(completion.update(markerless, 1_000)).toBeFalse();
+  expect(completion.update(markerless, 1_499)).toBeFalse();
+  expect(completion.update(markerless, 1_500)).toBeTrue();
+});
+
+test("browser completion does not accept markerless output while generation is active or changing", () => {
+  const completion = new ChatGptCompletionTracker(200, 500);
+  const markerless = {
+    responsePresent: true,
+    running: false,
+    currentText: "partial",
+    currentHtml: "<p>partial</p>",
+    completionActionVisible: false,
+  };
+  expect(completion.update(markerless, 1_000)).toBeFalse();
+  expect(completion.update({ ...markerless, running: true }, 1_400)).toBeFalse();
+  expect(completion.update(markerless, 1_500)).toBeFalse();
+  expect(completion.update({ ...markerless, currentText: "partial answer", currentHtml: "<p>partial answer</p>" }, 1_900)).toBeFalse();
+  expect(completion.update({ ...markerless, currentText: "partial answer", currentHtml: "<p>partial answer</p>" }, 2_399)).toBeFalse();
+  expect(completion.update({ ...markerless, currentText: "partial answer", currentHtml: "<p>partial answer</p>" }, 2_400)).toBeTrue();
+});
+
+test("browser completion still uses the faster settle window when the copy action is present", () => {
+  const completion = new ChatGptCompletionTracker(200, 500);
+  const completed = {
+    responsePresent: true,
+    running: false,
+    currentText: "complete answer",
+    currentHtml: "<p>complete answer</p>",
+    completionActionVisible: true,
+  };
+  expect(completion.update(completed, 1_000)).toBeFalse();
+  expect(completion.update(completed, 1_199)).toBeFalse();
+  expect(completion.update(completed, 1_200)).toBeTrue();
+});
+
 test("stalled-turn diagnostics record DOM metrics without response or overlay content", () => {
   const workerSource = readFileSync(new URL("../src/adapters/chatgpt-web/browser-worker.ts", import.meta.url), "utf8");
   const start = workerSource.indexOf("private async stalledTurnDiagnostic");
@@ -1864,11 +1909,12 @@ test("stalled-turn diagnostics record DOM metrics without response or overlay co
   expect(diagnosticSource).not.toMatch(/\bariaLabel:\s*candidate\.getAttribute/);
 });
 
-test("browser completion requires ChatGPT's response-scoped copy action", () => {
+test("browser completion uses ChatGPT's response-scoped copy action as supporting evidence", () => {
   const workerSource = readFileSync(new URL("../src/adapters/chatgpt-web/browser-worker.ts", import.meta.url), "utf8");
   const sessionSource = readFileSync(new URL("../src/chatgpt-session.ts", import.meta.url), "utf8");
   expect(sessionSource).toContain('button[data-testid="copy-turn-action-button"]');
   expect(workerSource).toContain("CHATGPT_COMPLETION_ACTION_SELECTOR");
+  expect(workerSource).toContain("CHATGPT_MARKERLESS_COMPLETION_SETTLE_MS");
   expect(workerSource).not.toContain('root.querySelectorAll<HTMLElement>("button")');
 });
 

--- a/tests/chatgpt-web-harness.test.ts
+++ b/tests/chatgpt-web-harness.test.ts
@@ -1152,7 +1152,7 @@ describe("ChatGPT outer-native harness v4", () => {
     expect(response.usage.total_tokens).toBe(usage.totalTokens!);
   });
 
-  test("accepts completion only from the response-scoped final answer action", () => {
+  test("treats a stopped non-empty response as a completion candidate without requiring the copy action", () => {
     const state = {
       responsePresent: true,
       running: false,
@@ -1161,7 +1161,9 @@ describe("ChatGPT outer-native harness v4", () => {
     };
     expect(chatGptTurnIsComplete(state)).toBe(true);
     expect(chatGptTurnIsComplete({ ...state, responsePresent: false })).toBe(false);
-    expect(chatGptTurnIsComplete({ ...state, completionActionVisible: false })).toBe(false);
+    expect(chatGptTurnIsComplete({ ...state, running: true })).toBe(false);
+    expect(chatGptTurnIsComplete({ ...state, currentText: "" })).toBe(false);
+    expect(chatGptTurnIsComplete({ ...state, completionActionVisible: false })).toBe(true);
   });
 
   test("requires completed-turn evidence to remain unchanged before accepting it", () => {


### PR DESCRIPTION
## Problem

v3.0.3 treats ChatGPT's response-scoped copy action as a required completion marker. In practice, ChatGPT can finish rendering a valid non-empty answer while that action is temporarily absent or omitted by the current DOM shape.

That leaves the adapter in a bad state: generation has stopped and the final answer is visible, but the turn is never accepted as complete because the copy-action marker is missing. The worker then keeps waiting and may eventually report a DOM/timeout failure for a response that was already complete.

## What this changes

A stopped, non-empty assistant response can now become a completion candidate even when the response-scoped copy action is absent.

The copy action is still useful evidence, but it is no longer the single required completion signal:

- with the copy action present, the existing fast settle window remains `2s`;
- without the copy action, the response must remain stable for a longer `5s` window before completion is accepted.

## Stability safeguards

Markerless completion is deliberately conservative:

- the response DOM must exist;
- generation must be stopped;
- the response text must be non-empty;
- the candidate signature includes both rendered text and HTML;
- any text/HTML change resets the stability timer;
- generation becoming active again invalidates the candidate and resets the timer.

This means the fallback does not accept a still-streaming or mutating response simply because the copy button is missing.

The existing DOM-health checks for vanished responses and empty completions remain in place.

## Why keep two settle windows

The copy action is a strong ChatGPT-owned completion signal, so the existing `2s` settling behavior is preserved when it is available. A markerless response has weaker evidence, so it receives a longer `5s` stability requirement to avoid trading the timeout bug for premature completion.

## Tests

Adds focused coverage for all three important cases:

- a stable markerless final answer is accepted only after the longer window;
- markerless output is not accepted while generation is active or while content is changing;
- responses with the normal copy action still use the existing shorter settle window.

The harness expectation is also updated to reflect that the copy action is supporting evidence rather than an absolute requirement.

## Verification

- `bun test tests/browser-worker-contract.test.ts tests/chatgpt-web-harness.test.ts` — 121 passed, 0 failed
- `git diff --check`
