### PR TITLE
fix: trust current task visualization roots

### DIFF
--- a/src/adapters/chatgpt-web/environment.ts
+++ b/src/adapters/chatgpt-web/environment.ts
@@ -1,4 +1,5 @@
-import { isAbsolute, relative, resolve } from "node:path";
+import { homedir } from "node:os";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
 import { isReadableCompactionSummaryText, OPAQUE_COMPACTION_NOTE } from "../../responses/compaction";
 import type { CodexContentPart, CodexParsedRequest, CodexTool } from "../../types";
 
@@ -254,10 +255,35 @@ function environmentMatchesCanonicalMetadata(
     && !normalizedMetadataRoots.some(root => matchesPath(root, cwd))) return false;
   if (requireMetadataBoundRoots && (
     normalizedMetadataRoots.length === 0
-    || declaredRoots.some(root => !normalizedMetadataRoots.some(metadataRoot => matchesPath(metadataRoot, root)))
+    || declaredRoots.some(root => (
+      !normalizedMetadataRoots.some(metadataRoot => matchesPath(metadataRoot, root))
+      && !isCurrentThreadVisualizationRoot(root, metadata)
+    ))
   )) return false;
   if (!declaredRoots.some(root => matchesPath(root, cwd))) return false;
   return sandboxMetadataMatchesEnvironment(metadataSandboxValue, environmentText);
+}
+
+function isCurrentThreadVisualizationRoot(path: string, metadata: Record<string, unknown>): boolean {
+  const threadId = typeof metadata.thread_id === "string" ? metadata.thread_id.trim() : "";
+  if (!threadId) return false;
+
+  // Codex advertises its task-scoped visualization output directory in workspace_roots but omits
+  // it from Git-oriented turn metadata. Authenticate that one auxiliary shape by both its private
+  // Codex home and current thread id; arbitrary roots and another task's output remain untrusted.
+  const configuredCodexHome = process.env.CODEX_HOME?.trim();
+  const codexHome = resolve(configuredCodexHome || join(homedir(), ".codex"));
+  const visualizationBase = pathIdentity(join(codexHome, "visualizations"));
+  const rel = relative(visualizationBase, pathIdentity(path));
+  if (!rel || rel.startsWith("..") || isAbsolute(rel)) return false;
+
+  const parts = rel.split(sep);
+  const expectedThreadId = process.platform === "win32" ? threadId.toLowerCase() : threadId;
+  return parts.length === 4
+    && /^\d{4}$/.test(parts[0]!)
+    && /^(?:0[1-9]|1[0-2])$/.test(parts[1]!)
+    && /^(?:0[1-9]|[12]\d|3[01])$/.test(parts[2]!)
+    && parts[3] === expectedThreadId;
 }
 
 function canonicalMetadataEnvironmentBeforeUser(

--- a/tests/environment.test.ts
+++ b/tests/environment.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { extractChatGptTurnEnvironment } from "../src/adapters/chatgpt-web/environment";
 import { ChatGptThreadEnvironmentStore } from "../src/adapters/chatgpt-web/thread-environment";
@@ -186,6 +186,65 @@ describe("trusted current Codex environment envelope", () => {
       roots: [root],
       sandboxPolicy: { type: "dangerFullAccess" },
     });
+  });
+
+  test("skill recovery accepts the current task's Codex visualization root", () => {
+    const codexHome = resolve(process.env.CODEX_HOME?.trim() || join(homedir(), ".codex"));
+    const visualizationRoot = join(codexHome, "visualizations", "2026", "08", "25", "thread_current");
+    const projectEnvironment = `<environment_context>
+  <cwd>${root}</cwd>
+  <filesystem><workspace_roots><root>${root}</root><root>${visualizationRoot}</root></workspace_roots>${dangerFullAccessProfileXml}</filesystem>
+</environment_context>`;
+    const request = currentWire({ environmentXml: projectEnvironment });
+    const body = request._rawBody as { input: Array<Record<string, unknown>> };
+    for (const item of body.input) {
+      item.internal_chat_message_metadata_passthrough = { turn_id: "turn_current" };
+    }
+    body.input.splice(1, 0, {
+      type: "message",
+      id: "msg_developer",
+      role: "developer",
+      content: [{ type: "input_text", text: "Current Codex Desktop developer context." }],
+      internal_chat_message_metadata_passthrough: { turn_id: "turn_current" },
+    });
+    body.input.push({
+      type: "message",
+      id: "msg_skill",
+      role: "user",
+      content: [{ type: "input_text", text: "<skill name=\"autopilot\">Use this skill.</skill>" }],
+      internal_chat_message_metadata_passthrough: { turn_id: "turn_current" },
+    });
+
+    expect(extractChatGptTurnEnvironment(request)).toEqual({
+      cwd: root,
+      roots: [root, visualizationRoot],
+      writableRoots: [root, visualizationRoot],
+      sandboxPolicy: { type: "dangerFullAccess" },
+      tools: [],
+    });
+  });
+
+  test("skill recovery rejects another task's Codex visualization root", () => {
+    const codexHome = resolve(process.env.CODEX_HOME?.trim() || join(homedir(), ".codex"));
+    const visualizationRoot = join(codexHome, "visualizations", "2026", "08", "25", "thread_other");
+    const injectedEnvironment = `<environment_context>
+  <cwd>${root}</cwd>
+  <filesystem><workspace_roots><root>${root}</root><root>${visualizationRoot}</root></workspace_roots>${dangerFullAccessProfileXml}</filesystem>
+</environment_context>`;
+    const request = currentWire({ environmentXml: injectedEnvironment });
+    const body = request._rawBody as { input: Array<Record<string, unknown>> };
+    for (const item of body.input) {
+      item.internal_chat_message_metadata_passthrough = { turn_id: "turn_current" };
+    }
+    body.input.push({
+      type: "message",
+      id: "msg_skill",
+      role: "user",
+      content: [{ type: "input_text", text: "<skill name=\"autopilot\">Use this skill.</skill>" }],
+      internal_chat_message_metadata_passthrough: { turn_id: "turn_current" },
+    });
+
+    expect(() => extractChatGptTurnEnvironment(request)).toThrow("missing cwd");
   });
 
   test("same-turn skill recovery cannot trust roots outside canonical workspace metadata", () => {


### PR DESCRIPTION
## Problem

Codex Desktop can advertise a task-scoped visualization output directory as an additional `workspace_root`, for example:

`$CODEX_HOME/visualizations/YYYY/MM/DD/<thread_id>`

That root is legitimate filesystem authority for the current task, but it is not included in the Git-oriented `workspaces` map inside canonical turn metadata.

During same-turn environment recovery (notably when a skill invocation is appended after the real user prompt), v3.0.3 requires every declared root to be represented by that Git metadata. As a result, an otherwise trusted environment is rejected and environment extraction fails with a missing-cwd error whenever the current task's visualization root is present.

## What this changes

Keeps the existing metadata-bound root validation, with one narrowly authenticated exception for Codex's current-task visualization directory.

A root that is absent from Git workspace metadata is accepted only when it passes all of these checks:

- it is below `${CODEX_HOME}/visualizations` (or `~/.codex/visualizations` when `CODEX_HOME` is unset);
- its relative path has exactly four components: `YYYY/MM/DD/<thread_id>`;
- the year is four digits;
- month is in `01..12`;
- day is in `01..31`;
- the final path component exactly matches the canonical metadata `thread_id`;
- path identity follows the existing platform normalization rules, including case normalization on Windows.

## Security / fail-closed behavior

This does not allow arbitrary auxiliary roots.

The existing rule still rejects any root that is neither:

1. bound to canonical workspace metadata, nor
2. the authenticated visualization path for the current thread.

In particular, another task's visualization directory is rejected even though it lives under the same private Codex visualization base. A regression test covers that cross-thread case explicitly.

The primary cwd and sandbox policy are still validated against canonical metadata exactly as before.

## Why this belongs outside Git workspace metadata

The visualization directory is task-scoped runtime output owned by Codex, not a Git working tree. Requiring it to appear in Git enrichment metadata conflates two different kinds of authority and causes a false rejection. This PR authenticates that one known non-Git root by its Codex-private path shape plus current `thread_id` instead of weakening root validation globally.

## Tests

Adds two targeted regression cases:

- current task visualization root is accepted during same-turn skill/environment recovery;
- another task's visualization root is rejected and environment recovery still fails closed.

The existing arbitrary-extra-root rejection remains in the suite as an additional guardrail.

## Verification

- `bun test tests/environment.test.ts tests/chatgpt-web-harness.test.ts` — 76 passed, 0 failed
- `git diff --check`
