### PR TITLE
fix(chatgpt-web): recover trusted cwd from canonical metadata

### DIFF
--- a/src/adapters/chatgpt-web/environment.ts
+++ b/src/adapters/chatgpt-web/environment.ts
@@ -434,7 +434,17 @@ function rawEnvironmentText(parsed: CodexParsedRequest): string | undefined {
 function hasRawEnvironmentEnvelope(parsed: CodexParsedRequest): boolean {
   const body = record(parsed._rawBody);
   const input = Array.isArray(body?.input) ? body.input : [];
-  for (const value of input) {
+  let activeUserIndex = -1;
+  for (let index = input.length - 1; index >= 0; index -= 1) {
+    const item = record(input[index]);
+    if (item?.role === "user" && !contextualUserMessage(item)) {
+      activeUserIndex = index;
+      break;
+    }
+  }
+  if (activeUserIndex < 0) return false;
+
+  for (const value of input.slice(0, activeUserIndex)) {
     const item = record(value);
     if (item?.type !== "message" || item.role !== "user") continue;
     const content = Array.isArray(item.content) ? item.content : [];

--- a/src/adapters/chatgpt-web/environment.ts
+++ b/src/adapters/chatgpt-web/environment.ts
@@ -44,6 +44,13 @@ export class MissingTrustedCodexEnvironmentError extends Error {
   }
 }
 
+class InvalidTrustedCodexEnvironmentError extends Error {
+  constructor(field: string) {
+    super(`ChatGPT web turn is missing ${field} because the native trusted Codex environment context is invalid`);
+    this.name = "InvalidTrustedCodexEnvironmentError";
+  }
+}
+
 function contentText(content: string | CodexContentPart[]): string {
   if (typeof content === "string") return content;
   return content.filter(part => part.type === "text").map(part => part.text).join("\n");
@@ -223,6 +230,36 @@ function sandboxMetadataMatchesEnvironment(
   return metadataSandbox === environmentSandbox;
 }
 
+function metadataAuthenticatedCwd(
+  environmentText: string,
+  metadata: Record<string, unknown> | undefined,
+): string | undefined {
+  if (!metadata || !sandboxMetadataMatchesEnvironment(canonicalSandboxMetadata(metadata), environmentText)) {
+    return undefined;
+  }
+
+  const workspaces = record(metadata.workspaces);
+  const metadataRoots = workspaces ? Object.keys(workspaces) : [];
+  if (metadataRoots.length === 0 || metadataRoots.some(path => !isAbsolute(path))) return undefined;
+  const metadataRootsByIdentity = new Map<string, string>();
+  for (const metadataRoot of metadataRoots) {
+    const resolvedRoot = resolve(metadataRoot);
+    const identity = pathIdentity(resolvedRoot);
+    if (!metadataRootsByIdentity.has(identity)) metadataRootsByIdentity.set(identity, resolvedRoot);
+  }
+
+  const rootMatches = [...environmentText.matchAll(/<workspace_roots>[\s\S]*?<\/workspace_roots>/g)]
+    .flatMap(section => [...section[0].matchAll(/<root>([^<]+)<\/root>/g)]
+      .map(match => decodeXmlText(match[1]!.trim())));
+  if (rootMatches.length === 0 || rootMatches.some(path => !isAbsolute(path))) return undefined;
+  const declaredRoots = [...new Set(rootMatches.map(pathIdentity))];
+
+  const candidates = [...metadataRootsByIdentity.entries()]
+    .filter(([identity]) => declaredRoots.some(declaredRoot => matchesPath(declaredRoot, identity)))
+    .map(([, metadataRoot]) => metadataRoot);
+  return candidates.length === 1 ? candidates[0] : undefined;
+}
+
 function environmentMatchesCanonicalMetadata(
   environmentText: string,
   metadata: Record<string, unknown>,
@@ -236,20 +273,24 @@ function environmentMatchesCanonicalMetadata(
   if (metadataRoots.some(path => !isAbsolute(path))) return false;
   const normalizedMetadataRoots = [...new Set(metadataRoots.map(pathIdentity))];
 
-  let cwdMatches: string[];
+  let cwdSelection: EnvironmentCwdSelection;
   try {
-    cwdMatches = environmentCwdMatches(environmentText, normalizedMetadataRoots)
-      .map(value => decodeXmlText(value.trim()));
+    cwdSelection = environmentCwdSelection(environmentText, normalizedMetadataRoots);
   } catch {
     return false;
   }
-  if (cwdMatches.length !== 1 || !isAbsolute(cwdMatches[0]!)) return false;
+  if (cwdSelection.kind === "invalid") return false;
+  const cwdMatches = cwdSelection.matches.map(value => decodeXmlText(value.trim()));
+  if (cwdMatches.length > 1 || cwdMatches.some(path => !isAbsolute(path))) return false;
   const rootMatches = [...environmentText.matchAll(/<workspace_roots>[\s\S]*?<\/workspace_roots>/g)]
     .flatMap(section => [...section[0].matchAll(/<root>([^<]+)<\/root>/g)].map(match => decodeXmlText(match[1]!.trim())));
   const declaredRootValues = rootMatches.length > 0 ? rootMatches : cwdMatches;
   if (declaredRootValues.some(path => !isAbsolute(path))) return false;
   const declaredRoots = [...new Set(declaredRootValues.map(pathIdentity))];
-  const cwd = pathIdentity(cwdMatches[0]!);
+  const cwd = cwdMatches.length === 1
+    ? pathIdentity(cwdMatches[0]!)
+    : metadataAuthenticatedCwd(environmentText, metadata);
+  if (!cwd) return false;
   if (normalizedMetadataRoots.length > 0
     && !normalizedMetadataRoots.some(root => matchesPath(root, cwd))) return false;
   if (requireMetadataBoundRoots && (
@@ -321,7 +362,8 @@ function rawEnvironmentText(parsed: CodexParsedRequest): string | undefined {
   const input = Array.isArray(body?.input) ? body.input : [];
   let activeUserIndex = -1;
   for (let index = input.length - 1; index >= 0; index -= 1) {
-    if (record(input[index])?.role === "user") {
+    const item = record(input[index]);
+    if (item?.role === "user" && !contextualUserMessage(item)) {
       activeUserIndex = index;
       break;
     }
@@ -389,6 +431,21 @@ function rawEnvironmentText(parsed: CodexParsedRequest): string | undefined {
   return undefined;
 }
 
+function hasRawEnvironmentEnvelope(parsed: CodexParsedRequest): boolean {
+  const body = record(parsed._rawBody);
+  const input = Array.isArray(body?.input) ? body.input : [];
+  for (const value of input) {
+    const item = record(value);
+    if (item?.type !== "message" || item.role !== "user") continue;
+    const content = Array.isArray(item.content) ? item.content : [];
+    for (const part of content) {
+      const text = record(part)?.text;
+      if (typeof text === "string" && /<environment_context\b/i.test(text)) return true;
+    }
+  }
+  return false;
+}
+
 function clientMetadataWorkspaceRoots(parsed: CodexParsedRequest): string[] {
   const workspaces = record(clientTurnMetadata(parsed)?.workspaces);
   if (!workspaces) return [];
@@ -416,40 +473,73 @@ function decodeXmlText(value: string): string {
     .replaceAll("&#39;", "'");
 }
 
-function environmentCwdMatches(text: string, preferredRoots: string[] = []): string[] {
+type EnvironmentCwdSelection =
+  | { kind: "absent"; matches: [] }
+  | { kind: "valid"; matches: [string] }
+  | { kind: "invalid"; matches: [] };
+
+function cwdDeclarations(text: string): { matches: string[]; malformed: boolean } {
+  const matches = [...text.matchAll(/<cwd>([^<]+)<\/cwd>/gi)].map(match => match[1] ?? "");
+  const openings = [...text.matchAll(/<cwd\b[^>]*>/gi)];
+  const closings = [...text.matchAll(/<\/cwd\s*>/gi)];
+  return {
+    matches,
+    malformed: openings.length !== matches.length || closings.length !== matches.length,
+  };
+}
+
+function environmentCwdSelection(text: string, preferredRoots: string[] = []): EnvironmentCwdSelection {
   const sections = [...text.matchAll(/<environments>([\s\S]*?)<\/environments>/gi)];
   if (sections.length === 0) {
-    return [...text.matchAll(/<cwd>([^<]+)<\/cwd>/gi)].map(match => match[1] ?? "");
+    const { matches, malformed } = cwdDeclarations(text);
+    if (malformed) return { kind: "invalid", matches: [] };
+    if (matches.length === 0) return { kind: "absent", matches: [] };
+    if (matches.length === 1) return { kind: "valid", matches: [matches[0]!] };
+    return { kind: "invalid", matches: [] };
   }
-  if (sections.length !== 1) return [];
+  if (sections.length !== 1) return { kind: "invalid", matches: [] };
 
   const section = sections[0]!;
   const outside = text.replace(section[0], "");
-  if (/<cwd>[^<]*<\/cwd>/i.test(outside)) return [];
+  const outsideCwd = cwdDeclarations(outside);
+  if (outsideCwd.malformed || outsideCwd.matches.length > 0) return { kind: "invalid", matches: [] };
 
   const environments = [...section[1]!.matchAll(/<environment\b([^>]*)>([\s\S]*?)<\/environment>/gi)];
+  let environmentRemainder = section[1]!;
+  for (const environment of environments) environmentRemainder = environmentRemainder.replace(environment[0], "");
+  const strayCwd = cwdDeclarations(environmentRemainder);
+  if (strayCwd.malformed || strayCwd.matches.length > 0) return { kind: "invalid", matches: [] };
+
+  const environmentCwds = environments.map(environment => cwdDeclarations(environment[2]!));
+  if (environmentCwds.some(cwd => cwd.malformed)) return { kind: "invalid", matches: [] };
   const primary = environments.filter(match => /\bprimary\s*=\s*["']true["']/i.test(match[1] ?? ""));
   if (primary.length === 1) {
-    return [...primary[0]![2]!.matchAll(/<cwd>([^<]+)<\/cwd>/gi)].map(match => match[1] ?? "");
+    const primaryIndex = environments.indexOf(primary[0]!);
+    const matches = environmentCwds[primaryIndex]!.matches;
+    if (matches.length === 1) return { kind: "valid", matches: [matches[0]!] };
+    if (matches.length === 0 && environmentCwds.every(cwd => cwd.matches.length === 0)) {
+      return { kind: "absent", matches: [] };
+    }
+    return { kind: "invalid", matches: [] };
   }
-  if (primary.length > 1) return [];
+  if (primary.length > 1) return { kind: "invalid", matches: [] };
 
   // Codex 0.146.x emitted multiple environments without a primary attribute. Only use that
   // legacy shape when canonical workspace metadata identifies one candidate; never pick by order.
-  const candidates = environments.flatMap(environment => {
-    const cwdMatches = [...environment[2]!.matchAll(/<cwd>([^<]+)<\/cwd>/gi)]
-      .map(match => match[1] ?? "");
-    return cwdMatches.length === 1 ? cwdMatches : [];
-  });
-  if (candidates.length === 1) return candidates;
-  if (preferredRoots.length === 0) return [];
+  if (environmentCwds.some(cwd => cwd.matches.length > 1)) return { kind: "invalid", matches: [] };
+  const candidates = environmentCwds.flatMap(cwd => cwd.matches);
+  if (candidates.length === 0) return { kind: "absent", matches: [] };
+  if (candidates.length === 1) return { kind: "valid", matches: [candidates[0]!] };
+  if (preferredRoots.length === 0) return { kind: "invalid", matches: [] };
 
   const exact = candidates.filter(candidate => preferredRoots
     .some(root => pathIdentity(root) === pathIdentity(candidate)));
-  if (exact.length === 1) return exact;
+  if (exact.length === 1) return { kind: "valid", matches: [exact[0]!] };
   const contained = candidates.filter(candidate => preferredRoots
     .some(root => matchesPath(root, candidate)));
-  return contained.length === 1 ? contained : [];
+  return contained.length === 1
+    ? { kind: "valid", matches: [contained[0]!] }
+    : { kind: "invalid", matches: [] };
 }
 
 function uniqueAbsolutePaths(values: string[], field: string): string[] {
@@ -469,9 +559,21 @@ function matchesPath(root: string, path: string): boolean {
 }
 
 export function extractChatGptTurnEnvironment(parsed: CodexParsedRequest): ChatGptTurnEnvironment {
-  const text = trustedEnvironmentText(parsed);
-  const cwdMatches = environmentCwdMatches(text, clientMetadataWorkspaceRoots(parsed));
-  const cwdCandidates = uniqueAbsolutePaths(cwdMatches, "cwd");
+  const rawText = rawEnvironmentText(parsed);
+  if (rawText === undefined && hasRawEnvironmentEnvelope(parsed)) {
+    throw new InvalidTrustedCodexEnvironmentError("cwd");
+  }
+  const text = rawText ?? trustedEnvironmentText(parsed);
+  const cwdSelection = environmentCwdSelection(text, clientMetadataWorkspaceRoots(parsed));
+  if (cwdSelection.kind === "invalid") throw new MissingTrustedCodexEnvironmentError("cwd");
+  const cwdMatches = cwdSelection.matches;
+  const inferredCwd = rawText !== undefined && cwdSelection.kind === "absent"
+    ? metadataAuthenticatedCwd(text, clientTurnMetadata(parsed))
+    : undefined;
+  const cwdCandidates = cwdMatches.length > 0
+    ? uniqueAbsolutePaths(cwdMatches, "cwd")
+    : (inferredCwd ? [inferredCwd] : []);
+  if (cwdCandidates.length === 0) throw new MissingTrustedCodexEnvironmentError("cwd");
   if (cwdCandidates.length !== 1) throw new Error("ChatGPT web turn has conflicting trusted Codex cwd values");
   const cwd = cwdCandidates[0]!;
 

--- a/tests/environment.test.ts
+++ b/tests/environment.test.ts
@@ -81,6 +81,118 @@ describe("trusted current Codex environment envelope", () => {
     });
   });
 
+  test("recovers cwd from canonical workspace metadata when the native envelope omits cwd", () => {
+    const cwdlessEnvironment = `<environment_context>
+  <filesystem><workspace_roots><root>${root}</root></workspace_roots>${dangerFullAccessProfileXml}</filesystem>
+</environment_context>`;
+
+    expect(extractChatGptTurnEnvironment(currentWire({ environmentXml: cwdlessEnvironment }))).toEqual({
+      cwd: root,
+      roots: [root],
+      writableRoots: [root],
+      sandboxPolicy: { type: "dangerFullAccess" },
+      tools: [],
+    });
+  });
+
+  test("does not recover cwd from unprovenanced developer fallback text", () => {
+    const cwdlessEnvironment = `<environment_context>
+  <filesystem><workspace_roots><root>${root}</root></workspace_roots>${dangerFullAccessProfileXml}</filesystem>
+</environment_context>`;
+    const request = currentWire();
+    const body = request._rawBody as { input: Array<Record<string, unknown>> };
+    body.input = [{
+      type: "message",
+      id: "msg_active",
+      role: "user",
+      content: [{ type: "input_text", text: "Inspect the workspace" }],
+    }];
+    request.context.messages = [
+      { role: "developer", content: cwdlessEnvironment, timestamp: 0 },
+      { role: "user", content: "Inspect the workspace", timestamp: 1 },
+    ];
+
+    expect(() => extractChatGptTurnEnvironment(request)).toThrow("missing cwd");
+  });
+
+  test("rejects cwd recovery when canonical workspace metadata is outside the declared roots", () => {
+    const cwdlessEnvironment = `<environment_context>
+  <filesystem><workspace_roots><root>${root}</root></workspace_roots>${dangerFullAccessProfileXml}</filesystem>
+</environment_context>`;
+
+    expect(() => extractChatGptTurnEnvironment(currentWire({
+      workspace: resolve(root, "..", "other-workspace"),
+      environmentXml: cwdlessEnvironment,
+    }))).toThrow("missing cwd");
+  });
+
+  test("rejects cwd recovery when multiple canonical workspaces match declared roots", () => {
+    const secondary = resolve(root, "secondary-workspace");
+    const cwdlessEnvironment = `<environment_context>
+  <filesystem><workspace_roots><root>${root}</root><root>${secondary}</root></workspace_roots>${dangerFullAccessProfileXml}</filesystem>
+</environment_context>`;
+    const request = currentWire({ environmentXml: cwdlessEnvironment });
+    const body = request._rawBody as { client_metadata: { "x-codex-turn-metadata": string } };
+    body.client_metadata["x-codex-turn-metadata"] = JSON.stringify({
+      thread_id: "thread_current",
+      turn_id: "turn_current",
+      sandbox: "none",
+      workspaces: {
+        [root]: { has_changes: true },
+        [secondary]: { has_changes: false },
+      },
+    });
+
+    expect(() => extractChatGptTurnEnvironment(request)).toThrow("missing cwd");
+  });
+
+  test("rejects malformed explicit cwd declarations instead of recovering metadata cwd", () => {
+    const malformedCwds = [
+      "<cwd></cwd>",
+      "<cwd/>",
+      `<cwd source="native">${root}</cwd>`,
+    ];
+
+    for (const malformedCwd of malformedCwds) {
+      const malformedEnvironment = `<environment_context>
+  ${malformedCwd}
+  <filesystem><workspace_roots><root>${root}</root></workspace_roots>${dangerFullAccessProfileXml}</filesystem>
+</environment_context>`;
+      expect(() => extractChatGptTurnEnvironment(currentWire({ environmentXml: malformedEnvironment })))
+        .toThrow("missing cwd");
+    }
+  });
+
+  test("does not let prompt-text authority rescue an invalid native environment envelope", () => {
+    const untrustedRoot = resolve(root, "..", "untrusted-fallback");
+    const fallbackEnvironment = `<environment_context>
+  <cwd>${untrustedRoot}</cwd>
+  <filesystem><workspace_roots><root>${untrustedRoot}</root></workspace_roots>${dangerFullAccessProfileXml}</filesystem>
+</environment_context>`;
+    const malformedEnvironment = `<environment_context>
+  <cwd/>
+  <filesystem><workspace_roots><root>${root}</root></workspace_roots>${dangerFullAccessProfileXml}</filesystem>
+</environment_context>`;
+    const ambiguousEnvironment = `<environment_context>
+  <cwd>${root}</cwd><cwd>${root}</cwd>
+  <filesystem><workspace_roots><root>${root}</root></workspace_roots>${dangerFullAccessProfileXml}</filesystem>
+</environment_context>`;
+    const cases = [
+      currentWire({ environmentXml: malformedEnvironment }),
+      currentWire({ environmentXml: ambiguousEnvironment }),
+      currentWire({ workspace: resolve(root, "elsewhere") }),
+      currentWire({ sandbox: "read-only" }),
+    ];
+
+    for (const request of cases) {
+      request.context.messages = [
+        { role: "developer", content: fallbackEnvironment, timestamp: 0 },
+        { role: "user", content: "Inspect the workspace", timestamp: 1 },
+      ];
+      expect(() => extractChatGptTurnEnvironment(request)).toThrow("missing cwd");
+    }
+  });
+
   test("accepts a trusted same-turn developer message between the environment and prompt", () => {
     const request = currentWire();
     const body = request._rawBody as { input: Array<Record<string, unknown>> };
@@ -278,6 +390,34 @@ describe("trusted current Codex environment envelope", () => {
     expect(extractChatGptTurnEnvironment(currentWire({ environmentXml: legacyEnvironment }))).toMatchObject({ cwd: root });
   });
 
+  test("rejects multiple primary environment cwd declarations instead of recovering metadata cwd", () => {
+    const ambiguousEnvironment = `<environment_context>
+  <environments>
+    <environment id="first" primary="true"><cwd>${root}</cwd></environment>
+    <environment id="second" primary="true"><cwd>${resolve(root, "secondary-environment")}</cwd></environment>
+  </environments>
+  <filesystem><workspace_roots><root>${root}</root></workspace_roots>${dangerFullAccessProfileXml}</filesystem>
+</environment_context>`;
+
+    expect(() => extractChatGptTurnEnvironment(currentWire({ environmentXml: ambiguousEnvironment })))
+      .toThrow("missing cwd");
+  });
+
+  test("rejects multiple contained legacy cwd candidates instead of recovering metadata cwd", () => {
+    const first = resolve(root, "first-environment");
+    const second = resolve(root, "second-environment");
+    const ambiguousEnvironment = `<environment_context>
+  <environments>
+    <environment id="first"><cwd>${first}</cwd></environment>
+    <environment id="second"><cwd>${second}</cwd></environment>
+  </environments>
+  <filesystem><workspace_roots><root>${root}</root></workspace_roots>${dangerFullAccessProfileXml}</filesystem>
+</environment_context>`;
+
+    expect(() => extractChatGptTurnEnvironment(currentWire({ environmentXml: ambiguousEnvironment })))
+      .toThrow("missing cwd");
+  });
+
   test("rejects a legacy multi-environment envelope when metadata cannot identify one cwd", () => {
     const secondary = resolve(root, "secondary-environment");
     const ambiguousEnvironment = `<environment_context>
@@ -425,7 +565,7 @@ describe("trusted Codex task environment continuity", () => {
 
     const invalidUpdate = currentWire({ sandbox: "read-only" });
     invalidUpdate.context.systemPrompt = [`<environment_context><cwd>${root}</cwd></environment_context>`];
-    expect(() => store.resolve(invalidUpdate)).toThrow("requires one explicit trusted Codex sandbox mode");
+    expect(() => store.resolve(invalidUpdate)).toThrow("native trusted Codex environment context is invalid");
   });
 
   test("inherits authority only through canonical Codex thread-spawn lineage", () => {


### PR DESCRIPTION
## Summary

Fixes ChatGPT web turns failing with `ChatGPT web turn is missing cwd in trusted Codex environment context` when the native Codex environment envelope omits an explicit `<cwd>` but still provides canonical workspace metadata for the active turn.

This PR is intentionally scoped to the trusted cwd/environment handling only. It is based directly on upstream `main` and changes only:

- `src/adapters/chatgpt-web/environment.ts`
- `tests/environment.test.ts`

## Problem

Recent Codex request shapes can contain a trusted native `<environment_context>` with workspace roots and sandbox information while omitting an explicit `<cwd>`. The ChatGPT web adapter previously required exactly one explicit cwd declaration, so otherwise-valid turns failed before execution.

There is also a replay/compaction edge case where contextual user-envelope messages may appear after the actual human prompt. Treating the last `role=user` item as the active user message can make trusted-environment lookup inspect the wrong boundary and report a missing cwd.

## Fix

- Recover cwd only from canonical turn metadata when the native environment envelope has no explicit cwd.
- Require the metadata workspace to be absolute, uniquely identifiable, consistent with the declared workspace roots, and bound to the same sandbox metadata.
- Keep malformed, ambiguous, conflicting, or unprovenanced cwd declarations fail-closed instead of silently falling back.
- Distinguish an absent cwd from an invalid cwd declaration so metadata recovery is only used for the former.
- Ignore contextual/system-generated user-envelope messages when locating the active human user message for trusted environment extraction.

## Security / trust properties

The fallback does not trust arbitrary prompt or developer text. It only accepts cwd recovered from canonical `x-codex-turn-metadata` when that metadata authenticates against the native environment envelope. Ambiguous roots, mismatched sandbox metadata, malformed `<cwd>` markup, duplicate primary environments, and conflicting candidates continue to fail closed.

## Tests

Added regression coverage for:

- cwd recovery from canonical workspace metadata
- rejection of unprovenanced developer fallback text
- workspace/root mismatch
- multiple matching canonical workspaces
- malformed or ambiguous explicit cwd declarations
- multiple primary environments and multiple legacy candidates
- invalid native envelopes remaining fail-closed

Validation performed:

- `bun test tests/environment.test.ts` — 34 passed, 0 failed
- `bun run typecheck` — passed
- `git diff --check` — passed

This supersedes the previously closed #177, whose head was the fork `main` branch and therefore unintentionally included unrelated fork commits.