### PR TITLE
fix: recover one durable stopped-thinking boundary

### DIFF
--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -87,6 +87,10 @@ import {
   ChatGptExternalTurnProgress,
   chatGptExternalProgressIsLive,
 } from "./turn-progress";
+import {
+  ChatGptCompletionAuditGate,
+  chatGptStoppedThinkingRecoveryPrompt,
+} from "./continuation";
 
 export { MAX_CHATGPT_BROWSER_TABS } from "./concurrency";
 
@@ -3410,15 +3414,28 @@ export class ChatGptBrowserWorker {
       let sawRunning = false;
       let loggedCompletionWait = false;
       let capturedResponse = false;
-      const sentAt = Date.now();
-      const visibleTrace = new ChatGptVisibleTraceTracker();
-      const markdownBuffer = new ChatGptMarkdownBuffer();
+      let roundStartedAt = Date.now();
+      let stoppedThinkingRecoveryAttempted = false;
+      let completionAuditGate: ChatGptCompletionAuditGate | undefined;
+      let roundBoundary = "";
+      let roundBoundaryEmitted = false;
+      let visibleTrace = new ChatGptVisibleTraceTracker();
+      let markdownBuffer = new ChatGptMarkdownBuffer();
       const checkpointStream = turn.captureLunaCheckpoint
         ? new ChatGptLunaCheckpointStream()
         : undefined;
-      const emitMarkdownDelta = (delta: string): void => {
+      const emitVisibleDelta = (delta: string): void => {
+        if (!delta) return;
         const visible = checkpointStream ? checkpointStream.push(delta) : delta;
         if (visible) turn.onTextDelta(visible);
+      };
+      const emitMarkdownDelta = (delta: string): void => {
+        if (!delta) return;
+        const gated = completionAuditGate ? completionAuditGate.push(delta) : delta;
+        if (!gated) return;
+        const boundary = roundBoundaryEmitted ? "" : roundBoundary;
+        roundBoundaryEmitted = true;
+        emitVisibleDelta(`${boundary}${gated}`);
       };
       const throwMarkdownConsistencyError = (error: unknown): never => {
         if (!(error instanceof ChatGptMarkdownConsistencyError)) throw error;
@@ -3429,11 +3446,114 @@ export class ChatGptBrowserWorker {
           retryable: false,
         });
       };
-      const completionTracker = new ChatGptCompletionTracker();
-      const domHealthTracker = new ChatGptTurnDomHealthTracker();
-      const stoppedThinkingTracker = new ChatGptStoppedThinkingTracker();
-      const responseDomCache: ChatGptResponseDomCache = {};
+      let completionTracker = new ChatGptCompletionTracker();
+      let domHealthTracker = new ChatGptTurnDomHealthTracker();
+      let stoppedThinkingTracker = new ChatGptStoppedThinkingTracker();
+      let responseDomCache: ChatGptResponseDomCache = {};
       let consecutiveObservationRebinds = 0;
+
+      const observeResponseSnapshot = (snapshot: ChatGptResponseDomSnapshot): void => {
+        const textDelta = (() => {
+          try {
+            return markdownBuffer.observe(snapshot.markdownSegments);
+          } catch (error) {
+            return throwMarkdownConsistencyError(error);
+          }
+        })();
+        for (const trace of visibleTrace.observe(snapshot.traceBlocks, snapshot.completionActionVisible)) {
+          if (trace.kind === "commentary") turn.onCommentary?.(trace.text, trace.continuation === true);
+          else turn.onReasoningSummary?.(trace.text, trace.continuation === true);
+        }
+        if (textDelta) emitMarkdownDelta(textDelta);
+      };
+
+      const finishResponseRound = (
+        visibleText: string,
+        acceptAuditCompletion: boolean,
+      ): { auditComplete: boolean } => {
+        const final = (() => {
+          try {
+            return markdownBuffer.finish();
+          } catch (error) {
+            return throwMarkdownConsistencyError(error);
+          }
+        })();
+        if (!final.markdown && visibleText) {
+          throw new Error("ChatGPT completed with visible text that could not be serialized as Markdown");
+        }
+        if (final.delta) emitMarkdownDelta(final.delta);
+        const audit = completionAuditGate?.finish();
+        if (audit?.delta) {
+          const boundary = roundBoundaryEmitted ? "" : roundBoundary;
+          roundBoundaryEmitted = true;
+          emitVisibleDelta(`${boundary}${audit.delta}`);
+        }
+        const sentinelOnly = audit?.complete === true;
+        if (!sentinelOnly && final.markdown) finalText += `${roundBoundary}${final.markdown}`;
+        return { auditComplete: acceptAuditCompletion && sentinelOnly };
+      };
+
+      const continuationSupported = !turn.compaction && !turn.captureLunaCheckpoint;
+      const startStoppedThinkingRecoveryRound = async (): Promise<void> => {
+        if (!continuationSupported || stoppedThinkingRecoveryAttempted) throw chatGptStoppedThinkingError();
+        stoppedThinkingRecoveryAttempted = true;
+        const continuation = chatGptStoppedThinkingRecoveryPrompt(turn.traceId);
+        const continuationBaseline = await this.captureSubmissionBaseline(page);
+        await this.runStage(
+turn.traceId,
+"stopped_thinking_recovery_attachment",
+browserStageTimeouts.promptAttachment,
+(stageSignal) => this.attachPrompt(
+  page,
+  continuation.text,
+  mode.localTools,
+  checkpoint => diagnostics.capture(page, `stopped-thinking-recovery-${checkpoint}`),
+  turn.abortSignal ? AbortSignal.any([stageSignal, turn.abortSignal]) : stageSignal,
+  false,
+  undefined,
+  mode.localTools,
+),
+        );
+        const evidence = await this.runStage(
+turn.traceId,
+"stopped_thinking_recovery_send",
+browserStageTimeouts.send,
+(stageSignal) => this.sendAttachedPrompt(
+  page,
+  continuationBaseline,
+  checkpoint => diagnostics.capture(page, `stopped-thinking-recovery-${checkpoint}`),
+  turn.abortSignal ? AbortSignal.any([stageSignal, turn.abortSignal]) : stageSignal,
+  turn.externalProgress,
+),
+        );
+        responseTurn = await this.waitForNewAssistantTurn(
+page,
+continuationBaseline,
+deadline,
+turn.abortSignal,
+turn.externalProgress,
+        );
+        submissionBaseline = continuationBaseline;
+        completionAuditGate = new ChatGptCompletionAuditGate(continuation.sentinel);
+        roundBoundary = "";
+        roundBoundaryEmitted = false;
+        roundStartedAt = Date.now();
+        visibleTrace = new ChatGptVisibleTraceTracker();
+        markdownBuffer = new ChatGptMarkdownBuffer();
+        completionTracker = new ChatGptCompletionTracker();
+        domHealthTracker = new ChatGptTurnDomHealthTracker();
+        stoppedThinkingTracker = new ChatGptStoppedThinkingTracker();
+        responseDomCache = {};
+        consecutiveObservationRebinds = 0;
+        sawRunning = false;
+        loggedCompletionWait = false;
+        capturedResponse = false;
+        await diagnostics.capture(page, "stopped-thinking-recovery-send-accepted");
+        console.info(
+`[chatgpt-web] browser turn ${turn.traceId} started one stopped-thinking recovery evidence=${evidence}`,
+        );
+      };
+
       for (;;) {
         if (page.isClosed()) {
           throw chatGptBrowserTabClosedError();
@@ -3505,9 +3625,7 @@ export class ChatGptBrowserWorker {
           }
         }
         if (snapshot.responsePresent) consecutiveObservationRebinds = 0;
-        if (stoppedThinkingTracker.update(snapshot.stoppedThinkingVisible)) {
-          throw chatGptStoppedThinkingError();
-        }
+        const stoppedThinking = stoppedThinkingTracker.update(snapshot.stoppedThinkingVisible);
         if (!snapshot.responsePresent && chatGptExternalProgressIsLive(
           turn.externalProgress?.snapshot(),
           Date.now(),
@@ -3527,18 +3645,14 @@ export class ChatGptBrowserWorker {
             capturedResponse = true;
             await diagnostics.capture(page, "response-visible");
           }
-          const textDelta = (() => {
-            try {
-              return markdownBuffer.observe(snapshot.markdownSegments);
-            } catch (error) {
-              return throwMarkdownConsistencyError(error);
+          observeResponseSnapshot(snapshot);
+          if (stoppedThinking) {
+              if (!continuationSupported || stoppedThinkingRecoveryAttempted) throw chatGptStoppedThinkingError();
+              finishResponseRound(snapshot.visibleText, false);
+              await diagnostics.capture(page, "stopped-thinking-recovery");
+              await startStoppedThinkingRecoveryRound();
+              continue;
             }
-          })();
-          for (const trace of visibleTrace.observe(snapshot.traceBlocks, snapshot.completionActionVisible)) {
-            if (trace.kind === "commentary") turn.onCommentary?.(trace.text, trace.continuation === true);
-            else turn.onReasoningSummary?.(trace.text, trace.continuation === true);
-          }
-          if (textDelta) emitMarkdownDelta(textDelta);
           const domError = domHealthTracker.update({
             responsePresent: snapshot.responsePresent,
             running,
@@ -3556,29 +3670,30 @@ export class ChatGptBrowserWorker {
             if (snapshot.visibleText === "api_tool unavailable") {
               throw new Error("ChatGPT selected mode rejected the Codex Native MCP tool (api_tool unavailable)");
             }
-            const final = (() => {
-              try {
-                return markdownBuffer.finish();
-              } catch (error) {
-                return throwMarkdownConsistencyError(error);
-              }
-            })();
-            if (!final.markdown && snapshot.visibleText) {
-              throw new Error("ChatGPT completed with visible text that could not be serialized as Markdown");
-            }
-            if (final.delta) emitMarkdownDelta(final.delta);
             if (checkpointStream) {
+              const final = (() => {
+                try {
+                  return markdownBuffer.finish();
+                } catch (error) {
+                  return throwMarkdownConsistencyError(error);
+                }
+              })();
+              if (!final.markdown && snapshot.visibleText) {
+                throw new Error("ChatGPT completed with visible text that could not be serialized as Markdown");
+              }
+              if (final.delta) emitMarkdownDelta(final.delta);
               const completed = checkpointStream.finishOptional(snapshot.visibleText);
               if (completed.visibleRemainder) turn.onTextDelta(completed.visibleRemainder);
               if (completed.captured) turn.onLunaCheckpoint!(completed.captured);
               else console.warn(`[chatgpt-web] browser turn ${turn.traceId} completed without a Luna rolling checkpoint; preserving full native history`);
               finalText = completed.answer;
-            } else {
-              finalText = final.markdown;
+              break;
             }
+            const finishedRound = finishResponseRound(snapshot.visibleText, true);
+            if (finishedRound.auditComplete) break;
             break;
           }
-          if (!loggedCompletionWait && Date.now() - sentAt >= 30_000) {
+          if (!loggedCompletionWait && Date.now() - roundStartedAt >= 30_000) {
             loggedCompletionWait = true;
             await diagnostics.capture(page, "response-stalled-30s");
             const diagnostic = await this.stalledTurnDiagnostic(page, responseTurn.locator).catch(error => JSON.stringify({

--- a/src/adapters/chatgpt-web/continuation.ts
+++ b/src/adapters/chatgpt-web/continuation.ts
@@ -1,0 +1,63 @@
+const TRACE_ID = /^[A-Za-z0-9_-]{6,128}$/;
+const COMPLETION_SENTINEL_PREFIX = "CODEX_NATIVE_STOPPED_THINKING_COMPLETE_";
+
+export function chatGptStoppedThinkingCompletionSentinel(traceId: string): string {
+  if (!TRACE_ID.test(traceId)) throw new Error("ChatGPT continuation trace id is invalid");
+  return `${COMPLETION_SENTINEL_PREFIX}${traceId}`;
+}
+
+/**
+ * One private same-conversation recovery message for a durable ChatGPT `Stopped thinking`
+ * state. It never replays the already accepted Codex request.
+ */
+export function chatGptStoppedThinkingRecoveryPrompt(
+  traceId: string,
+): { text: string; sentinel: string } {
+  const sentinel = chatGptStoppedThinkingCompletionSentinel(traceId);
+  return {
+    sentinel,
+    text: [
+      "<codex_native_stopped_thinking_recovery>",
+      "This is a private recovery check for the SAME active Codex turn, not a new user task.",
+      "ChatGPT exposed a durable Stopped thinking state before the outer Codex turn could safely accept completion.",
+      "Re-read the original Codex task and the immediately preceding work in this conversation. Preserve every completed tool effect, result, decision, and constraint.",
+      "Do not restart the task, redo completed work, or repeat user-facing text that the preceding assistant response already returned.",
+      "If local work is still required, keep using the already attached Codex Native tools and the same turn_token supplied by the prior Codex transport message. Never expose that token.",
+      `If and only if the original Codex request is already fully complete and verified AND the preceding assistant output already contains the complete user-facing answer, reply with exactly ${sentinel} and nothing else.`,
+      "Otherwise continue the unfinished work now and return only the missing continuation that should be appended to the same outer Codex response.",
+      "Do not mention this recovery check, the execution boundary, the sentinel, or the transport in user-facing output.",
+      "</codex_native_stopped_thinking_recovery>",
+    ].join("\n"),
+  };
+}
+
+/** Suppress only the private completion sentinel; real recovery text passes through. */
+export class ChatGptCompletionAuditGate {
+  private pending = "";
+  private passthrough = false;
+
+  constructor(readonly sentinel: string) {
+    if (!sentinel.trim()) throw new Error("ChatGPT completion audit sentinel must not be empty");
+  }
+
+  push(delta: string): string {
+    if (!delta) return "";
+    if (this.passthrough) return delta;
+    this.pending += delta;
+    const candidate = this.pending.trimStart();
+    if (!candidate || this.sentinel.startsWith(candidate)) return "";
+    this.passthrough = true;
+    const visible = this.pending;
+    this.pending = "";
+    return visible;
+  }
+
+  finish(): { complete: boolean; delta: string } {
+    if (this.passthrough) return { complete: false, delta: "" };
+    const pending = this.pending;
+    this.pending = "";
+    if (pending.trim() === this.sentinel) return { complete: true, delta: "" };
+    this.passthrough = true;
+    return { complete: false, delta: pending };
+  }
+}

--- a/tests/chatgpt-web-continuation.test.ts
+++ b/tests/chatgpt-web-continuation.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import {
+  ChatGptCompletionAuditGate,
+  chatGptStoppedThinkingCompletionSentinel,
+  chatGptStoppedThinkingRecoveryPrompt,
+} from "../src/adapters/chatgpt-web/continuation";
+
+test("Stopped-thinking recovery keeps the same task ledger and capability", () => {
+  const traceId = "abc123def456";
+  const recovery = chatGptStoppedThinkingRecoveryPrompt(traceId);
+  expect(recovery.sentinel).toBe(chatGptStoppedThinkingCompletionSentinel(traceId));
+  expect(recovery.text).toContain("SAME active Codex turn");
+  expect(recovery.text).toContain("same turn_token");
+  expect(recovery.text).toContain("Do not restart the task");
+  expect(recovery.text).toContain("Stopped thinking");
+  expect(recovery.text).toContain(recovery.sentinel);
+  expect(() => chatGptStoppedThinkingCompletionSentinel("bad trace id")).toThrow("trace id is invalid");
+});
+
+test("private completion sentinel is suppressed while real recovery text passes through", () => {
+  const sentinel = chatGptStoppedThinkingCompletionSentinel("abc123def456");
+  const completed = new ChatGptCompletionAuditGate(sentinel);
+  expect(completed.push(sentinel.slice(0, 17))).toBe("");
+  expect(completed.push(sentinel.slice(17))).toBe("");
+  expect(completed.finish()).toEqual({ complete: true, delta: "" });
+
+  const continued = new ChatGptCompletionAuditGate(sentinel);
+  expect(continued.push("C")).toBe("");
+  expect(continued.push("ontinuing the remaining verification now.")).toBe(
+    "Continuing the remaining verification now.",
+  );
+  expect(continued.push(" Done.")).toBe(" Done.");
+  expect(continued.finish()).toEqual({ complete: false, delta: "" });
+});
+
+test("browser integration permits exactly one event-driven recovery and no elapsed-time audit", () => {
+  const source = readFileSync(new URL("../src/adapters/chatgpt-web/browser-worker.ts", import.meta.url), "utf8");
+  expect(source).toContain("chatGptStoppedThinkingRecoveryPrompt");
+  expect(source).toContain("startStoppedThinkingRecoveryRound");
+  expect(source).toContain("stoppedThinkingRecoveryAttempted");
+  expect(source).toContain("!turn.compaction && !turn.captureLunaCheckpoint");
+  expect(source).not.toContain("chatGptLongTurnNeedsAudit");
+  expect(source).not.toContain("CHATGPT_LONG_TURN_COMPLETION_AUDIT_AFTER_MS");
+  expect(source).not.toContain("MAX_CHATGPT_WEB_CONTINUATION_ROUNDS");
+  expect(source).not.toContain("long_turn_completion");
+  expect(source).not.toContain("startContinuationRound");
+
+  const start = source.indexOf("const startStoppedThinkingRecoveryRound");
+  const end = source.indexOf("for (;;) {", start);
+  const recovery = source.slice(start, end);
+  expect(recovery).toContain("this.attachPrompt(");
+  expect(recovery).toContain("this.sendAttachedPrompt(");
+  expect(recovery).not.toContain("turn.onSendActivated");
+  expect(recovery).not.toContain("turn.prepare(");
+});


### PR DESCRIPTION
Addresses #194.

This PR is now deliberately narrow. It handles only the durable ChatGPT Web `Stopped thinking` UI state that the bridge already recognizes as terminal; it no longer infers an execution boundary from elapsed time.

What changes:

- On a normal non-Luna, non-compaction turn, the first durable `Stopped thinking` observation may trigger exactly one private recovery message in the same owned Temporary Chat.
- The already accepted Codex request is not replayed. The recovery path does not call `turn.prepare` or `turn.onSendActivated`; it sends only the private recovery instruction into the existing conversation.
- Existing work, tool effects, decisions, and streamed text remain authoritative. The recovery instruction tells the model to keep using the same turn-bound Codex Native capability / `turn_token` if more local work is actually required.
- If the prior work was already complete, a private completion sentinel is suppressed from Codex output. Otherwise only the missing continuation is returned.
- Recovery is event-driven and single-use. A second durable `Stopped thinking` observation fails closed through the existing terminal error path.
- Compaction and Luna rolling-checkpoint flows remain excluded.
- The previous 20-minute completion audit, generic long-turn continuation behavior, and eight-round continuation budget have been removed. This adds no absolute browser-turn deadline; the existing 30-second stalled-response capture remains diagnostic only.

Validation on the exact proposed tree (`eb0988ea8f992e4648c0638b530df38de3cbe8c6`):

- focused continuation + browser-worker contract tests: passed
- `bunx tsc --noEmit`: passed
- full `bun run verify`: passed
- one clean commit on current upstream `main` (`34336fb2deb5d17bcf12be74c6573c2fb26ee0ed`)
- changed files are only `browser-worker.ts`, `continuation.ts`, and the focused regression test; no temporary Gauntlet workflow is in the proposed tree

Evidence boundary: I do **not** have a real-account reproduction or redacted browser trace for a spontaneous `Stopped thinking` incident. The case was a protocol hypothesis based on the bridge's existing durable terminal-state handling. This PR therefore should be read as narrowly tested recovery hardening for that observed DOM state, not proof that current ChatGPT accounts hit such a boundary under a particular tier, usage level, or duration.