### PR TITLE
fix: preserve native subagent delegation for Pro

### DIFF
--- a/src/adapters/chatgpt-web/prompt.ts
+++ b/src/adapters/chatgpt-web/prompt.ts
@@ -413,11 +413,6 @@ export function compileChatGptWebPrompt(
       "Do not claim a new local inspection, command, edit, or verification unless it actually appears in the task history. If the latest request requires fresh local-computer access or a local mutation, state only that exact limitation instead of inventing success.",
       "Otherwise perform the full requested research, analysis, or synthesis with every capability actually available to you; do not stop at a plan or progress report.",
     ];
-  const proDelegationContract = !parsed._compactionRequest && mode.effort === "max"
-    ? [
-      "Complete this task directly in the current parent response. Do not create, spawn, delegate to, or wait on sub-agents, parallel agents, background agents, or delegated workers, even if such tools are available. Use non-agent tools directly instead.",
-    ]
-    : [];
   const checkpointContract = captureLunaCheckpoint
     ? [
       "After the complete user-facing answer, append one private rolling task checkpoint for the next Luna turn.",
@@ -470,7 +465,6 @@ export function compileChatGptWebPrompt(
         commit: [
           ...sharedContract,
           ...transportContract,
-          ...proDelegationContract,
           ...checkpointContract,
           answerContract,
           ...transportResume,
@@ -482,7 +476,6 @@ export function compileChatGptWebPrompt(
     const text = [
       ...sharedContract,
       ...transportContract,
-      ...proDelegationContract,
       ...checkpointContract,
       answerContract,
       "<codex_context_json>",

--- a/tests/prompt-contract.test.ts
+++ b/tests/prompt-contract.test.ts
@@ -63,16 +63,19 @@ test("Full-mode Pro prompts pass one stable turn token directly to native action
   expect(compiled.text).not.toContain("internally compacts this response");
 });
 
-test("Pro executes directly without delegating while other Web modes keep their existing contract", () => {
+test("Pro preserves the same native Codex delegation contract as Extra High", () => {
   const token = "turn_12345678901234567890123456789012";
   const capabilities = { localToolsEnabled: true, solAvailable: true, proAvailable: true };
   const pro = compileChatGptWebPrompt(request("max"), capabilities, token);
   const extraHigh = compileChatGptWebPrompt(request("xhigh"), capabilities, token);
 
-  expect(pro.text).toContain("Complete this task directly in the current parent response.");
-  expect(pro.text).toContain("Do not create, spawn, delegate to, or wait on sub-agents");
-  expect(pro.text).toContain("Use non-agent tools directly instead.");
-  expect(extraHigh.text).not.toContain("Do not create, spawn, delegate to, or wait on sub-agents");
+  for (const compiled of [pro, extraHigh]) {
+    expect(compiled.text).toContain("For local work required by the task, use the attached Codex Native tools directly according to their declared descriptions and schemas.");
+    expect(compiled.text).toContain(`Pass turn_token ${token} unchanged to every Codex Native call in this response`);
+    expect(compiled.text).not.toContain("Complete this task directly in the current parent response.");
+    expect(compiled.text).not.toContain("Do not create, spawn, delegate to, or wait on sub-agents");
+    expect(compiled.text).not.toContain("Use non-agent tools directly instead.");
+  }
 });
 
 test("read-only prompts resume without exposing a bind capability", () => {


### PR DESCRIPTION
Closes #196.

Full mode already gives every Web effort the same turn-bound Codex Native capability, and the outer Codex harness remains authoritative for collaboration tools and subagent protocol selection. The prompt compiler nevertheless added a Pro-only instruction telling the model not to spawn, delegate to, or wait on subagents.

This removes only that effort-specific behavioral suppression. It does not add a second agent runtime and it does not change the MCP broker, permissions, sandboxing, or MultiAgent protocol handling. Pro now receives the same generic native Codex tool contract as Extra High and can use collaboration tools when the outer Codex turn exposes them.

Validation on the proposed source change:

- targeted prompt/subagent/harness tests: passed
- `bunx tsc --noEmit`: passed
- full `bun run verify`: passed
- no temporary CI workflow files are included in this clean branch

The branch is one commit and two files on top of upstream `97fe185f19bd10358d532f5c4966617d9cd48388`.