### PR TITLE
fix: wait for ChatGPT send readiness before compaction submit

### DIFF
--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -118,6 +118,7 @@ const CHATGPT_SMOKE_EXPECTED = "CODEX WEB GPT READY";
  * editor has taken the previous one. This is headroom for that, not a readiness check.
  */
 export const CHATGPT_UI_SETTLE_MS = 250;
+export const CHATGPT_SEND_ENABLE_GRACE_MS = 5_000;
 
 const CHATGPT_DOM_REVISION_ATTRIBUTES = [
   "aria-hidden",
@@ -2298,12 +2299,21 @@ export class ChatGptBrowserWorker {
       .locator("xpath=ancestor::form[1]")
       .getByTestId("send-button");
     await sendButton.waitFor({ state: "visible", timeout: browserStageTimeouts.send });
-    if (!await sendButton.isEnabled()) {
-      throw new Error("ChatGPT send button is disabled after the complete prompt was attached");
-    }
     await settleChatGptUi();
+    const sendEnableDeadline = Date.now() + CHATGPT_SEND_ENABLE_GRACE_MS;
+    for (;;) {
+      if (abortSignal?.aborted) throw new DOMException("ChatGPT web turn aborted", "AbortError");
+      if (page.isClosed()) throw chatGptBrowserTabClosedError();
+      await throwIfChatGptSessionFailureAlert(page);
+      await throwIfChatGptRateLimitDialog(page);
+      if (await sendButton.isEnabled()) break;
+      if (Date.now() >= sendEnableDeadline) {
+        await captureDiagnostic?.("send-disabled");
+        throw new Error("ChatGPT send button remained disabled after the complete prompt was attached");
+      }
+      await settleChatGptUi();
+    }
     await captureDiagnostic?.("send-ready");
-    await throwIfChatGptSessionFailureAlert(page);
     const initialToolBatchRevision = externalProgress?.snapshot().lastToolBatchRevision ?? 0;
     await submissionLifecycle?.onSendActivated?.();
     await sendButton.press("Enter");

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -34,10 +34,25 @@ test("browser turn orchestration retains owned prompt insertion and semantic sub
     workerSource.indexOf("  private async sendAttachedPrompt("),
     workerSource.indexOf("  private async waitForMultipartAcknowledgement("),
   );
+  const sendSettled = sendAttachedPrompt.indexOf("await settleChatGptUi()");
+  const sendDeadline = sendAttachedPrompt.indexOf("CHATGPT_SEND_ENABLE_GRACE_MS", sendSettled);
+  const sessionChecked = sendAttachedPrompt.indexOf("await throwIfChatGptSessionFailureAlert(page)", sendDeadline);
+  const rateLimitChecked = sendAttachedPrompt.indexOf("await throwIfChatGptRateLimitDialog(page)", sessionChecked);
+  const enabledChecked = sendAttachedPrompt.indexOf("if (await sendButton.isEnabled()) break;", rateLimitChecked);
+  const sendReady = sendAttachedPrompt.indexOf('await captureDiagnostic?.("send-ready")');
   const sendActivated = sendAttachedPrompt.indexOf("submissionLifecycle?.onSendActivated?.()");
   const sendPressed = sendAttachedPrompt.indexOf('await sendButton.press("Enter")');
   const submissionWait = sendAttachedPrompt.indexOf("await this.waitForSubmissionAccepted(");
   const submitted = sendAttachedPrompt.indexOf("submissionLifecycle?.onSubmitted?.()");
+  expect(sendSettled).toBeGreaterThan(-1);
+  expect(sendDeadline).toBeGreaterThan(sendSettled);
+  expect(sessionChecked).toBeGreaterThan(sendDeadline);
+  expect(rateLimitChecked).toBeGreaterThan(sessionChecked);
+  expect(enabledChecked).toBeGreaterThan(rateLimitChecked);
+  expect(sendReady).toBeGreaterThan(enabledChecked);
+  expect(sendActivated).toBeGreaterThan(sendReady);
+  expect(sendAttachedPrompt).toContain("send button remained disabled after the complete prompt was attached");
+  expect(sendAttachedPrompt).not.toContain("send button is disabled after the complete prompt was attached");
   expect(sendActivated).toBeGreaterThan(-1);
   expect(sendActivated).toBeLessThan(sendPressed);
   expect(sendAttachedPrompt).toContain("await submissionLifecycle?.onSendActivated?.()");


### PR DESCRIPTION
## Summary

Fix a retained ChatGPT compaction submission race where the prompt is fully attached but the Web UI has not enabled Send yet.

Changes:
- settle the ChatGPT composer before evaluating send readiness
- give asynchronous Send activation a bounded 5-second grace window
- surface session-expiry and rate-limit errors while waiting
- abort cleanly if the Codex turn is cancelled or the browser page closes
- preserve fail-closed behavior when Send remains disabled
- add regression coverage for the readiness ordering

## Reproduction

Observed on v4.0.5 during retained remote compaction:

`The retained ChatGPT agent did not complete the structured context handoff: ChatGPT send button is disabled after the complete prompt was attached`

The existing implementation checked `sendButton.isEnabled()` before its own UI-settle step.

## Verification

- `tests/browser-worker-contract.test.ts`: 80 passed, 0 failed
- TypeScript `tsc --noEmit`: passed
- `git diff --check`: passed

## Safety

This change does not:
- force-click Send
- resend an accepted prompt
- weaken prompt-integrity verification
- bypass account/session/rate-limit failures
- change tool approval behavior

The readiness wait is bounded and still fails closed.