### PR TITLE
Fix headless/Xvfb viewport collapse and stale turn-tab acquisition

### DIFF
--- a/launcher/electron/browser-host.cjs
+++ b/launcher/electron/browser-host.cjs
@@ -243,7 +243,7 @@ class BrowserHost {
     this.turnLeaseSweep = setInterval(() => this.reapExpiredTurnTabs(), TURN_HEARTBEAT_SWEEP_MS);
     this.turnLeaseSweep.unref?.();
     this.boundsReady = false;
-    this.bounds = { x: 0, y: 0, width: 1, height: 1 };
+    this.bounds = { x: 0, y: 0, width: 1280, height: 800 };
     this.state = {
       status: "idle",
       message: "No active task",
@@ -317,6 +317,10 @@ class BrowserHost {
   }
 
   createTurnTab(traceId, helperPid, conversationKey, connectorIdentity) {
+    // Reaper: finished tabs keep stale surface ids and 0x0 viewports that break acquisition.
+    for (const staleTab of [...this.turnTabs.values()]) {
+      if (staleTab.status !== "running") this.removeTurnTab(staleTab, false);
+    }
     if (this.turnTabs.size >= MAX_BROWSER_TABS
       && !BrowserHost.prototype.evictOldestRetainedTurnTab.call(this)) {
       throw new Error(
@@ -868,6 +872,9 @@ class BrowserHost {
       normalizeBounds(scaleBrowserBounds(bounds, rendererZoomFactor)),
       { width, height },
     );
+    // Headless/Xvfb: never let the browser surface collapse below an operational viewport.
+    this.bounds.width = Math.max(this.bounds.width, 1280);
+    this.bounds.height = Math.max(this.bounds.height, 800);
     this.boundsReady = true;
     this.view.setBounds(this.bounds);
     this.authView?.setBounds(this.bounds);
@@ -890,8 +897,9 @@ class BrowserHost {
       // Electron collapses a hidden WebContentsView's renderer viewport to 0x0. Keep running
       // turn views visible to Chromium and move them wholly outside the launcher content area so
       // Playwright retains a real viewport without exposing the task to the user.
-      x: Math.max(width, Math.round(contentWidth || 0)) + 1,
-      y: Math.max(height, Math.round(contentHeight || 0)) + 1,
+      // Park on-screen: Xvfb/headless compositors still collapse offscreen views to 0x0.
+      x: 0,
+      y: 0,
       width,
       height,
     };
@@ -946,7 +954,10 @@ class BrowserHost {
   syncViewVisibility() {
     const visible = browserViewVisible(this.visible, this.surfaceActive, this.boundsReady);
     const selected = this.selectedTurnTab();
-    this.view.setVisible(visible && !this.authView && !selected);
+    const homeVisible = visible && !this.authView && !selected;
+    // Keep the home surface composited with a real viewport even when "hidden".
+    this.view.setBounds(homeVisible ? this.bounds : this.hiddenTurnBounds());
+    this.view.setVisible(true);
     for (const tab of this.turnTabs.values()) {
       const tabVisible = visible && !this.authView && selected?.id === tab.id;
       this.presentTurnView(tab, tabVisible);

--- a/src/stall-timeout.ts
+++ b/src/stall-timeout.ts
@@ -5,7 +5,7 @@
  * Raised from 90s so long reasoning + large tool writes are not cut mid-turn.
  * Hung streams still die; they just get a more realistic window.
  */
-export const DEFAULT_STALL_TIMEOUT_SEC = 300;
+export const DEFAULT_STALL_TIMEOUT_SEC = 900;
 
 /**
  * Resolve the effective bridge stall deadline for a turn.


### PR DESCRIPTION
## Summary
Running the launcher on a headless Linux server (Xvfb, systemd) surfaced three failure modes that all end in `ChatGPT browser surface did not expose an operational viewport` or `multipart_stage_2_send` timeouts. This PR fixes the underlying viewport lifecycle:

- **Default surface bounds `1x1` → `1280x800` + floor in `setBounds`** — until the renderer sends its first measured bounds, the embedded ChatGPT surface sits at 1x1 and the operational-viewport probe can never pass.
- **Home surface stays composited with a real viewport** — `setVisible(false)` makes Electron collapse a WebContentsView renderer to `0x0` even with valid bounds; hidden-turn parking now keeps views alive.
- **On-screen parking for hidden turns** — offscreen `x = contentWidth + 1` parking still collapses to `0x0` under Xvfb; parked views now keep a real (`>= 800x600`) viewport at `0,0`.
- **Turn-tab reaper** — finished tabs retained their surface ids and dead `0x0` viewports, so later acquisitions could bind to a dead surface (`multipart_stage_2_send` after several turns). New turns now reap finished tabs first.
- **Stall budget 300s → 900s** — long reasoning + large tool writes are legitimate upstream silence; the old budget cut healthy turns mid-stream.

## Testing
- Headless Xvfb `:99` + systemd, single account, `browser-only` and `full` modes.
- `codex exec` turns repeatedly before (viewport timeout loops, `multipart_stage_2_send` after ~3 turns) and after (stable, multi-turn, large docker-build tool outputs).
- Interactive launcher sign-in, smoke test, and model install unaffected on a desktop session.

No API or protocol changes; Electron view lifecycle only.