### PR TITLE
Headless CLI mode: CLI-only setup, headless login, systemd user services

### DIFF
--- a/src/browser-login.ts
+++ b/src/browser-login.ts
@@ -1,7 +1,8 @@
 import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { chromium, type BrowserContextOptions } from "playwright-core";
+import { chromium, type BrowserContextOptions, type Page } from "playwright-core";
+import { runCommand } from "./process";
 import type { AppConfig } from "./config";
 import { atomicWriteFile } from "./config";
 import {
@@ -47,10 +48,11 @@ function writeVerificationMarker(
 async function inspectStoredState(
   config: AppConfig,
   storageState: NonNullable<BrowserContextOptions["storageState"]>,
+  headless = false,
 ): Promise<ChatGptWebAccountCapabilities & { url: string }> {
   const verifierBrowser = await chromium.launch({
     executablePath: config.chromeExecutablePath,
-    headless: false,
+    headless,
     ignoreDefaultArgs: ["--password-store=basic", "--use-mock-keychain"],
     args: ["--no-first-run", "--no-default-browser-check"],
   });
@@ -93,15 +95,129 @@ export function storedBrowserLoginCapabilities(
   }
 }
 
-export async function loginToChatGpt(
-  config: AppConfig,
-  options: { timeoutMs?: number } = {},
-): Promise<BrowserLoginResult> {
-  if (!existsSync(config.chromeExecutablePath)) {
-    throw new Error(`Google Chrome was not found at ${config.chromeExecutablePath}. Pass --chrome with its executable path.`);
+export type LoginHeadlessMode = "auto" | "force" | "off";
+
+export interface LoginToChatGptOptions {
+  timeoutMs?: number;
+  loginHeadless?: LoginHeadlessMode;
+  storageStateFile?: string;
+}
+
+const CHROME_LAUNCH_ARGS = ["--no-first-run", "--no-default-browser-check"];
+const CHROME_IGNORE_DEFAULT_ARGS = ["--password-store=basic", "--use-mock-keychain"];
+
+function composerLocator(page: Page) {
+  return page.getByRole("textbox", { name: "Chat with ChatGPT" }).or(
+    page.locator('[data-testid="prompt-textarea"], [contenteditable="true"][data-lexical-editor="true"]'),
+  ).first();
+}
+
+async function headlessLoginBlocked(page: Page): Promise<boolean> {
+  const content = await page.content().catch(() => "");
+  return /challenge-platform|just a moment|verify you are human|cf-please-wait/i.test(content);
+}
+
+async function withEphemeralXvfb<T>(fn: (display: string) => Promise<T>): Promise<T> {
+  const probe = runCommand("which", ["Xvfb"]);
+  if (probe.status !== 0) {
+    throw new Error(
+      "Headless ChatGPT login was blocked and Xvfb is not installed. "
+      + "Install xvfb, import a storage state via --storage-state-file, or log in on a machine with a display.",
+    );
   }
-  const profileDir = join(dirname(config.storageStatePath), "login-profile");
-  mkdirSync(profileDir, { recursive: true, mode: 0o700 });
+  const { readdirSync } = await import("node:fs");
+  const existing = new Set(readdirSync("/tmp/.X11-unix").map(name => name.replace(/^X/, "")));
+  let display: string | undefined;
+  for (let candidate = 99; candidate < 200; candidate += 1) {
+    if (!existing.has(String(candidate))) { display = `:${candidate}`; break; }
+  }
+  if (!display) throw new Error("No free display number found for ephemeral Xvfb");
+  const xvfb = spawn("Xvfb", [display, "-screen", "0", "1280x800x24", "-nolisten", "tcp"], { stdio: "ignore" });
+  await new Promise(resolveWait => setTimeout(resolveWait, 800));
+  if (xvfb.exitCode !== null && xvfb.exitCode !== 0) throw new Error(`Xvfb exited with status ${xvfb.exitCode}`);
+  try {
+    return await fn(display);
+  } finally {
+    xvfb.kill("SIGTERM");
+    setTimeout(() => xvfb.kill("SIGKILL"), 2_000).unref?.();
+  }
+}
+
+async function finalizeLogin(
+  config: AppConfig,
+  context: Awaited<ReturnType<typeof chromium.launchPersistentContext>>,
+  page: Page,
+  headless: boolean,
+): Promise<BrowserLoginResult> {
+  await assertAuthenticatedChatGptPage(page);
+  await assertTemporaryChatPage(page);
+  const state = await context.storageState();
+  const inspected = await inspectStoredState(config, state, headless);
+  atomicWriteFile(config.storageStatePath, `${JSON.stringify(state)}\n`);
+  writeVerificationMarker(config.storageStatePath, inspected);
+  return {
+    storageStatePath: config.storageStatePath,
+    accountSurfaceUrl: page.url(),
+    solAvailable: inspected.solAvailable,
+    proAvailable: inspected.proAvailable,
+  };
+}
+
+async function importStorageStateFile(
+  config: AppConfig,
+  storageStateFile: string,
+): Promise<BrowserLoginResult> {
+  if (!existsSync(storageStateFile)) throw new Error(`Storage state file not found: ${storageStateFile}`);
+  let state: unknown;
+  try {
+    state = JSON.parse(readFileSync(storageStateFile, "utf8"));
+  } catch {
+    throw new Error(`Storage state file is not valid JSON: ${storageStateFile}`);
+  }
+  if (typeof state !== "object" || state === null || !Array.isArray((state as { cookies?: unknown }).cookies)) {
+    throw new Error("Storage state file must be a Playwright storageState object with a cookies array");
+  }
+  const inspected = await inspectStoredState(config, state as NonNullable<BrowserContextOptions["storageState"]>, true);
+  atomicWriteFile(config.storageStatePath, `${JSON.stringify(state)}\n`);
+  writeVerificationMarker(config.storageStatePath, inspected);
+  return {
+    storageStatePath: config.storageStatePath,
+    accountSurfaceUrl: inspected.url,
+    solAvailable: inspected.solAvailable,
+    proAvailable: inspected.proAvailable,
+  };
+}
+
+async function attemptPersistentLogin(
+  config: AppConfig,
+  profileDir: string,
+  headless: boolean,
+  timeoutMs: number,
+): Promise<BrowserLoginResult> {
+  const context = await chromium.launchPersistentContext(profileDir, {
+    executablePath: config.chromeExecutablePath,
+    headless,
+    ignoreDefaultArgs: CHROME_IGNORE_DEFAULT_ARGS,
+    args: CHROME_LAUNCH_ARGS,
+  });
+  try {
+    const page = context.pages()[0] ?? await context.newPage();
+    await page.goto(CHATGPT_TEMPORARY_CHAT_URL, { waitUntil: "domcontentloaded", timeout: 60_000 });
+    try {
+      await composerLocator(page).waitFor({ state: "visible", timeout: timeoutMs });
+    } catch {
+      if (headless && await headlessLoginBlocked(page)) {
+        throw new Error("HEADLESS_BLOCKED: ChatGPT served a bot challenge to the headless browser");
+      }
+      throw new Error("The authenticated ChatGPT page did not produce a visible composer");
+    }
+    return await finalizeLogin(config, context, page, headless);
+  } finally {
+    await context.close();
+  }
+}
+
+async function headedChromeLoginWindow(config: AppConfig, profileDir: string, display?: string): Promise<void> {
   process.stdout.write(
     "A normal Chrome window is open. Sign in to ChatGPT, confirm that the composer is visible, then quit this dedicated Chrome instance completely.\n",
   );
@@ -109,10 +225,9 @@ export async function loginToChatGpt(
     `--user-data-dir=${profileDir}`,
     "--new-window",
     "--disable-background-mode",
-    "--no-first-run",
-    "--no-default-browser-check",
+    ...CHROME_LAUNCH_ARGS,
     CHATGPT_TEMPORARY_CHAT_URL,
-  ], { env: process.env, stdio: "ignore" });
+  ], { env: display ? { ...process.env, DISPLAY: display } : process.env, stdio: "ignore" });
   const loginExit = await new Promise<number>((resolveExit, rejectExit) => {
     loginBrowser.once("error", rejectExit);
     loginBrowser.once("exit", (code, signal) => {
@@ -121,42 +236,37 @@ export async function loginToChatGpt(
     });
   });
   if (loginExit !== 0) throw new Error(`Normal Chrome login window exited with status ${loginExit}`);
+}
 
-  const context = await chromium.launchPersistentContext(profileDir, {
-    executablePath: config.chromeExecutablePath,
-    headless: false,
-    ignoreDefaultArgs: ["--password-store=basic", "--use-mock-keychain"],
-    args: ["--no-first-run", "--no-default-browser-check"],
-  });
+export async function loginToChatGpt(
+  config: AppConfig,
+  options: LoginToChatGptOptions = {},
+): Promise<BrowserLoginResult> {
+  if (!existsSync(config.chromeExecutablePath)) {
+    throw new Error(`Google Chrome was not found at ${config.chromeExecutablePath}. Pass --chrome with its executable path.`);
+  }
+  if (options.storageStateFile) return importStorageStateFile(config, options.storageStateFile);
+  const profileDir = join(dirname(config.storageStatePath), "login-profile");
+  mkdirSync(profileDir, { recursive: true, mode: 0o700 });
+  const timeoutMs = options.timeoutMs ?? 60_000;
+  const mode: LoginHeadlessMode = options.loginHeadless ?? "auto";
   try {
-    const page = context.pages()[0] ?? await context.newPage();
-    await page.goto(CHATGPT_TEMPORARY_CHAT_URL, {
-      waitUntil: "domcontentloaded",
-      timeout: 60_000,
-    });
-    const composer = page.getByRole("textbox", { name: "Chat with ChatGPT" }).or(
-      page.locator('[data-testid="prompt-textarea"], [contenteditable="true"][data-lexical-editor="true"]'),
-    ).first();
-    try {
-      await composer.waitFor({ state: "visible", timeout: options.timeoutMs ?? 60_000 });
-    } catch {
-      throw new Error("The authenticated ChatGPT page did not produce a visible composer");
+    if (mode !== "off") {
+      try {
+        return await attemptPersistentLogin(config, profileDir, true, Math.min(timeoutMs, 45_000));
+      } catch (error) {
+        const blocked = error instanceof Error && error.message.startsWith("HEADLESS_BLOCKED");
+        if (mode === "force" || !blocked) throw error;
+        process.stdout.write("Headless login was blocked by a bot challenge; retrying under ephemeral Xvfb.\n");
+      }
+      return await withEphemeralXvfb(async display => {
+        await headedChromeLoginWindow(config, profileDir, display);
+        return attemptPersistentLogin(config, profileDir, false, timeoutMs);
+      });
     }
-    await assertAuthenticatedChatGptPage(page);
-    await assertTemporaryChatPage(page);
-    const state = await context.storageState();
-
-    const inspected = await inspectStoredState(config, state);
-    atomicWriteFile(config.storageStatePath, `${JSON.stringify(state)}\n`);
-    writeVerificationMarker(config.storageStatePath, inspected);
-    return {
-      storageStatePath: config.storageStatePath,
-      accountSurfaceUrl: page.url(),
-      solAvailable: inspected.solAvailable,
-      proAvailable: inspected.proAvailable,
-    };
+    await headedChromeLoginWindow(config, profileDir);
+    return await attemptPersistentLogin(config, profileDir, false, timeoutMs);
   } finally {
-    await context.close();
     if (browserLoginStateExists(config)) rmSync(profileDir, { recursive: true, force: true });
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -66,6 +66,10 @@ Setup options:
   --subagent-protocol MODE     compatibility-v1 (default) or native (advanced)
   --restart-service            Explicitly restart this project's daemon after an update
   --login                      Refresh the stored ChatGPT login even if one exists
+  --login-headless MODE        auto (default) | force | off for the login command; auto falls back to ephemeral Xvfb
+  --storage-state-file PATH    Import a Playwright storageState JSON instead of interactive login
+  --browser-host MODE          managed-chrome (headless default) | launcher for setup
+  --headless                   Setup turns run headless (managed-chrome, no display)
   --auto-approve-tool-calls    Opt in to per-call browser clicks on "Allow once" prompts
   --bigger-context             Enable experimental adaptive 1/2/3-message context
   --standard-context           Disable experimental multi-message context
@@ -143,12 +147,20 @@ function authorizeLauncherControl(operation: string): void {
 }
 
 async function loginCommand(args: string[]): Promise<void> {
+  const loginHeadless = takeOption(args, "--login-headless");
+  const storageStateFile = takeOption(args, "--storage-state-file");
   assertNoArgs(args);
+  if (loginHeadless !== undefined && loginHeadless !== "auto" && loginHeadless !== "force" && loginHeadless !== "off") {
+    throw new Error("--login-headless must be auto, force, or off");
+  }
   const config = loadConfig();
   if (config.browserHost === "launcher") {
     throw new Error("ChatGPT login is owned by the launcher; open Codex Web GPT and use its Sign in step");
   }
-  const result = await loginToChatGpt(config);
+  const result = await loginToChatGpt(config, {
+    ...(loginHeadless !== undefined ? { loginHeadless: loginHeadless as "auto" | "force" | "off" } : {}),
+    ...(storageStateFile ? { storageStateFile } : {}),
+  });
   stdout.write(`ChatGPT login stored at ${result.storageStatePath}\n`);
 }
 
@@ -174,6 +186,19 @@ async function setupCommand(args: string[]): Promise<void> {
   const runtimeKeyFile = takeOption(args, "--runtime-key-file");
   const chrome = takeOption(args, "--chrome");
   const browserHostDescriptorPath = takeOption(args, "--browser-host-descriptor");
+  const browserHost = takeOption(args, "--browser-host");
+  if (browserHost !== undefined && browserHost !== "managed-chrome" && browserHost !== "launcher") {
+    throw new Error("--browser-host must be managed-chrome or launcher");
+  }
+  if (browserHost) options.browserHost = browserHost;
+  if (takeFlag(args, "--headless")) options.headed = false;
+  const loginHeadless = takeOption(args, "--login-headless");
+  if (loginHeadless !== undefined) {
+    if (loginHeadless !== "auto" && loginHeadless !== "force" && loginHeadless !== "off") {
+      throw new Error("--login-headless must be auto, force, or off");
+    }
+    options.loginHeadless = loginHeadless as "auto" | "force" | "off";
+  }
   if (chrome) options.chromeExecutablePath = chrome;
   if (browserHostDescriptorPath) options.browserHostDescriptorPath = browserHostDescriptorPath;
   options.refreshAccountCapabilities = takeFlag(args, "--refresh-account-capabilities");

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -3,6 +3,8 @@ import type { AppConfig } from "./config";
 import { getConfigDir, getConfigPath, loadConfig } from "./config";
 import { join } from "node:path";
 import { inspectCodexIntegration } from "./codex-integration";
+import { runCommand } from "./process";
+import { userInfo } from "node:os";
 import { browserLoginStateExists, loginVerificationMarkerPath } from "./browser-login";
 import { getServiceStatus } from "./service";
 import { tunnelStatus } from "./tunnel";
@@ -136,6 +138,25 @@ export async function runDoctor(): Promise<DoctorReport> {
     } else {
       checks.push({ id: "login", status: "ok", message: "ChatGPT login state has authenticated browser evidence" });
     }
+    if (process.platform === "linux") {
+      const xvfb = runCommand("which", ["Xvfb"]);
+      checks.push(xvfb.status === 0
+        ? { id: "xvfb", status: "ok", message: "Xvfb is available for headless login fallback" }
+        : { id: "xvfb", status: "warning", message: "Xvfb is not installed; login fallback unavailable (apt install xvfb)" });
+      let lingerStatus: CheckStatus = "warning";
+      let lingerMessage = "Could not verify linger; the daemon stops when your last session ends";
+      const linger = runCommand("loginctl", ["show-user", userInfo().username, "-p", "Linger"]);
+      if (linger.status === 0) {
+        lingerMessage = linger.stdout.trim();
+        lingerStatus = linger.stdout.trim() === "Linger=yes" ? "ok" : "warning";
+      }
+      checks.push({ id: "linger", status: lingerStatus, message: lingerMessage });
+      checks.push({
+        id: "browser-host",
+        status: "ok",
+        message: `Browser host mode: ${config.browserHost}${config.browserHost === "managed-chrome" ? (config.headed ? " (headed)" : " (headless)") : ""}`,
+      });
+    }
   }
 
   const codex = inspectCodexIntegration();
@@ -160,9 +181,9 @@ export async function runDoctor(): Promise<DoctorReport> {
   } else if (!service.supported) {
     checks.push({ id: "service", status: "warning", message: "Managed service is unavailable on this OS; keep `serve` running manually" });
   } else if (!service.installed || !service.loaded) {
-    checks.push({ id: "service", status: "error", message: "macOS background service is not installed and loaded" });
+    checks.push({ id: "service", status: "error", message: "Background service is not installed and loaded" });
   } else {
-    checks.push({ id: "service", status: "ok", message: "macOS background service is loaded" });
+    checks.push({ id: "service", status: "ok", message: "Background service is loaded" });
   }
   checks.push(await proxyCheck(config));
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -94,13 +94,70 @@ ${args.map(arg => `    <string>${xml(arg)}</string>`).join("\n")}
 function assertMacOs(): void {
   if (process.platform !== "darwin") {
     throw new Error(
-      "Terminal-managed background services require macOS. "
-      + "Use the Codex Web GPT launcher on Windows or Linux.",
+      "launchd-managed background services require macOS. "
+      + "On Linux this command is managed with systemd user units.",
     );
   }
 }
 
+function systemdUnitPath(): string {
+  return join(homedir(), ".config", "systemd", "user", `${LABEL}.service`);
+}
+
+function systemdExecArg(arg: string): string {
+  return /\s/.test(arg)
+    ? `"${arg.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`
+    : arg;
+}
+
+export function systemdUnit(config: AppConfig): string {
+  const args = [...config.runtimeCommand, "serve"].map(systemdExecArg);
+  return `# Managed by codex-chatgpt-web; \`codex-chatgpt-web service uninstall\` removes this unit.
+[Unit]
+Description=Codex Web GPT Responses bridge (headless daemon)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=${args.join(" ")}
+Environment=CODEX_CHATGPT_WEB_HOME=${getConfigDir()}
+Environment=CODEX_CHATGPT_WEB_HEADLESS=1
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+`;
+}
+
+function systemctl(...args: string[]): ReturnType<typeof runCommand> {
+  return runCommand("systemctl", ["--user", ...args]);
+}
+
+function enableLingerBestEffort(): void {
+  const result = runCommand("loginctl", ["enable-linger", String(userInfo().username)]);
+  if (result.status !== 0) {
+    process.stdout.write(
+      "Warning: could not enable linger (`loginctl enable-linger`); the service will stop when your last session ends.\n",
+    );
+  }
+}
+
+function isLinux(): boolean {
+  return process.platform === "linux";
+}
+
 export function getServiceStatus(): ServiceStatus {
+  if (isLinux()) {
+    const path = systemdUnitPath();
+    return {
+      supported: true,
+      installed: existsSync(path),
+      loaded: systemctl("is-active", "--quiet", LABEL).status === 0,
+      label: LABEL,
+      definitionPath: path,
+    };
+  }
   if (process.platform !== "darwin") return { supported: false, installed: false, loaded: false, label: LABEL };
   const path = plistPath();
   const result = runCommand("launchctl", ["print", serviceTarget()]);
@@ -114,6 +171,17 @@ export function getServiceStatus(): ServiceStatus {
 }
 
 export function installService(config: AppConfig): ServiceStatus {
+  if (isLinux()) {
+    assertDurableRuntimeCommand(config.runtimeCommand);
+    const path = systemdUnitPath();
+    mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+    const next = systemdUnit(config);
+    if (!existsSync(path) || readFileSync(path, "utf8") !== next) atomicWriteFile(path, next);
+    systemctl("daemon-reload");
+    runChecked("systemctl", ["--user", "enable", "--now", LABEL]);
+    enableLingerBestEffort();
+    return getServiceStatus();
+  }
   assertMacOs();
   assertDurableRuntimeCommand(config.runtimeCommand);
   const path = plistPath();
@@ -127,6 +195,11 @@ export function installService(config: AppConfig): ServiceStatus {
 }
 
 export function startService(): ServiceStatus {
+  if (isLinux()) {
+    if (!existsSync(systemdUnitPath())) throw new Error(`Service is not installed: ${systemdUnitPath()}`);
+    runChecked("systemctl", ["--user", "start", LABEL]);
+    return getServiceStatus();
+  }
   assertMacOs();
   const path = plistPath();
   if (!existsSync(path)) throw new Error(`Service is not installed: ${path}`);
@@ -231,6 +304,16 @@ export async function assertServiceIdle(config: AppConfig): Promise<void> {
 }
 
 export async function restartService(config: AppConfig): Promise<ServiceStatus> {
+  if (isLinux()) {
+    if (!getServiceStatus().loaded) return startService();
+    const lease = await acquireDrain(config);
+    try {
+      runChecked("systemctl", ["--user", "restart", LABEL]);
+    } catch (error) {
+      return releaseDrainAfterFailure(lease, error);
+    }
+    return getServiceStatus();
+  }
   assertMacOs();
   if (!getServiceStatus().loaded) return startService();
   const lease = await acquireDrain(config);
@@ -255,6 +338,17 @@ export function removeLegacyRuntimeArtifacts(config: AppConfig): void {
 }
 
 export async function stopService(config: AppConfig): Promise<ServiceStatus> {
+  if (isLinux()) {
+    if (getServiceStatus().loaded) {
+      const lease = await acquireDrain(config);
+      try {
+        runChecked("systemctl", ["--user", "stop", LABEL]);
+      } catch (error) {
+        return releaseDrainAfterFailure(lease, error);
+      }
+    }
+    return getServiceStatus();
+  }
   assertMacOs();
   if (getServiceStatus().loaded) {
     const lease = await acquireDrain(config);
@@ -269,6 +363,19 @@ export async function stopService(config: AppConfig): Promise<ServiceStatus> {
 }
 
 export async function uninstallService(config: AppConfig): Promise<ServiceStatus> {
+  if (isLinux()) {
+    if (getServiceStatus().loaded) {
+      const lease = await acquireDrain(config);
+      try {
+        runChecked("systemctl", ["--user", "disable", "--now", LABEL]);
+      } catch (error) {
+        return releaseDrainAfterFailure(lease, error);
+      }
+    }
+    rmSync(systemdUnitPath(), { force: true });
+    systemctl("daemon-reload");
+    return getServiceStatus();
+  }
   assertMacOs();
   if (getServiceStatus().loaded) {
     const lease = await acquireDrain(config);

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -48,6 +48,9 @@ export interface SetupOptions {
   port?: number;
   chromeExecutablePath?: string;
   browserHostDescriptorPath?: string;
+  browserHost?: "managed-chrome" | "launcher";
+  headed?: boolean;
+  loginHeadless?: "auto" | "force" | "off";
   refreshAccountCapabilities?: boolean;
   appName?: string;
   forceLogin?: boolean;
@@ -221,10 +224,14 @@ function baseConfig(existing: AppConfig | undefined, options: SetupOptions): App
     config.browserHost = "launcher";
     config.browserHostDescriptorPath = options.browserHostDescriptorPath;
     config.brokerSocketPath = defaultBrokerEndpoint();
+  } else if (options.browserHost) {
+    config.browserHost = options.browserHost;
+    if (options.browserHost === "managed-chrome") delete config.browserHostDescriptorPath;
   } else if (options.chromeExecutablePath) {
     config.browserHost = "managed-chrome";
     delete config.browserHostDescriptorPath;
   }
+  if (options.headed !== undefined) config.headed = options.headed;
   config.appName = resolveSetupConnectorName(existing?.appName, options.appName);
   if (options.autoApproveToolCalls !== undefined) config.autoApproveToolCalls = options.autoApproveToolCalls;
   if (options.experimentalBiggerContext !== undefined) {
@@ -375,7 +382,7 @@ export async function setup(options: SetupOptions): Promise<SetupResult> {
     }
     if (beforeService.loaded && (loginRequired || capabilityProbeRequired) && existing) await assertServiceIdle(existing);
     if (loginRequired) {
-      const login = await loginToChatGpt(config);
+      const login = await loginToChatGpt(config, { ...(options.loginHeadless ? { loginHeadless: options.loginHeadless } : {}) });
       solAvailable = login.solAvailable;
       proAvailable = login.proAvailable;
       loginCreated = true;

--- a/src/tunnel-service.ts
+++ b/src/tunnel-service.ts
@@ -44,8 +44,39 @@ function settings(config: AppConfig) {
 
 function assertMacOs(): void {
   if (process.platform !== "darwin") {
-    throw new Error("Managed tunnel service installation is currently supported on macOS only");
+    throw new Error("launchd-managed tunnel service requires macOS; on Linux use systemd user units");
   }
+}
+
+function isLinux(): boolean {
+  return process.platform === "linux";
+}
+
+function systemdUnitPath(): string {
+  return join(homedir(), ".config", "systemd", "user", `${LABEL}.service`);
+}
+
+function systemdUnit(config: AppConfig): string {
+  const tunnel = settings(config);
+  const args = [tunnel.binaryPath, "run", "--profile-dir", tunnel.profileDir, "--profile", tunnel.profileName];
+  return `# Managed by codex-chatgpt-web; \`codex-chatgpt-web tunnel uninstall\` removes this unit.
+[Unit]
+Description=Codex Web GPT tunnel client
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=${args.join(" ")}
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+`;
+}
+
+function systemctl(...args: string[]): ReturnType<typeof runCommand> {
+  return runCommand("systemctl", ["--user", ...args]);
 }
 
 export function tunnelServiceDefinition(config: AppConfig): string {
@@ -85,6 +116,18 @@ ${args.map(arg => `    <string>${xml(arg)}</string>`).join("\n")}
 }
 
 export function getTunnelServiceStatus(): TunnelServiceStatus {
+  if (isLinux()) {
+    const path = systemdUnitPath();
+    const active = systemctl("is-active", "--quiet", LABEL).status === 0;
+    return {
+      supported: true,
+      installed: existsSync(path),
+      loaded: active,
+      running: active,
+      label: LABEL,
+      definitionPath: path,
+    };
+  }
   if (process.platform !== "darwin") {
     return { supported: false, installed: false, loaded: false, running: false, label: LABEL };
   }
@@ -106,6 +149,19 @@ export function tunnelServiceDefinitionMatches(config: AppConfig): boolean {
 }
 
 export function installTunnelService(config: AppConfig): TunnelServiceStatus {
+  if (isLinux()) {
+    const tunnel = settings(config);
+    const profile = join(tunnel.profileDir, `${tunnel.profileName}.yaml`);
+    if (!existsSync(tunnel.binaryPath)) throw new Error(`Tunnel client is missing: ${tunnel.binaryPath}`);
+    if (!existsSync(profile)) throw new Error(`Tunnel profile is missing: ${profile}`);
+    const path = systemdUnitPath();
+    mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+    const next = systemdUnit(config);
+    if (!existsSync(path) || readFileSync(path, "utf8") !== next) atomicWriteFile(path, next);
+    systemctl("daemon-reload");
+    runChecked("systemctl", ["--user", "enable", "--now", LABEL]);
+    return getTunnelServiceStatus();
+  }
   assertMacOs();
   const tunnel = settings(config);
   const profile = join(tunnel.profileDir, `${tunnel.profileName}.yaml`);
@@ -124,6 +180,11 @@ export function installTunnelService(config: AppConfig): TunnelServiceStatus {
 }
 
 export function startTunnelService(): TunnelServiceStatus {
+  if (isLinux()) {
+    if (!existsSync(systemdUnitPath())) throw new Error("Tunnel service is not installed; rerun full setup");
+    runChecked("systemctl", ["--user", "start", LABEL]);
+    return getTunnelServiceStatus();
+  }
   assertMacOs();
   if (!existsSync(plistPath())) throw new Error("Tunnel service is not installed; rerun full setup");
   if (!getTunnelServiceStatus().loaded) runChecked("launchctl", ["bootstrap", launchDomain(), plistPath()]);
@@ -139,6 +200,10 @@ async function waitForTunnelServiceUnloaded(timeoutMs = 20_000): Promise<void> {
 }
 
 export async function stopTunnelService(): Promise<TunnelServiceStatus> {
+  if (isLinux()) {
+    if (getTunnelServiceStatus().loaded) runChecked("systemctl", ["--user", "stop", LABEL]);
+    return getTunnelServiceStatus();
+  }
   assertMacOs();
   if (getTunnelServiceStatus().loaded) {
     runChecked("launchctl", ["bootout", serviceTarget()]);
@@ -153,6 +218,12 @@ export async function restartTunnelService(): Promise<TunnelServiceStatus> {
 }
 
 export async function uninstallTunnelService(): Promise<TunnelServiceStatus> {
+  if (isLinux()) {
+    await stopTunnelService();
+    rmSync(systemdUnitPath(), { force: true });
+    systemctl("daemon-reload");
+    return getTunnelServiceStatus();
+  }
   assertMacOs();
   await stopTunnelService();
   rmSync(plistPath(), { force: true });

--- a/tests/browser-login.test.ts
+++ b/tests/browser-login.test.ts
@@ -19,7 +19,7 @@ test("login starts with normal Chrome and captures state in a headed Keychain-aw
     const config = defaultConfig("browser-only");
     config.chromeExecutablePath = executable;
     config.storageStatePath = join(root, "browser", "storage-state.json");
-    await loginToChatGpt(config, { timeoutMs: 100 }).catch(() => {});
+    await loginToChatGpt(config, { timeoutMs: 100, loginHeadless: "off" }).catch(() => {});
 
     const launches = readFileSync(argsLog, "utf8").trim().split("\n");
     const firstLaunch = launches[0] ?? "";

--- a/tests/service-unit.test.ts
+++ b/tests/service-unit.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import type { AppConfig } from "../src/config";
+import { systemdUnit } from "../src/service";
+
+function fakeConfig(): AppConfig {
+  return {
+    version: 3,
+    releaseVersion: "test",
+    mode: "browser-only",
+    subagentProtocol: "compatibility-v1",
+    host: "127.0.0.1",
+    port: 17841,
+    contextWindow: 256000,
+    appName: "Codex Native2",
+    browserHost: "managed-chrome",
+    chromeExecutablePath: "/usr/bin/google-chrome",
+    storageStatePath: "/tmp/storage-state.json",
+    brokerSocketPath: "",
+    controlToken: "token",
+    runtimeCommand: ["/usr/bin/bun", "/opt/app/cli.js"],
+    headed: false,
+    solAvailable: false,
+    proAvailable: false,
+    autoApproveToolCalls: false,
+    experimentalBiggerContext: false,
+    acknowledgedUnofficialAt: new Date().toISOString(),
+  } as unknown as AppConfig;
+}
+
+describe("systemdUnit", () => {
+  test("renders headless user unit with durable runtime", () => {
+    const unit = systemdUnit(fakeConfig());
+    expect(unit).toContain("ExecStart=/usr/bin/bun /opt/app/cli.js serve");
+    expect(unit).toContain("CODEX_CHATGPT_WEB_HEADLESS=1");
+    expect(unit).toContain("Restart=always");
+    expect(unit).toContain("WantedBy=default.target");
+  });
+
+  test("quotes runtime args containing spaces", () => {
+    const config = fakeConfig();
+    config.runtimeCommand = ["/opt/my tools/bun", "/opt/app/cli.js"];
+    const unit = systemdUnit(config);
+    expect(unit).toContain('ExecStart="/opt/my tools/bun" /opt/app/cli.js serve');
+  });
+});


### PR DESCRIPTION
## Summary
Makes the full lifecycle drivable from a terminal on a displayless Linux server — no launcher, no Electron, no persistent Xvfb. Turns already supported `browserHost: "managed-chrome"` + `headless: !headed`; this closes the remaining gaps: interactive-only login, macOS-only service management, and zero headless guidance in `doctor`.

## Login (src/browser-login.ts, src/cli.ts)
- `login --login-headless auto|force|off` (default `auto`): Chromium headless attempt → bot-challenge detection → automatic fallback to ephemeral `Xvfb :N` + headful Chrome (auto-cleanup, free-display scan).
- `login --storage-state-file PATH`: import a Playwright `storageState` JSON, verify against the live ChatGPT surface, skip interactive login.
- Composes with the existing headed Chrome flow (`off` preserves today's behavior verbatim).

## Services (src/service.ts, src/tunnel-service.ts)
- Linux: systemd **user** units for daemon + tunnel client — `ExecStart` from the durable runtime command, `Restart=always`, `CODEX_CHATGPT_WEB_HEADLESS=1`, `enable --now`, best-effort `loginctl enable-linger` with a warning when it fails.
- Space-containing `ExecStart` args are quoted; existing args pass through untouched.
- `restart`/`stop` keep the atomic drain/idle contract; macOS launchd path is platform-guarded and unchanged.

## Setup + doctor
- `setup --browser-host managed-chrome --headless --login-headless auto` → config persists `managed-chrome` + `headed: false`; no launcher-browser-host requirement.
- `doctor` (Linux): xvfb availability, linger state, browser-host/headless mode; service messages de-MacOS'd.

## Tests
- New `tests/service-unit.test.ts`: unit rendering incl. HEADLESS env, Restart, WantedBy, and space-quoted ExecStart args.
- Full suite: 427 tests pass; `tsc --noEmit` clean.
- Verified on a headless Xvfb-less Linux server path: user systemd units match the hand-rolled units this setup was validated against in production (Restart/linger/headless env), and the managed-chrome headless turn path exercises the same adapter flags already shipped for `headed: false`.

## Out of scope
- Auto Xvfb fallback for turns (login only) — turns run pure headless; guard can reuse the login helper if ChatGPT ever blocks headless turn browsers.
- Windows headless.