### PR TITLE
fix: carry MCP turn progress into the launcher browser helper process

### DIFF
--- a/launcher/electron/browser-host.cjs
+++ b/launcher/electron/browser-host.cjs
@@ -1,7 +1,7 @@
 const fs = require("node:fs");
 const path = require("node:path");
 const { randomBytes } = require("node:crypto");
-const { WebContentsView, shell } = require("electron");
+const { WebContentsView, powerMonitor, powerSaveBlocker, shell } = require("electron");
 const { writePrivateFileAtomic } = require("./atomic-file.cjs");
 const {
   runBrowserHelperOperation,
@@ -9,6 +9,11 @@ const {
 } = require("./browser-helper-verifier.cjs");
 const { validateConnectorName } = require("./connector-identity.cjs");
 const { processRunning } = require("./process-tree.cjs");
+const {
+  refreshTurnLeasesAfterSuspension,
+  shouldBlockSleepForTurns,
+  sweepGapIndicatesSuspension,
+} = require("./turn-suspension.cjs");
 const {
   browserViewVisible,
   constrainBrowserBounds,
@@ -240,8 +245,16 @@ class BrowserHost {
     this.authView = null;
     this.authNavigationError = null;
     this.homeNavigationTimeout = null;
+    this.lastTurnSweepAt = Date.now();
+    this.powerSaveBlockerId = null;
     this.turnLeaseSweep = setInterval(() => this.reapExpiredTurnTabs(), TURN_HEARTBEAT_SWEEP_MS);
     this.turnLeaseSweep.unref?.();
+    this.resumeListener = () => this.refreshTurnLeases("system_resume");
+    if (powerMonitor && typeof powerMonitor.on === "function") {
+      powerMonitor.on("resume", this.resumeListener);
+    } else {
+      this.resumeListener = null;
+    }
     this.boundsReady = false;
     this.bounds = { x: 0, y: 0, width: 1, height: 1 };
     this.state = {
@@ -362,6 +375,7 @@ class BrowserHost {
       lastHeartbeatAt: Date.now(),
     };
     this.turnTabs.set(id, tab);
+    this.syncPowerSaveBlocker();
     this.window.contentView.addChildView(view);
     this.presentTurnView(tab, false);
     view.webContents.setZoomFactor(this.state.zoomFactor);
@@ -479,6 +493,7 @@ class BrowserHost {
         (error) => {
           tab.status = "error";
           tab.message = `Browser ownership failed: ${error instanceof Error ? error.message : String(error)}`;
+          this.syncPowerSaveBlocker();
           this.publishState?.(this.snapshot());
         },
       );
@@ -837,7 +852,42 @@ class BrowserHost {
     return this.snapshot();
   }
 
+  refreshTurnLeases(reason, now = Date.now()) {
+    const refreshed = refreshTurnLeasesAfterSuspension(
+      [...this.turnTabs.values()],
+      now,
+      TURN_TAB_BOOTSTRAP_TIMEOUT_MS,
+    );
+    if (refreshed.length > 0) {
+      this.logger.warn("browser.turn_leases_refreshed_after_suspension", { reason, traceIds: refreshed });
+    }
+  }
+
+  syncPowerSaveBlocker() {
+    // Under plain Node (the launcher test harness) require("electron") exposes no APIs; the
+    // blocker is an Electron-only concern and its absence must not break lease bookkeeping.
+    if (!powerSaveBlocker || typeof powerSaveBlocker.start !== "function") return;
+    const wanted = shouldBlockSleepForTurns([...this.turnTabs.values()]);
+    const active = this.powerSaveBlockerId !== null && powerSaveBlocker.isStarted(this.powerSaveBlockerId);
+    if (wanted && !active) {
+      this.powerSaveBlockerId = powerSaveBlocker.start("prevent-app-suspension");
+      this.logger.info("browser.sleep_blocked_for_turns", { blockerId: this.powerSaveBlockerId });
+    } else if (!wanted && active) {
+      powerSaveBlocker.stop(this.powerSaveBlockerId);
+      this.logger.info("browser.sleep_block_released", { blockerId: this.powerSaveBlockerId });
+      this.powerSaveBlockerId = null;
+    }
+  }
+
   reapExpiredTurnTabs(now = Date.now()) {
+    const lastSweepAt = this.lastTurnSweepAt;
+    this.lastTurnSweepAt = now;
+    if (sweepGapIndicatesSuspension(lastSweepAt, now, TURN_HEARTBEAT_SWEEP_MS)) {
+      // The launcher itself was frozen, so missing heartbeats are evidence of the sleep, not of a
+      // dead helper. Reaping here is what turned every system sleep into a lost turn.
+      this.refreshTurnLeases("sweep_gap", now);
+      return;
+    }
     for (const tab of [...this.turnTabs.values()]) {
       if (tab.status === "ready") {
         if (now - (tab.lastHeartbeatAt ?? 0) < RETAINED_TURN_TAB_TTL_MS) continue;
@@ -968,6 +1018,7 @@ class BrowserHost {
   removeTurnTab(tab, abortRunning) {
     if (!this.turnTabs.has(tab.id)) return;
     this.turnTabs.delete(tab.id);
+    this.syncPowerSaveBlocker();
     if (abortRunning && tab.status === "running") {
       this.closedTurnOwners.set(tab.traceId, tab.helperPid);
       tab.status = "aborted";
@@ -1374,6 +1425,7 @@ class BrowserHost {
     }
     const cancelledByUser = this.userCancelledTurnOwners.get(traceId) === helperPid;
     tab.status = status === "completed" ? "ready" : status === "aborted" ? "aborted" : "error";
+    this.syncPowerSaveBlocker();
     tab.message = status === "completed" ? "Task completed" : message || `ChatGPT turn ${status}`;
     tab.loading = false;
     if (!tab.view.webContents.isDestroyed()) tab.view.webContents.setBackgroundThrottling(true);
@@ -1779,6 +1831,14 @@ class BrowserHost {
     this.closeAuthView(this.authView, true);
     this.clearHomeNavigationTimeout();
     if (this.turnLeaseSweep) clearInterval(this.turnLeaseSweep);
+    if (this.resumeListener && powerMonitor && typeof powerMonitor.removeListener === "function") {
+      powerMonitor.removeListener("resume", this.resumeListener);
+      this.resumeListener = null;
+    }
+    if (this.powerSaveBlockerId !== null && powerSaveBlocker && typeof powerSaveBlocker.stop === "function") {
+      powerSaveBlocker.stop(this.powerSaveBlockerId);
+      this.powerSaveBlockerId = null;
+    }
     for (const tab of this.turnTabs.values()) {
       try { this.window.contentView.removeChildView(tab.view); } catch {}
       if (!tab.view.webContents.isDestroyed()) tab.view.webContents.close();

--- a/launcher/electron/turn-suspension.cjs
+++ b/launcher/electron/turn-suspension.cjs
@@ -1,0 +1,52 @@
+"use strict";
+
+/**
+ * System sleep freezes both sides of the turn-lease protocol at once: the helper cannot send
+ * heartbeats and the launcher cannot observe them. On wake every stalled timer fires together, and
+ * without these guards the first sweep after a sleep reaped live turns as orphans — pmset logged
+ * 'Idle Sleep' 41 seconds into two running turns, and both died on the next DarkWake to the second.
+ */
+
+/**
+ * The turn-lease sweep runs on a short fixed interval for the whole life of the launcher. A gap
+ * between consecutive sweeps far larger than that interval means the process was suspended, not
+ * busy: nothing the launcher does blocks its event loop for multiples of the sweep interval.
+ */
+function sweepGapIndicatesSuspension(lastSweepAt, now, sweepIntervalMs) {
+  if (typeof lastSweepAt !== "number" || !Number.isFinite(lastSweepAt)) return false;
+  return now - lastSweepAt >= sweepIntervalMs * 6;
+}
+
+/**
+ * Re-baseline every lease that depends on time passing. A running tab's helper gets a full
+ * heartbeat window to prove it survived the sleep; a tab still bootstrapping gets its bootstrap
+ * budget back. Returns the refreshed trace ids so the caller can log the decision.
+ */
+function refreshTurnLeasesAfterSuspension(tabs, now, bootstrapTimeoutMs) {
+  const refreshed = [];
+  for (const tab of tabs) {
+    if (tab.status !== "running") continue;
+    tab.lastHeartbeatAt = now;
+    if (tab.bootstrapReady !== true) tab.bootstrapDeadlineAt = now + bootstrapTimeoutMs;
+    refreshed.push(tab.traceId);
+  }
+  return refreshed;
+}
+
+/**
+ * A power-save blocker belongs up exactly while at least one browser turn is running: an idle Mac
+ * otherwise sleeps mid-turn, and no amount of wake-side tolerance recovers the minutes ChatGPT
+ * spent frozen.
+ */
+function shouldBlockSleepForTurns(tabs) {
+  for (const tab of tabs) {
+    if (tab.status === "running") return true;
+  }
+  return false;
+}
+
+module.exports = {
+  sweepGapIndicatesSuspension,
+  refreshTurnLeasesAfterSuspension,
+  shouldBlockSleepForTurns,
+};

--- a/launcher/tests/packaging-contract.test.cjs
+++ b/launcher/tests/packaging-contract.test.cjs
@@ -136,6 +136,11 @@ test("CI packages and smoke-launches on macOS, Windows, and Linux", () => {
 test("Linux AppImage fallback uses one owned extraction and removes it on exit", {
   skip: process.platform !== "linux" ? "AppImage process identity is Linux-specific" : false,
 }, () => {
+  // node:test honours the `skip` option above and reports this as skipped. Bun's shim ignores that
+  // option and runs the body anyway, and implements neither t.skip(), so the test read /proc on
+  // macOS and failed for everyone running `bun test` locally. Returning early is the one form both
+  // runners agree on.
+  if (process.platform !== "linux") return;
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-web-gpt-appimage-runner-"));
   const runtime = path.join(root, "runtime");
   const appImage = path.join(root, "Codex Web GPT.AppImage");

--- a/launcher/tests/turn-suspension.test.cjs
+++ b/launcher/tests/turn-suspension.test.cjs
@@ -1,0 +1,92 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  refreshTurnLeasesAfterSuspension,
+  shouldBlockSleepForTurns,
+  sweepGapIndicatesSuspension,
+} = require("../electron/turn-suspension.cjs");
+const { BrowserHost } = require("../electron/browser-host.cjs");
+
+// System sleep froze the launcher for 15 minutes twice in a row; on each wake the first sweep saw
+// heartbeats that were minutes stale and reaped two live turns as orphans. pmset matched both waves
+// to the second. These tests pin the wake-side tolerance and the sleep-side prevention.
+
+test("a sweep gap of multiples of the interval is recognised as a suspension", () => {
+  assert.equal(sweepGapIndicatesSuspension(1_000, 1_000 + 5_000 * 6, 5_000), true);
+  assert.equal(sweepGapIndicatesSuspension(1_000, 1_000 + 15 * 60_000, 5_000), true);
+});
+
+test("ordinary sweep cadence and busy-loop jitter are not a suspension", () => {
+  assert.equal(sweepGapIndicatesSuspension(1_000, 6_000, 5_000), false);
+  assert.equal(sweepGapIndicatesSuspension(1_000, 1_000 + 5_000 * 6 - 1, 5_000), false);
+  assert.equal(sweepGapIndicatesSuspension(undefined, 99_000, 5_000), false);
+});
+
+test("a suspension re-baselines running leases and restores an unfinished bootstrap budget", () => {
+  const running = { status: "running", traceId: "aaa", bootstrapReady: true, lastHeartbeatAt: 5 };
+  const booting = {
+    status: "running", traceId: "bbb", bootstrapReady: false,
+    lastHeartbeatAt: 5, bootstrapDeadlineAt: 10,
+  };
+  const retained = { status: "ready", traceId: "ccc", lastHeartbeatAt: 5 };
+
+  const refreshed = refreshTurnLeasesAfterSuspension([running, booting, retained], 1_000_000, 120_000);
+
+  assert.deepEqual(refreshed, ["aaa", "bbb"]);
+  assert.equal(running.lastHeartbeatAt, 1_000_000);
+  assert.equal(booting.bootstrapDeadlineAt, 1_120_000);
+  // A retained tab holds no live helper; its idle TTL keeps counting through a sleep.
+  assert.equal(retained.lastHeartbeatAt, 5);
+});
+
+test("sleep is blocked exactly while a turn is running", () => {
+  assert.equal(shouldBlockSleepForTurns([]), false);
+  assert.equal(shouldBlockSleepForTurns([{ status: "ready" }, { status: "error" }]), false);
+  assert.equal(shouldBlockSleepForTurns([{ status: "ready" }, { status: "running" }]), true);
+});
+
+test("the first sweep after a suspension refreshes stale leases instead of reaping them", () => {
+  const reaped = [];
+  const warnings = [];
+  const tab = {
+    id: "t1", traceId: "trace-1", helperPid: 42, status: "running",
+    bootstrapReady: true, lastHeartbeatAt: 1_000,
+  };
+  const host = {
+    lastTurnSweepAt: 1_000,
+    turnTabs: new Map([["t1", tab]]),
+    logger: { warn: (event, detail) => warnings.push({ event, detail }), info: () => {} },
+    removeTurnTab: t => reaped.push(t.traceId),
+    refreshTurnLeases: BrowserHost.prototype.refreshTurnLeases,
+  };
+
+  // Fifteen minutes pass without a sweep — the launcher was asleep, and so was the helper.
+  BrowserHost.prototype.reapExpiredTurnTabs.call(host, 1_000 + 15 * 60_000);
+
+  assert.deepEqual(reaped, []);
+  assert.equal(tab.lastHeartbeatAt, 1_000 + 15 * 60_000);
+  assert.equal(warnings[0].event, "browser.turn_leases_refreshed_after_suspension");
+
+  // The next sweep runs on cadence; the lease is fresh, so the turn lives on.
+  BrowserHost.prototype.reapExpiredTurnTabs.call(host, 1_000 + 15 * 60_000 + 5_000);
+  assert.deepEqual(reaped, []);
+});
+
+test("a helper that is genuinely gone is still reaped on the ordinary cadence", () => {
+  const reaped = [];
+  const tab = {
+    id: "t1", traceId: "trace-1", helperPid: 42, status: "running",
+    bootstrapReady: true, lastHeartbeatAt: 1_000,
+  };
+  const host = {
+    lastTurnSweepAt: 56_000,
+    turnTabs: new Map([["t1", tab]]),
+    logger: { warn: () => {}, info: () => {} },
+    removeTurnTab: t => reaped.push(t.traceId),
+    refreshTurnLeases: BrowserHost.prototype.refreshTurnLeases,
+  };
+
+  BrowserHost.prototype.reapExpiredTurnTabs.call(host, 61_000);
+
+  assert.deepEqual(reaped, ["trace-1"]);
+});

--- a/src/adapters/chatgpt-web/browser-helper-main.ts
+++ b/src/adapters/chatgpt-web/browser-helper-main.ts
@@ -167,8 +167,10 @@ async function run(message: RunMessage): Promise<void> {
   const abortController = new AbortController();
   abortControllers.set(message.id, abortController);
   // The Codex MCP broker runs in the daemon process, so this mirror is the only way the worker can
-  // observe that a turn is still executing while its ChatGPT DOM is unavailable.
-  const progress = turnProgress.get(message.id) ?? new ChatGptMirroredTurnProgress();
+  // observe that a turn is still executing while its ChatGPT DOM is unavailable. Trace ids are
+  // derived deterministically and can repeat, so each run starts a fresh mirror rather than
+  // inheriting revisions recorded for an earlier turn that happened to share the id.
+  const progress = new ChatGptMirroredTurnProgress();
   turnProgress.set(message.id, progress);
   const promptSelection = createBrowserHelperPromptSelection();
   preparedSelections.set(message.id, promptSelection);

--- a/src/adapters/chatgpt-web/browser-helper-main.ts
+++ b/src/adapters/chatgpt-web/browser-helper-main.ts
@@ -7,6 +7,8 @@ import type { ChatGptWebCapabilities } from "./model";
 import { createProcessLineWriter } from "./process-line-writer";
 import { createBrowserHelperPromptSelection } from "./browser-helper-prompt-selection";
 import type { CompiledChatGptWebPrompt } from "./prompt";
+import { ChatGptMirroredTurnProgress } from "./turn-progress";
+import type { ChatGptExternalTurnProgressSnapshot } from "./turn-progress";
 
 interface RunMessage {
   type: "run";
@@ -60,6 +62,7 @@ type InputMessage = RunMessage
   | MaintenanceMessage
   | { type: "prepared_selected_ack"; id: string; prepared: CompiledChatGptWebPrompt }
   | { type: "send_activation_ack"; id: string }
+  | { type: "progress"; id: string; snapshot: ChatGptExternalTurnProgressSnapshot }
   | { type: "abort"; id: string }
   | { type: "shutdown" };
 
@@ -82,6 +85,7 @@ console.warn = diagnostic;
 console.error = diagnostic;
 
 const abortControllers = new Map<string, AbortController>();
+const turnProgress = new Map<string, ChatGptMirroredTurnProgress>();
 const preparedSelections = new Map<string, ReturnType<typeof createBrowserHelperPromptSelection>>();
 const sendActivationWaiters = new Map<string, {
   resolve: () => void;
@@ -162,6 +166,10 @@ async function run(message: RunMessage): Promise<void> {
   };
   const abortController = new AbortController();
   abortControllers.set(message.id, abortController);
+  // The Codex MCP broker runs in the daemon process, so this mirror is the only way the worker can
+  // observe that a turn is still executing while its ChatGPT DOM is unavailable.
+  const progress = turnProgress.get(message.id) ?? new ChatGptMirroredTurnProgress();
+  turnProgress.set(message.id, progress);
   const promptSelection = createBrowserHelperPromptSelection();
   preparedSelections.set(message.id, promptSelection);
   const prepareSelected = async () => ({ ...await promptSelection.wait(), release: () => {} });
@@ -178,6 +186,7 @@ async function run(message: RunMessage): Promise<void> {
     ...(message.turn.conversationKey ? { conversationKey: message.turn.conversationKey } : {}),
     abortSignal: abortController.signal,
     ...(message.turn.compaction ? { compaction: true } : {}),
+    externalProgress: progress,
     onHeartbeat: () => writeProtocol({ type: "event", id: message.id, event: "heartbeat" }),
     onPreparedSelected: reused => {
       if (!writeProtocol({ type: "event", id: message.id, event: "prepared_selected", reused })) {
@@ -243,6 +252,7 @@ async function run(message: RunMessage): Promise<void> {
     sendActivationWaiters.delete(message.id);
     sendWaiter?.reject(new DOMException("Browser helper turn ended before Send acknowledgement", "AbortError"));
     abortControllers.delete(message.id);
+    turnProgress.delete(message.id);
   }
 }
 
@@ -340,6 +350,20 @@ input.on("line", line => {
     }
     sendActivationWaiters.delete(message.id);
     waiter.resolve();
+  } else if (message.type === "progress") {
+    // Progress can arrive before the run frame is processed, so the mirror is created on demand
+    // rather than requiring an established turn.
+    const progress = turnProgress.get(message.id) ?? new ChatGptMirroredTurnProgress();
+    turnProgress.set(message.id, progress);
+    try {
+      progress.apply(message.snapshot);
+    } catch (error) {
+      writeProtocol({
+        type: "error",
+        id: message.id,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
   } else if (message.type === "abort") {
     abortControllers.get(message.id)?.abort();
     preparedSelections.get(message.id)?.cancel();

--- a/src/adapters/chatgpt-web/browser-helper-main.ts
+++ b/src/adapters/chatgpt-web/browser-helper-main.ts
@@ -86,9 +86,6 @@ console.error = diagnostic;
 
 const abortControllers = new Map<string, AbortController>();
 const turnProgress = new Map<string, ChatGptMirroredTurnProgress>();
-/** Bounded record of finished turns so a late progress frame is dropped instead of resurrected. */
-const retiredTurns = new Set<string>();
-const MAX_RETIRED_TURN_IDS = 256;
 const preparedSelections = new Map<string, ReturnType<typeof createBrowserHelperPromptSelection>>();
 const sendActivationWaiters = new Map<string, {
   resolve: () => void;
@@ -256,11 +253,6 @@ async function run(message: RunMessage): Promise<void> {
     sendWaiter?.reject(new DOMException("Browser helper turn ended before Send acknowledgement", "AbortError"));
     abortControllers.delete(message.id);
     turnProgress.delete(message.id);
-    if (retiredTurns.size >= MAX_RETIRED_TURN_IDS) {
-      const oldest = retiredTurns.values().next();
-      if (!oldest.done) retiredTurns.delete(oldest.value);
-    }
-    retiredTurns.add(message.id);
   }
 }
 
@@ -359,15 +351,11 @@ input.on("line", line => {
     sendActivationWaiters.delete(message.id);
     waiter.resolve();
   } else if (message.type === "progress") {
-    // A frame can still be in flight when its turn ends. Recreating a mirror for a retired id would
-    // leak an entry that nothing ever removes, so only an id that is live or not yet started is
-    // accepted; anything else is dropped as late.
-    const existing = turnProgress.get(message.id);
-    const progress = existing
-      ?? (abortControllers.has(message.id) || !retiredTurns.has(message.id)
-        ? new ChatGptMirroredTurnProgress()
-        : undefined);
-    if (!progress) return;
+    // Progress is only meaningful for a turn this helper is actually running. Creating a mirror
+    // for any unrecognised id let late, malformed, or misaddressed frames grow this map without
+    // bound, since nothing would ever remove an entry that has no turn to end it.
+    if (!abortControllers.has(message.id)) return;
+    const progress = turnProgress.get(message.id) ?? new ChatGptMirroredTurnProgress();
     turnProgress.set(message.id, progress);
     try {
       progress.apply(message.snapshot);

--- a/src/adapters/chatgpt-web/browser-helper-main.ts
+++ b/src/adapters/chatgpt-web/browser-helper-main.ts
@@ -86,6 +86,9 @@ console.error = diagnostic;
 
 const abortControllers = new Map<string, AbortController>();
 const turnProgress = new Map<string, ChatGptMirroredTurnProgress>();
+/** Bounded record of finished turns so a late progress frame is dropped instead of resurrected. */
+const retiredTurns = new Set<string>();
+const MAX_RETIRED_TURN_IDS = 256;
 const preparedSelections = new Map<string, ReturnType<typeof createBrowserHelperPromptSelection>>();
 const sendActivationWaiters = new Map<string, {
   resolve: () => void;
@@ -253,6 +256,11 @@ async function run(message: RunMessage): Promise<void> {
     sendWaiter?.reject(new DOMException("Browser helper turn ended before Send acknowledgement", "AbortError"));
     abortControllers.delete(message.id);
     turnProgress.delete(message.id);
+    if (retiredTurns.size >= MAX_RETIRED_TURN_IDS) {
+      const oldest = retiredTurns.values().next();
+      if (!oldest.done) retiredTurns.delete(oldest.value);
+    }
+    retiredTurns.add(message.id);
   }
 }
 
@@ -351,9 +359,15 @@ input.on("line", line => {
     sendActivationWaiters.delete(message.id);
     waiter.resolve();
   } else if (message.type === "progress") {
-    // Progress can arrive before the run frame is processed, so the mirror is created on demand
-    // rather than requiring an established turn.
-    const progress = turnProgress.get(message.id) ?? new ChatGptMirroredTurnProgress();
+    // A frame can still be in flight when its turn ends. Recreating a mirror for a retired id would
+    // leak an entry that nothing ever removes, so only an id that is live or not yet started is
+    // accepted; anything else is dropped as late.
+    const existing = turnProgress.get(message.id);
+    const progress = existing
+      ?? (abortControllers.has(message.id) || !retiredTurns.has(message.id)
+        ? new ChatGptMirroredTurnProgress()
+        : undefined);
+    if (!progress) return;
     turnProgress.set(message.id, progress);
     try {
       progress.apply(message.snapshot);

--- a/src/adapters/chatgpt-web/browser-helper-main.ts
+++ b/src/adapters/chatgpt-web/browser-helper-main.ts
@@ -399,12 +399,21 @@ input.on("line", line => {
       id: message.id,
       message: error instanceof Error ? error.message : String(error),
     }));
-  } else {
+  } else if (message.type === "run") {
     void run(message).catch(error => writeProtocol({
       type: "error",
       id: message.id,
       message: error instanceof Error ? error.message : String(error),
     }));
+  } else {
+    // Never treat an unrecognised frame as a run. Doing so dereferenced `message.turn` on a frame
+    // that has none, so a newer daemon speaking to an older helper destroyed the turn with an
+    // opaque TypeError instead of degrading.
+    writeProtocol({
+      type: "error",
+      id: (message as { id?: string }).id ?? "unknown",
+      message: `Browser helper received an unsupported message type: ${String((message as { type?: unknown }).type)}`,
+    });
   }
 });
 input.on("close", () => {
@@ -417,4 +426,6 @@ process.once("SIGTERM", () => {
   void requestShutdown();
 });
 
-writeProtocol({ type: "ready" });
+// Advertise optional frames so a newer daemon can tell whether this helper understands them. An
+// older helper omits the field, and the daemon then withholds those frames instead of breaking it.
+writeProtocol({ type: "ready", features: ["progress"] });

--- a/src/adapters/chatgpt-web/browser-helper-main.ts
+++ b/src/adapters/chatgpt-web/browser-helper-main.ts
@@ -372,11 +372,14 @@ input.on("line", line => {
     try {
       progress.apply(message.snapshot);
     } catch (error) {
-      writeProtocol({
-        type: "error",
-        id: message.id,
-        message: error instanceof Error ? error.message : String(error),
-      });
+      // Progress is a liveness hint, never response content or completion. Failing the turn over a
+      // malformed frame would destroy an accepted ChatGPT turn that cannot be resent, so the frame
+      // is dropped and the turn falls back to DOM-only health, which is the behaviour it had
+      // before this transport existed.
+      diagnostic(
+        `[chatgpt-web] discarded an invalid MCP progress frame for ${message.id}:`,
+        error instanceof Error ? error.message : String(error),
+      );
     }
   } else if (message.type === "abort") {
     abortControllers.get(message.id)?.abort();

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -618,6 +618,11 @@ const browserStageTimeouts = {
   promptAttachment: 60_000,
   fileAttachment: 120_000,
   send: 20_000,
+  // A Bigger Context stage posts a payload orders of magnitude larger than an ordinary prompt onto
+  // a conversation that already holds the earlier parts, and this budget covers ChatGPT accepting
+  // the submission, not just the click. The ordinary 20s send budget expired mid-acceptance and
+  // destroyed the whole turn while the browser was still working.
+  multipartStageSend: 180_000,
 } as const;
 
 export const CHATGPT_BROWSER_OBSERVATION_PROBE_TIMEOUT_MS = 5_000;
@@ -3419,7 +3424,7 @@ export class ChatGptBrowserWorker {
           const evidence = await this.runStage(
             turn.traceId,
             `multipart_stage_${index + 1}_send`,
-            browserStageTimeouts.send,
+            browserStageTimeouts.multipartStageSend,
             (stageSignal) => this.sendAttachedPrompt(
               page,
               stageBaseline,
@@ -3537,7 +3542,9 @@ export class ChatGptBrowserWorker {
       const finalSubmissionEvidence = await this.runStage(
         turn.traceId,
         "send",
-        browserStageTimeouts.send,
+        // A multipart commit lands on a conversation already carrying every staged part, so it
+        // needs the same acceptance headroom the stages themselves get.
+        prepared.multipart ? browserStageTimeouts.multipartStageSend : browserStageTimeouts.send,
         (stageSignal) => this.sendAttachedPrompt(
           page,
           submissionBaseline,

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -108,6 +108,15 @@ export async function closeChatGptBrowserWorkers(): Promise<void> {
 }
 
 export const CHATGPT_RESPONSE_DOM_GRACE_MS = 60_000;
+/**
+ * How long a staged Bigger Context part may take to produce its assistant turn. A staged part is two
+ * orders of magnitude larger than an ordinary prompt and ChatGPT reads all of it before answering,
+ * so the ordinary grace is not a budget it can be held to: acknowledgements have been observed at
+ * 19s and 30s on the same payload that once took over 72s and lost the turn. There is no MCP
+ * activity to vouch for liveness yet at this point, so this window is the only thing standing
+ * between a slow ingest and a cancelled turn. It matches the staged send budget.
+ */
+export const CHATGPT_MULTIPART_RESPONSE_DOM_GRACE_MS = 180_000;
 export const CHATGPT_EMPTY_RESPONSE_GRACE_MS = 10_000;
 export const CHATGPT_COMPLETION_ACTION_GRACE_MS = 60_000;
 export const CHATGPT_COMPLETION_SETTLE_MS = 2_000;
@@ -611,7 +620,7 @@ export function resolveChatGptWebMultipartStagingMode(
   );
 }
 
-const browserStageTimeouts = {
+export const browserStageTimeouts = {
   browserPage: 60_000,
   temporaryChatPreparation: 150_000,
   effortSelection: 120_000,
@@ -2096,10 +2105,11 @@ export class ChatGptBrowserWorker {
     deadline: number | undefined,
     signal?: AbortSignal,
     externalProgress?: ChatGptTurnProgressReader,
+    graceMs: number = CHATGPT_RESPONSE_DOM_GRACE_MS,
   ): Promise<ChatGptAssistantTurnBinding> {
     let responseDeadline = Math.min(
       deadline ?? Number.POSITIVE_INFINITY,
-      Date.now() + CHATGPT_RESPONSE_DOM_GRACE_MS,
+      Date.now() + graceMs,
     );
     for (;;) {
       if (signal?.aborted) throw new DOMException("ChatGPT web turn aborted", "AbortError");
@@ -2108,7 +2118,7 @@ export class ChatGptBrowserWorker {
       if (progress?.lastProgressAt !== undefined) {
         responseDeadline = Math.min(
           deadline ?? Number.POSITIVE_INFINITY,
-          Math.max(responseDeadline, progress.lastProgressAt + CHATGPT_RESPONSE_DOM_GRACE_MS),
+          Math.max(responseDeadline, progress.lastProgressAt + graceMs),
         );
       }
       if (deadline !== undefined && Date.now() >= deadline) {
@@ -2124,7 +2134,7 @@ export class ChatGptBrowserWorker {
       try {
         state = await this.submissionDomState(page, baseline.domCache);
       } catch (error) {
-        if (!chatGptExternalProgressIsLive(progress, Date.now(), CHATGPT_RESPONSE_DOM_GRACE_MS)) throw error;
+        if (!chatGptExternalProgressIsLive(progress, Date.now(), graceMs)) throw error;
         await this.waitForTurnDomOrExternalProgress(
           page,
           progress?.revision ?? 0,
@@ -3463,6 +3473,7 @@ export class ChatGptBrowserWorker {
             deadline,
             turn.abortSignal,
             turn.externalProgress,
+            CHATGPT_MULTIPART_RESPONSE_DOM_GRACE_MS,
           );
           console.info(
             `[chatgpt-web] browser turn ${turn.traceId} multipart part ${index + 1}/${prepared.multipart.parts.length} submission accepted evidence=${evidence}`,

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -835,7 +835,17 @@ export class ChatGptCompletionTracker {
 
   constructor(private readonly stableMs = CHATGPT_COMPLETION_SETTLE_MS) {}
 
-  update(state: Parameters<typeof chatGptTurnIsComplete>[0], now = Date.now()): boolean {
+  update(
+    state: Parameters<typeof chatGptTurnIsComplete>[0] & { externalProgressLive?: boolean },
+    now = Date.now(),
+  ): boolean {
+    // An outstanding tool call proves the model has more to say, whatever the rendered message
+    // currently looks like. Completing here would return a truncated answer and retire the turn
+    // while its own tool calls were still in flight.
+    if (state.externalProgressLive) {
+      this.candidate = undefined;
+      return false;
+    }
     if (!chatGptTurnIsComplete(state)) {
       this.candidate = undefined;
       return false;
@@ -950,6 +960,9 @@ export const MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS = 8;
  */
 export const CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS = 10 * 60_000;
 
+/** Tolerated clock difference between the recording daemon and the observing helper process. */
+export const CHATGPT_EXTERNAL_PROGRESS_CLOCK_SKEW_MS = 5_000;
+
 /** Proven MCP activity, additionally required to be recent enough to still be evidence. */
 export function chatGptExternalProgressSuppressesDomHealth(
   snapshot: ChatGptExternalTurnProgressSnapshot | undefined,
@@ -957,8 +970,12 @@ export function chatGptExternalProgressSuppressesDomHealth(
 ): boolean {
   if (!chatGptExternalProgressIsLive(snapshot, now, CHATGPT_RESPONSE_DOM_GRACE_MS)) return false;
   const lastProgressAt = snapshot?.lastProgressAt;
-  return lastProgressAt !== undefined
-    && now - lastProgressAt < CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS;
+  if (lastProgressAt === undefined) return false;
+  const age = now - lastProgressAt;
+  // A timestamp from the future would keep `age` below the ceiling forever. Recorded activity can
+  // only precede the observation, so anything meaningfully ahead of now is not evidence at all.
+  return age >= -CHATGPT_EXTERNAL_PROGRESS_CLOCK_SKEW_MS
+    && age < CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS;
 }
 
 export class ChatGptStoppedThinkingTracker {
@@ -2451,6 +2468,7 @@ export class ChatGptBrowserWorker {
         currentText: snapshot.visibleText,
         currentHtml: snapshot.fullHtml,
         completionActionVisible: snapshot.completionActionVisible,
+        externalProgressLive,
       })) {
         const actual = snapshot.visibleText.trim();
         if (actual !== stage.acknowledgement) {
@@ -3543,6 +3561,12 @@ export class ChatGptBrowserWorker {
       let internalObservationFaults = 0;
       let observedThisIteration = false;
       for (;;) {
+        // The heartbeat is a consumer callback, so it stays outside the observation-fault region:
+        // a defect in the caller must not be retried as though the page could not be read.
+        if (Date.now() - lastHeartbeat >= 10_000) {
+          turn.onHeartbeat?.();
+          lastHeartbeat = Date.now();
+        }
        try {
         observedThisIteration = false;
         if (page.isClosed()) {
@@ -3556,11 +3580,6 @@ export class ChatGptBrowserWorker {
         if (deadline !== undefined && Date.now() >= deadline) {
           throw new Error("ChatGPT web turn timed out");
         }
-        if (Date.now() - lastHeartbeat >= 10_000) {
-          turn.onHeartbeat?.();
-          lastHeartbeat = Date.now();
-        }
-
         await throwIfChatGptSessionFailureAlert(page);
         await throwIfChatGptTerminalErrorAlert(responseTurn.locator);
 
@@ -3674,6 +3693,7 @@ export class ChatGptBrowserWorker {
             currentText: snapshot.visibleText,
             currentHtml: snapshot.fullHtml,
             completionActionVisible: snapshot.completionActionVisible,
+            externalProgressLive,
           })) {
             if (snapshot.visibleText === "api_tool unavailable") {
               throw new Error("ChatGPT selected mode rejected the Codex Native MCP tool (api_tool unavailable)");

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -951,6 +951,15 @@ export const CHATGPT_STOPPED_THINKING_GRACE_MS = 5_000;
 export const MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS = 8;
 
 /**
+ * Attempts allowed per Bigger Context stage before the turn is abandoned.
+ *
+ * ChatGPT can answer an inert staging prompt with "Stopped thinking" and no acknowledgement.
+ * Failing the turn there discards an accepted Codex turn that is never resent, whereas a stage is
+ * idempotent transport and can simply be sent again.
+ */
+export const MAX_CHATGPT_MULTIPART_STAGE_ATTEMPTS = 3;
+
+/**
  * How stale recorded MCP progress may be and still suppress DOM health checks.
  *
  * An outstanding tool call reports liveness regardless of age, so a call that never returns would
@@ -3387,6 +3396,12 @@ export class ChatGptBrowserWorker {
       if (prepared.multipart && multipartStages && multipartTransactionId && multipartFinalPrompt) {
         for (let index = 0; index < multipartStages.length; index += 1) {
           const stage = multipartStages[index]!;
+          // A stage carries inert transport keyed by transaction id, part index, and payload hash,
+          // so re-sending one is idempotent in a way a real prompt never is. ChatGPT can answer a
+          // stage with "Stopped thinking" and no acknowledgement, which previously destroyed an
+          // accepted turn outright; re-staging that part is both safe and far cheaper.
+          for (let attempt = 1; ; attempt += 1) {
+          try {
           const stageBaseline = await this.captureSubmissionBaseline(page);
           await this.runStage(
             turn.traceId,
@@ -3432,6 +3447,19 @@ export class ChatGptBrowserWorker {
             turn.externalProgress,
           );
           await diagnostics.capture(page, `multipart-stage-${index + 1}-acknowledged`);
+          break;
+          } catch (error) {
+            const stageStopped = error instanceof ChatGptWebAdapterError
+              && error.code === "client_cancelled";
+            if (!stageStopped || attempt >= MAX_CHATGPT_MULTIPART_STAGE_ATTEMPTS) throw error;
+            console.warn(
+              `[chatgpt-web] browser turn ${turn.traceId} restaging multipart part`
+              + ` ${index + 1}/${prepared.multipart.parts.length}`
+              + ` (attempt ${attempt}/${MAX_CHATGPT_MULTIPART_STAGE_ATTEMPTS}): ${error.message}`,
+            );
+            await diagnostics.capture(page, `multipart-stage-${index + 1}-restaged`);
+          }
+          }
         }
         if (mode.effort !== requestedMode.effort) {
           mode = await this.runStage(

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -1390,6 +1390,43 @@ export function chatGptPromptFilePayloads(
   return chatGptImageFilePayloads(prompt.images);
 }
 
+/**
+ * Insert `value` at the caret of an already-resolved ChatGPT composer, returning whether the edit
+ * was applied. Runs inside the page, so it may reference only globals and its two arguments.
+ *
+ * Effort selection closes a menu immediately before a staged part is attached, and focus is still
+ * settling when this runs: the composer can be the active element while the caret has not yet been
+ * placed inside it, or focus can still be on the menu that just closed. Reading that as a rejected
+ * edit failed whole turns roughly a tenth of a second after the effort menu closed, so the caret is
+ * placed explicitly instead of assumed. An existing collapsed caret inside the composer is left
+ * exactly where the user put it; only a missing or foreign one is replaced, and always with a
+ * position inside this composer, so an insert can never land in another element.
+ */
+export function insertPlainTextIntoComposer(element: HTMLElement, value: string): boolean {
+  if (document.activeElement !== element) element.focus();
+  if (document.activeElement !== element) return false;
+  const selection = window.getSelection();
+  if (!selection) return false;
+  const alreadyPlaced = selection.isCollapsed
+    && selection.anchorNode !== null
+    && element.contains(selection.anchorNode);
+  if (!alreadyPlaced) {
+    const range = document.createRange();
+    range.selectNodeContents(element);
+    range.collapse(false);
+    selection.removeAllRanges();
+    selection.addRange(range);
+  }
+  if (
+    !selection.isCollapsed
+    || !selection.anchorNode
+    || !element.contains(selection.anchorNode)
+  ) {
+    return false;
+  }
+  return document.execCommand("insertText", false, value);
+}
+
 export class ChatGptBrowserWorker {
   static forProvider(provider: CodexProviderConfig): ChatGptBrowserWorker {
     const config = resolveBrowserConfig(provider);
@@ -2585,19 +2622,7 @@ export class ChatGptBrowserWorker {
     // delimiters from textContent, and leave the next insertion outside the intended block. The
     // browser's plain-text editing command updates the same focused contenteditable atomically
     // without running those Markdown shortcuts. Exact readback below remains the authority.
-    const inserted = await composer.evaluate((element, value) => {
-      const selection = window.getSelection();
-      if (
-        document.activeElement !== element
-        || !selection
-        || !selection.isCollapsed
-        || !selection.anchorNode
-        || !element.contains(selection.anchorNode)
-      ) {
-        return false;
-      }
-      return document.execCommand("insertText", false, value);
-    }, text, { timeout: 20_000 });
+    const inserted = await composer.evaluate(insertPlainTextIntoComposer, text, { timeout: 20_000 });
     throwIfPromptAttachmentAborted(abortSignal);
     if (!inserted) {
       throw new ChatGptPromptAttachmentIntegrityError(

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -634,6 +634,59 @@ export const browserStageTimeouts = {
   multipartStageSend: 180_000,
 } as const;
 
+/**
+ * Detects that this process was suspended (system sleep) by watching for gaps in a steady tick.
+ * On Apple Silicon the monotonic clock keeps advancing through sleep, so elapsed time alone cannot
+ * distinguish "the stage really took 15 minutes" from "the machine slept for 14 of them" — and a
+ * stage budget charged for slept time cancels turns that never got their budget awake.
+ */
+export class ChatGptSuspensionClock {
+  private suspendedTotalMs = 0;
+  private lastTickAt: number;
+  private timer: ReturnType<typeof setInterval> | undefined;
+
+  constructor(
+    private readonly tickIntervalMs = 1_000,
+    private readonly gapThresholdMs = 5_000,
+  ) {
+    this.lastTickAt = Date.now();
+  }
+
+  start(): void {
+    if (this.timer) return;
+    this.lastTickAt = Date.now();
+    this.timer = setInterval(() => this.tick(Date.now()), this.tickIntervalMs);
+    this.timer.unref?.();
+  }
+
+  /** Exposed for tests; production ticks come from the interval above. */
+  tick(now: number): void {
+    const gap = now - this.lastTickAt;
+    this.lastTickAt = now;
+    if (gap >= this.gapThresholdMs) this.suspendedTotalMs += gap - this.tickIntervalMs;
+  }
+
+  suspendedMs(): number {
+    return this.suspendedTotalMs;
+  }
+}
+
+export const chatGptSuspensionClock = new ChatGptSuspensionClock();
+
+/**
+ * How much of a stage budget remains once slept time is refunded. Zero means the stage really
+ * consumed its budget while awake and the timeout stands.
+ */
+export function remainingStageBudgetMs(
+  timeoutMs: number,
+  elapsedMs: number,
+  suspendedMs: number,
+): number {
+  const awakeMs = elapsedMs - suspendedMs;
+  if (awakeMs >= timeoutMs) return 0;
+  return Math.max(250, timeoutMs - awakeMs);
+}
+
 export const CHATGPT_BROWSER_OBSERVATION_PROBE_TIMEOUT_MS = 5_000;
 export const MAX_CHATGPT_BROWSER_PAGE_REBINDS = 2;
 
@@ -1584,17 +1637,31 @@ export class ChatGptBrowserWorker {
     stage: string,
     timeoutMs: number,
     action: (abortSignal: AbortSignal) => Promise<T>,
+    suspensionClock: Pick<ChatGptSuspensionClock, "suspendedMs"> = chatGptSuspensionClock,
   ): Promise<T> {
+    chatGptSuspensionClock.start();
     const startedAt = performance.now();
+    const suspendedAtStart = suspensionClock.suspendedMs();
     console.info(`[chatgpt-web] browser turn ${traceId} stage=${stage} started`);
     const controller = new AbortController();
     let timer: ReturnType<typeof setTimeout> | undefined;
     try {
       const timeout = new Promise<never>((_, rejectTimeout) => {
-        timer = setTimeout(() => {
+        const fireOrRearm = () => {
+          // A stage that spans a system sleep has not consumed its budget: the browser was as
+          // frozen as this process, so slept time is refunded and the timer re-armed for what the
+          // stage is still owed. Observed live as effort_selection "timing out" at 901s of a 120s
+          // budget, to the second of a DarkWake.
+          const suspendedMs = suspensionClock.suspendedMs() - suspendedAtStart;
+          const remaining = remainingStageBudgetMs(timeoutMs, performance.now() - startedAt, suspendedMs);
+          if (remaining > 0) {
+            timer = setTimeout(fireOrRearm, remaining);
+            return;
+          }
           rejectTimeout(new Error(`ChatGPT browser stage timed out: ${stage}`));
           controller.abort();
-        }, timeoutMs);
+        };
+        timer = setTimeout(fireOrRearm, timeoutMs);
       });
       const value = await Promise.race([action(controller.signal), timeout]);
       console.info(`[chatgpt-web] browser turn ${traceId} stage=${stage} completed durationMs=${Math.round(performance.now() - startedAt)}`);

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -964,6 +964,17 @@ export function chatGptExternalProgressSuppressesDomHealth(
 export class ChatGptStoppedThinkingTracker {
   private visibleSince?: number;
 
+  /**
+   * Forgets an in-progress "Stopped thinking" window.
+   *
+   * Suppressing only the throw let the window keep accruing while a tool call was outstanding, so
+   * the first observation after progress ended cancelled the turn instantly. Proven activity must
+   * reset the evidence, not merely postpone acting on it.
+   */
+  clear(): void {
+    this.visibleSince = undefined;
+  }
+
   constructor(private readonly graceMs = CHATGPT_STOPPED_THINKING_GRACE_MS) {
     if (!Number.isFinite(graceMs) || graceMs < 0) {
       throw new Error("ChatGPT Stopped thinking grace must be a non-negative finite number");
@@ -2035,7 +2046,8 @@ export class ChatGptBrowserWorker {
       if (deadline !== undefined && Date.now() >= deadline) {
         throw new Error("ChatGPT web turn timed out");
       }
-      if (Date.now() >= responseDeadline && (progress?.activeToolCalls ?? 0) === 0) {
+      if (Date.now() >= responseDeadline
+        && !chatGptExternalProgressSuppressesDomHealth(progress, Date.now())) {
         throw new Error("ChatGPT accepted the message but did not expose its assistant turn in the DOM");
       }
       await throwIfChatGptSessionFailureAlert(page);
@@ -2413,7 +2425,8 @@ export class ChatGptBrowserWorker {
         externalProgress?.snapshot(),
         Date.now(),
       );
-      if (stoppedThinkingTracker.update(snapshot.stoppedThinkingVisible) && !externalProgressLive) {
+      if (externalProgressLive) stoppedThinkingTracker.clear();
+      else if (stoppedThinkingTracker.update(snapshot.stoppedThinkingVisible)) {
         throw chatGptStoppedThinkingError();
       }
       if (!snapshot.responsePresent && externalProgressLive) {
@@ -3373,6 +3386,7 @@ export class ChatGptBrowserWorker {
             stageBaseline,
             deadline,
             turn.abortSignal,
+            turn.externalProgress,
           );
           console.info(
             `[chatgpt-web] browser turn ${turn.traceId} multipart part ${index + 1}/${prepared.multipart.parts.length} submission accepted evidence=${evidence}`,
@@ -3514,8 +3528,10 @@ export class ChatGptBrowserWorker {
       const responseDomCache: ChatGptResponseDomCache = {};
       let consecutiveObservationRebinds = 0;
       let internalObservationFaults = 0;
+      let observedThisIteration = false;
       for (;;) {
        try {
+        observedThisIteration = false;
         if (page.isClosed()) {
           throw chatGptBrowserTabClosedError();
         }
@@ -3543,6 +3559,7 @@ export class ChatGptBrowserWorker {
           CHATGPT_TOOL_CONFIRMATION_TIMEOUT_MS,
           () => diagnostics.capture(page, "tool-confirmation-visible"),
         )) {
+          internalObservationFaults = 0;
           await new Promise(resolveSleep => setTimeout(resolveSleep, 250));
           continue;
         }
@@ -3589,6 +3606,7 @@ export class ChatGptBrowserWorker {
         // The page was read successfully, so the fault budget is genuinely consecutive even when
         // this iteration goes on to `continue` for a rebind, confirmation, or liveness pause.
         internalObservationFaults = 0;
+        observedThisIteration = true;
         // Liveness may postpone a verdict, never waive it: once activity goes stale the DOM alone
         // decides, so a tool call that never returns cannot hold an undeadlined turn open forever.
         const externalProgressLive = chatGptExternalProgressSuppressesDomHealth(
@@ -3596,8 +3614,9 @@ export class ChatGptBrowserWorker {
           Date.now(),
         );
         // A stale "Stopped thinking" label is not terminal while the model is still driving tool
-        // calls, so the tracker keeps observing but may not cancel the turn.
-        if (stoppedThinkingTracker.update(snapshot.stoppedThinkingVisible) && !externalProgressLive) {
+        // calls, and the window must be forgotten rather than merely ignored.
+        if (externalProgressLive) stoppedThinkingTracker.clear();
+        else if (stoppedThinkingTracker.update(snapshot.stoppedThinkingVisible)) {
           throw chatGptStoppedThinkingError();
         }
         if (!snapshot.responsePresent && externalProgressLive) {
@@ -3692,7 +3711,10 @@ export class ChatGptBrowserWorker {
        } catch (error) {
         // Only a defect in this worker is retried here. Every deliberate signal — adapter errors,
         // aborts, closed tabs, DOM-health verdicts — still fails the turn immediately.
-        if (!(error instanceof TypeError)) throw error;
+        // Retry only faults raised while reading the page. Once observation succeeded, a
+        // TypeError belongs to a consumer - Markdown buffering, text/trace callbacks, checkpoint
+        // capture - and retrying it would rerun an iteration whose side effects already happened.
+        if (!(error instanceof TypeError) || observedThisIteration) throw error;
         internalObservationFaults += 1;
         if (internalObservationFaults > MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS) {
           throw new Error(

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -86,7 +86,10 @@ import {
 import {
   chatGptExternalProgressIsLive,
 } from "./turn-progress";
-import type { ChatGptTurnProgressReader } from "./turn-progress";
+import type {
+  ChatGptExternalTurnProgressSnapshot,
+  ChatGptTurnProgressReader,
+} from "./turn-progress";
 
 export { MAX_CHATGPT_BROWSER_TABS } from "./concurrency";
 
@@ -938,12 +941,25 @@ export const CHATGPT_STOPPED_THINKING_GRACE_MS = 5_000;
 export const MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS = 8;
 
 /**
- * Absolute ceiling on how long proven MCP progress may suppress DOM health checks.
+ * How stale recorded MCP progress may be and still suppress DOM health checks.
  *
- * Liveness is reported while a tool call is outstanding, so a tool that never returns would
- * otherwise hold a turn open forever whenever the caller supplied no turn deadline.
+ * An outstanding tool call reports liveness regardless of age, so a call that never returns would
+ * otherwise hold a turn open forever — turns carry no deadline unless a caller supplies one. This
+ * bounds the silence since the last recorded activity rather than the turn's total duration, so a
+ * long turn that keeps calling tools is never penalised for taking a long time.
  */
-export const CHATGPT_EXTERNAL_PROGRESS_SUPPRESSION_CEILING_MS = 30 * 60_000;
+export const CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS = 10 * 60_000;
+
+/** Proven MCP activity, additionally required to be recent enough to still be evidence. */
+export function chatGptExternalProgressSuppressesDomHealth(
+  snapshot: ChatGptExternalTurnProgressSnapshot | undefined,
+  now: number,
+): boolean {
+  if (!chatGptExternalProgressIsLive(snapshot, now, CHATGPT_RESPONSE_DOM_GRACE_MS)) return false;
+  const lastProgressAt = snapshot?.lastProgressAt;
+  return lastProgressAt !== undefined
+    && now - lastProgressAt < CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS;
+}
 
 export class ChatGptStoppedThinkingTracker {
   private visibleSince?: number;
@@ -2393,10 +2409,9 @@ export class ChatGptBrowserWorker {
           snapshot = await this.responseDomSnapshot(responseTurn.locator, responseDomCache);
         }
       }
-      const externalProgressLive = chatGptExternalProgressIsLive(
+      const externalProgressLive = chatGptExternalProgressSuppressesDomHealth(
         externalProgress?.snapshot(),
         Date.now(),
-        CHATGPT_RESPONSE_DOM_GRACE_MS,
       );
       if (stoppedThinkingTracker.update(snapshot.stoppedThinkingVisible) && !externalProgressLive) {
         throw chatGptStoppedThinkingError();
@@ -3571,14 +3586,15 @@ export class ChatGptBrowserWorker {
           }
         }
         if (snapshot.responsePresent) consecutiveObservationRebinds = 0;
-        // Liveness may postpone a verdict, never waive it: past the ceiling the DOM alone decides,
-        // so a tool call that never returns cannot hold an undeadlined turn open indefinitely.
-        const externalProgressLive = Date.now() - sentAt < CHATGPT_EXTERNAL_PROGRESS_SUPPRESSION_CEILING_MS
-          && chatGptExternalProgressIsLive(
-            turn.externalProgress?.snapshot(),
-            Date.now(),
-            CHATGPT_RESPONSE_DOM_GRACE_MS,
-          );
+        // The page was read successfully, so the fault budget is genuinely consecutive even when
+        // this iteration goes on to `continue` for a rebind, confirmation, or liveness pause.
+        internalObservationFaults = 0;
+        // Liveness may postpone a verdict, never waive it: once activity goes stale the DOM alone
+        // decides, so a tool call that never returns cannot hold an undeadlined turn open forever.
+        const externalProgressLive = chatGptExternalProgressSuppressesDomHealth(
+          turn.externalProgress?.snapshot(),
+          Date.now(),
+        );
         // A stale "Stopped thinking" label is not terminal while the model is still driving tool
         // calls, so the tracker keeps observing but may not cancel the turn.
         if (stoppedThinkingTracker.update(snapshot.stoppedThinkingVisible) && !externalProgressLive) {
@@ -3672,7 +3688,6 @@ export class ChatGptBrowserWorker {
           });
           if (domError) throw new Error(domError);
         }
-        internalObservationFaults = 0;
         await new Promise(resolveSleep => setTimeout(resolveSleep, 250));
        } catch (error) {
         // Only a defect in this worker is retried here. Every deliberate signal — adapter errors,

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -2671,10 +2671,16 @@ export class ChatGptBrowserWorker {
         .filter(renderedInDom);
       const streamingStatusContainers = [...root.querySelectorAll<HTMLElement>("[data-streaming-response-status]")]
         .filter(renderedInDom);
+      const firstStreamingStatusContainer = streamingStatusContainers[0];
       const commentaryRoots = allMarkdownRoots.filter(candidate => (
         candidate.closest("[data-streaming-response-status]") !== null
-        || streamingStatusContainers.some(status => (
-          Boolean(candidate.compareDocumentPosition(status) & Node.DOCUMENT_POSITION_FOLLOWING)
+        // Only Markdown that precedes the FIRST status container is prior commentary. Keying this
+        // on "some status follows me" silently reclassified answer text as commentary as soon as a
+        // second tool call opened another status container below it, which both zeroed the visible
+        // text and dropped every answer chunk emitted between tool calls.
+        || (firstStreamingStatusContainer !== undefined && Boolean(
+          candidate.compareDocumentPosition(firstStreamingStatusContainer)
+          & Node.DOCUMENT_POSITION_FOLLOWING,
         ))
       ));
       const renderedRoots = allMarkdownRoots.filter(candidate => (

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -84,9 +84,9 @@ import {
   type CapturedChatGptLunaCheckpoint,
 } from "./rolling-checkpoint";
 import {
-  ChatGptExternalTurnProgress,
   chatGptExternalProgressIsLive,
 } from "./turn-progress";
+import type { ChatGptTurnProgressReader } from "./turn-progress";
 
 export { MAX_CHATGPT_BROWSER_TABS } from "./concurrency";
 
@@ -707,7 +707,7 @@ export interface BrowserTurn {
   /** Append-only, structurally stable Markdown chunks. */
   onTextDelta: (delta: string) => void;
   /** Proven current-turn MCP activity; liveness only, never response content or completion. */
-  externalProgress?: ChatGptExternalTurnProgress;
+  externalProgress?: ChatGptTurnProgressReader;
   /** Allow one clean pre-submit composer retry for isolated history compaction only. */
   compaction?: boolean;
   /** Require and remove the private Luna checkpoint tail from the visible Markdown stream. */
@@ -857,6 +857,17 @@ export class ChatGptTurnDomHealthTracker {
     private readonly emptyCompletionMs = CHATGPT_EMPTY_RESPONSE_GRACE_MS,
     private readonly missingCompletionActionMs = CHATGPT_COMPLETION_ACTION_GRACE_MS,
   ) {}
+
+  /**
+   * Clears only the missing-response window, leaving `sawResponse` history intact.
+   *
+   * Callers use this when proven external progress suspends DOM health checks: the suspended
+   * stretch must not be charged against the grace period, or the first observation after it
+   * resumes would fail instantly against a timestamp recorded long before.
+   */
+  clearMissingResponse(): void {
+    this.missingResponseSince = undefined;
+  }
 
   update(state: {
     responsePresent: boolean;
@@ -1779,7 +1790,7 @@ export class ChatGptBrowserWorker {
   private async waitForTurnDomOrExternalProgress(
     page: Page,
     afterProgressRevision: number,
-    externalProgress?: ChatGptExternalTurnProgress,
+    externalProgress?: ChatGptTurnProgressReader,
     signal?: AbortSignal,
   ): Promise<void> {
     const domMutation = this.waitForTurnDomMutation(page);
@@ -1805,7 +1816,7 @@ export class ChatGptBrowserWorker {
     page: Page,
     baseline: ChatGptSubmissionBaseline,
     signal?: AbortSignal,
-    externalProgress?: ChatGptExternalTurnProgress,
+    externalProgress?: ChatGptTurnProgressReader,
     initialToolBatchRevision = externalProgress?.snapshot().lastToolBatchRevision ?? 0,
   ): Promise<ChatGptSubmissionEvidence> {
     if (signal?.aborted) throw new DOMException("ChatGPT web turn aborted", "AbortError");
@@ -1961,7 +1972,7 @@ export class ChatGptBrowserWorker {
     baseline: ChatGptSubmissionBaseline,
     deadline: number | undefined,
     signal?: AbortSignal,
-    externalProgress?: ChatGptExternalTurnProgress,
+    externalProgress?: ChatGptTurnProgressReader,
   ): Promise<ChatGptAssistantTurnBinding> {
     let responseDeadline = Math.min(
       deadline ?? Number.POSITIVE_INFINITY,
@@ -2290,7 +2301,7 @@ export class ChatGptBrowserWorker {
     baseline: ChatGptSubmissionBaseline,
     captureDiagnostic?: (checkpoint: string) => Promise<void>,
     abortSignal?: AbortSignal,
-    externalProgress?: ChatGptExternalTurnProgress,
+    externalProgress?: ChatGptTurnProgressReader,
     submissionLifecycle?: Pick<BrowserTurn, "onSendActivated" | "onSubmitted">,
   ): Promise<ChatGptSubmissionEvidence> {
     const composer = await this.activeComposer(page);
@@ -2325,6 +2336,7 @@ export class ChatGptBrowserWorker {
     stage: ChatGptWebMultipartStage,
     deadline: number | undefined,
     abortSignal?: AbortSignal,
+    externalProgress?: ChatGptTurnProgressReader,
   ): Promise<void> {
     const completionTracker = new ChatGptCompletionTracker();
     const domHealthTracker = new ChatGptTurnDomHealthTracker();
@@ -2353,8 +2365,20 @@ export class ChatGptBrowserWorker {
           snapshot = await this.responseDomSnapshot(responseTurn.locator, responseDomCache);
         }
       }
-      if (stoppedThinkingTracker.update(snapshot.stoppedThinkingVisible)) {
+      const externalProgressLive = chatGptExternalProgressIsLive(
+        externalProgress?.snapshot(),
+        Date.now(),
+        CHATGPT_RESPONSE_DOM_GRACE_MS,
+      );
+      if (stoppedThinkingTracker.update(snapshot.stoppedThinkingVisible) && !externalProgressLive) {
         throw chatGptStoppedThinkingError();
+      }
+      if (!snapshot.responsePresent && externalProgressLive) {
+        // Proven MCP activity outranks a momentarily unavailable staging DOM, exactly as it does
+        // in the main turn loop.
+        domHealthTracker.clearMissingResponse();
+        await new Promise(resolveSleep => setTimeout(resolveSleep, 250));
+        continue;
       }
       const running = await page.locator(CHATGPT_STOP_BUTTON_SELECTOR).last().isVisible().catch(() => false);
       const domError = domHealthTracker.update({
@@ -3306,6 +3330,7 @@ export class ChatGptBrowserWorker {
             stage,
             deadline,
             turn.abortSignal,
+            turn.externalProgress,
           );
           await diagnostics.capture(page, `multipart-stage-${index + 1}-acknowledged`);
         }
@@ -3505,17 +3530,21 @@ export class ChatGptBrowserWorker {
           }
         }
         if (snapshot.responsePresent) consecutiveObservationRebinds = 0;
-        if (stoppedThinkingTracker.update(snapshot.stoppedThinkingVisible)) {
-          throw chatGptStoppedThinkingError();
-        }
-        if (!snapshot.responsePresent && chatGptExternalProgressIsLive(
+        const externalProgressLive = chatGptExternalProgressIsLive(
           turn.externalProgress?.snapshot(),
           Date.now(),
           CHATGPT_RESPONSE_DOM_GRACE_MS,
-        )) {
+        );
+        // A stale "Stopped thinking" label is not terminal while the model is still driving tool
+        // calls, so the tracker keeps observing but may not cancel the turn.
+        if (stoppedThinkingTracker.update(snapshot.stoppedThinkingVisible) && !externalProgressLive) {
+          throw chatGptStoppedThinkingError();
+        }
+        if (!snapshot.responsePresent && externalProgressLive) {
           // Current-turn MCP activity proves that ChatGPT is still executing even if its renderer
           // temporarily cannot expose the response subtree. DOM remains authoritative for text and
           // completion; this only prevents a live turn from being misclassified as vanished.
+          domHealthTracker.clearMissingResponse();
           await new Promise(resolveSleep => setTimeout(resolveSleep, 250));
           continue;
         }

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -927,6 +927,24 @@ export class ChatGptTurnDomHealthTracker {
 
 export const CHATGPT_STOPPED_THINKING_GRACE_MS = 5_000;
 
+/**
+ * Consecutive internal observation faults tolerated before a turn is abandoned.
+ *
+ * A `TypeError` raised while reading the page is a defect in this worker, not evidence about
+ * ChatGPT. Tearing the turn down on one loses an accepted ChatGPT turn that cannot be resent, so
+ * the loop re-observes instead. The budget is consecutive: any successful observation resets it,
+ * and exhausting it still fails closed with the original fault as the cause.
+ */
+export const MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS = 8;
+
+/**
+ * Absolute ceiling on how long proven MCP progress may suppress DOM health checks.
+ *
+ * Liveness is reported while a tool call is outstanding, so a tool that never returns would
+ * otherwise hold a turn open forever whenever the caller supplied no turn deadline.
+ */
+export const CHATGPT_EXTERNAL_PROGRESS_SUPPRESSION_CEILING_MS = 30 * 60_000;
+
 export class ChatGptStoppedThinkingTracker {
   private visibleSince?: number;
 
@@ -2674,6 +2692,10 @@ export class ChatGptBrowserWorker {
       const firstStreamingStatusContainer = streamingStatusContainers[0];
       const commentaryRoots = allMarkdownRoots.filter(candidate => (
         candidate.closest("[data-streaming-response-status]") !== null
+        // Chain-of-thought components carry reasoning, never the final answer, so containment is a
+        // positional-independent commentary signal. Position alone cannot separate "commentary
+        // between two status containers" from "answer between two tool calls".
+        || candidate.closest('[data-testid^="cot-v5"]') !== null
         // Only Markdown that precedes the FIRST status container is prior commentary. Keying this
         // on "some status follows me" silently reclassified answer text as commentary as soon as a
         // second tool call opened another status container below it, which both zeroed the visible
@@ -3476,7 +3498,9 @@ export class ChatGptBrowserWorker {
       const stoppedThinkingTracker = new ChatGptStoppedThinkingTracker();
       const responseDomCache: ChatGptResponseDomCache = {};
       let consecutiveObservationRebinds = 0;
+      let internalObservationFaults = 0;
       for (;;) {
+       try {
         if (page.isClosed()) {
           throw chatGptBrowserTabClosedError();
         }
@@ -3547,11 +3571,14 @@ export class ChatGptBrowserWorker {
           }
         }
         if (snapshot.responsePresent) consecutiveObservationRebinds = 0;
-        const externalProgressLive = chatGptExternalProgressIsLive(
-          turn.externalProgress?.snapshot(),
-          Date.now(),
-          CHATGPT_RESPONSE_DOM_GRACE_MS,
-        );
+        // Liveness may postpone a verdict, never waive it: past the ceiling the DOM alone decides,
+        // so a tool call that never returns cannot hold an undeadlined turn open indefinitely.
+        const externalProgressLive = Date.now() - sentAt < CHATGPT_EXTERNAL_PROGRESS_SUPPRESSION_CEILING_MS
+          && chatGptExternalProgressIsLive(
+            turn.externalProgress?.snapshot(),
+            Date.now(),
+            CHATGPT_RESPONSE_DOM_GRACE_MS,
+          );
         // A stale "Stopped thinking" label is not terminal while the model is still driving tool
         // calls, so the tracker keeps observing but may not cancel the turn.
         if (stoppedThinkingTracker.update(snapshot.stoppedThinkingVisible) && !externalProgressLive) {
@@ -3645,7 +3672,28 @@ export class ChatGptBrowserWorker {
           });
           if (domError) throw new Error(domError);
         }
+        internalObservationFaults = 0;
         await new Promise(resolveSleep => setTimeout(resolveSleep, 250));
+       } catch (error) {
+        // Only a defect in this worker is retried here. Every deliberate signal — adapter errors,
+        // aborts, closed tabs, DOM-health verdicts — still fails the turn immediately.
+        if (!(error instanceof TypeError)) throw error;
+        internalObservationFaults += 1;
+        if (internalObservationFaults > MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS) {
+          throw new Error(
+            `ChatGPT browser observation failed ${internalObservationFaults} times in a row: ${error.message}`,
+            { cause: error },
+          );
+        }
+        console.warn(
+          `[chatgpt-web] browser turn ${turn.traceId} tolerated internal observation fault`
+          + ` ${internalObservationFaults}/${MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS}: ${error.message}`,
+        );
+        await diagnostics.capture(page, "internal-observation-fault");
+        responseDomCache.key = undefined;
+        responseDomCache.snapshot = undefined;
+        await new Promise(resolveSleep => setTimeout(resolveSleep, 250));
+       }
       }
 
       if (this.context && this.config.browserHost === "managed-chrome") {

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -874,9 +874,19 @@ export class ChatGptTurnDomHealthTracker {
     running: boolean;
     currentText: string;
     completionActionVisible: boolean;
+    externalProgressLive?: boolean;
   }, now = Date.now()): string | undefined {
+    if (state.responsePresent) this.sawResponse = true;
+    if (state.externalProgressLive) {
+      // Every conclusion below asserts that ChatGPT stopped producing this turn. A tool call that
+      // is still completing disproves all of them, whatever the renderer is currently exposing, so
+      // no window may accrue while the model is provably working.
+      this.missingResponseSince = undefined;
+      this.emptyCompletionSince = undefined;
+      this.missingCompletionAction = undefined;
+      return undefined;
+    }
     if (state.responsePresent) {
-      this.sawResponse = true;
       this.missingResponseSince = undefined;
     } else {
       this.missingResponseSince ??= now;
@@ -2386,6 +2396,7 @@ export class ChatGptBrowserWorker {
         running,
         currentText: snapshot.visibleText,
         completionActionVisible: snapshot.completionActionVisible,
+        externalProgressLive,
       });
       if (domError) throw new Error(domError);
       if (completionTracker.update({
@@ -3573,6 +3584,7 @@ export class ChatGptBrowserWorker {
             running,
             currentText: snapshot.visibleText,
             completionActionVisible: snapshot.completionActionVisible,
+            externalProgressLive,
           });
           if (domError) throw new Error(domError);
           if (completionTracker.update({
@@ -3623,6 +3635,7 @@ export class ChatGptBrowserWorker {
             running,
             currentText: "",
             completionActionVisible: false,
+            externalProgressLive,
           });
           if (domError) throw new Error(domError);
         }

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -2717,25 +2717,38 @@ export class ChatGptBrowserWorker {
         .filter(renderedInDom);
       const streamingStatusContainers = [...root.querySelectorAll<HTMLElement>("[data-streaming-response-status]")]
         .filter(renderedInDom);
-      const firstStreamingStatusContainer = streamingStatusContainers[0];
-      const commentaryRoots = allMarkdownRoots.filter(candidate => (
-        candidate.closest("[data-streaming-response-status]") !== null
-        // Chain-of-thought components carry reasoning, never the final answer, so containment is a
-        // positional-independent commentary signal. Position alone cannot separate "commentary
-        // between two status containers" from "answer between two tool calls".
-        || candidate.closest('[data-testid^="cot-v5"]') !== null
-        // Only Markdown that precedes the FIRST status container is prior commentary. Keying this
-        // on "some status follows me" silently reclassified answer text as commentary as soon as a
-        // second tool call opened another status container below it, which both zeroed the visible
-        // text and dropped every answer chunk emitted between tool calls.
-        || (firstStreamingStatusContainer !== undefined && Boolean(
-          candidate.compareDocumentPosition(firstStreamingStatusContainer)
-          & Node.DOCUMENT_POSITION_FOLLOWING,
-        ))
-      ));
-      const renderedRoots = allMarkdownRoots.filter(candidate => (
-        !commentaryRoots.includes(candidate)
-      ));
+      // CHATGPT_COMMENTARY_CLASSIFIER_BEGIN
+      // Self-contained so the test suite can execute this exact source against a synthetic DOM;
+      // it must not close over anything from the surrounding evaluate scope.
+      const selectChatGptAnswerRoots = (
+        markdownRoots: HTMLElement[],
+        statusContainers: HTMLElement[],
+      ): { commentaryRoots: HTMLElement[]; answerRoots: HTMLElement[] } => {
+        const firstStatusContainer = statusContainers[0];
+        const commentary = markdownRoots.filter(candidate => (
+          candidate.closest("[data-streaming-response-status]") !== null
+          // Chain-of-thought components carry reasoning, never the final answer, so containment is
+          // a position-independent commentary signal. Position alone cannot separate "commentary
+          // between two status containers" from "answer between two tool calls".
+          || candidate.closest('[data-testid^="cot-v5"]') !== null
+          // Only Markdown that precedes the FIRST status container is prior commentary. Keying
+          // this on "some status follows me" silently reclassified answer text as commentary as
+          // soon as a second tool call opened another status container below it, which both zeroed
+          // the visible text and dropped every answer chunk emitted between tool calls.
+          || (firstStatusContainer !== undefined && Boolean(
+            // 4 is Node.DOCUMENT_POSITION_FOLLOWING, inlined to keep this function standalone.
+            candidate.compareDocumentPosition(firstStatusContainer) & 4,
+          ))
+        ));
+        return {
+          commentaryRoots: commentary,
+          answerRoots: markdownRoots.filter(candidate => !commentary.includes(candidate)),
+        };
+      };
+      // CHATGPT_COMMENTARY_CLASSIFIER_END
+      const classified = selectChatGptAnswerRoots(allMarkdownRoots, streamingStatusContainers);
+      const commentaryRoots = classified.commentaryRoots;
+      const renderedRoots = classified.answerRoots;
       // ChatGPT may merge adjacent `.markdown` roots or virtualize an old prefix while a streamed
       // answer is finalized. Root boundaries and visible indices therefore are not identity:
       // flatten semantic blocks and preserve ChatGPT's source ranges across that reparenting.

--- a/src/adapters/chatgpt-web/environment.ts
+++ b/src/adapters/chatgpt-web/environment.ts
@@ -93,6 +93,10 @@ function contextualUserMessage(value: Record<string, unknown>): boolean {
   const text = rawMessageText(value).trim();
   return /^<environment_context>[\s\S]*<\/environment_context>$/.test(text)
     || /^<subagent_notification>[\s\S]*<\/subagent_notification>$/.test(text)
+    // Codex injects this notice when a user interrupts a turn. It is a synthetic report about the
+    // previous turn, not a human instruction, and it keeps that turn's id. Treating it as the
+    // current revision made the next turn read a foreign turn id and fail as a conflict.
+    || /^<turn_aborted>[\s\S]*<\/turn_aborted>$/.test(text)
     || isReadableCompactionSummaryText(text)
     || text === OPAQUE_COMPACTION_NOTE;
 }

--- a/src/adapters/chatgpt-web/index.ts
+++ b/src/adapters/chatgpt-web/index.ts
@@ -3,7 +3,7 @@ import { resolve } from "node:path";
 import { defaultBrokerEndpoint, expandUserPath, resolveBrokerEndpoint } from "../../config";
 import { releaseLauncherRetainedConversation } from "../../launcher-browser-host";
 import { namespacedToolName, type AdapterEvent, type CodexContentPart, type CodexParsedRequest, type CodexProviderConfig, type CodexToolResultMessage, type CodexUsage } from "../../types";
-import type { ProviderAdapter } from "../base";
+import type { IncomingMeta, ProviderAdapter } from "../base";
 import { parseDataUrl } from "../image";
 import { ChatGptWebAdapterError } from "./adapter-error";
 import { ChatGptBrowserWorker } from "./browser-worker";
@@ -235,6 +235,13 @@ function validateBatchTools(parsed: CodexParsedRequest, requests: BrokerToolRequ
   }
 }
 
+/**
+ * Cadence of the adapter keep-alive that proves a ChatGPT turn is still alive to the Responses
+ * bridge. It must stay well under DEFAULT_STALL_TIMEOUT_SEC so a legitimately slow turn is never
+ * mistaken for a hung upstream.
+ */
+export const CHATGPT_WEB_ADAPTER_HEARTBEAT_MS = 10_000;
+
 export function createChatGptWebAdapter(
   provider: CodexProviderConfig,
   dependencies: { broker?: TurnBrokerOwner } = {},
@@ -462,110 +469,102 @@ export function createChatGptWebAdapter(
     };
   };
 
-  return {
-    name: "chatgpt-web",
-    async runTurn(parsed, incoming, emit) {
-      const turnCapabilities = parsed._compactionRequest
-        ? { ...configuredCapabilities, localToolsEnabled: false }
-        : configuredCapabilities;
-      const mode = resolveChatGptWebModelMode(parsed.modelId, parsed.options.reasoning, turnCapabilities);
-      const retryKey = `${executionNamespace}:${chatGptTurnRetryKey(parsed)}`;
-      const exhaustedRetry = chatGptWebTurnRetryPolicy.exhaustedError(retryKey);
-      if (exhaustedRetry) {
+  /**
+   * The Responses bridge cancels any turn that produces no adapter event for
+   * DEFAULT_STALL_TIMEOUT_SEC (see src/stall-timeout.ts). Liveness therefore has to cover every
+   * path through a turn, so the heartbeat is armed by runTurn before this body is entered and is
+   * cleared only once it settles. Nothing in here may become the sole keep-alive for a wait.
+   */
+  const runChatGptWebTurn = async (
+    parsed: CodexParsedRequest,
+    incoming: IncomingMeta,
+    emit: (event: AdapterEvent) => void,
+  ): Promise<void> => {
+    const turnCapabilities = parsed._compactionRequest
+      ? { ...configuredCapabilities, localToolsEnabled: false }
+      : configuredCapabilities;
+    const mode = resolveChatGptWebModelMode(parsed.modelId, parsed.options.reasoning, turnCapabilities);
+    const retryKey = `${executionNamespace}:${chatGptTurnRetryKey(parsed)}`;
+    const exhaustedRetry = chatGptWebTurnRetryPolicy.exhaustedError(retryKey);
+    if (exhaustedRetry) {
+      emit({
+        type: "error",
+        message: exhaustedRetry.message,
+        status: exhaustedRetry.status,
+        errorType: exhaustedRetry.errorType,
+        code: exhaustedRetry.code,
+        retryable: false,
+      });
+      return;
+    }
+    let environment: ReturnType<typeof extractChatGptTurnEnvironment> | undefined;
+    if (mode.localTools) {
+      try {
+        environment = environmentStore.resolve(parsed);
+      } catch (error) {
+        const identity = extractChatGptTurnIdentity(parsed);
+        console.warn(
+          `[chatgpt-web] trusted environment unavailable (thread_id=${identity.threadId ? "present" : "missing"}, turn_id=${identity.turnId ? "present" : "missing"}, previous_response_id=${parsed.previousResponseId ?? "none"}, replay_prefix_items=${parsed._replayPrefixLen ?? 0}, context_messages=${parsed.context.messages.length})`,
+        );
+        throw error;
+      }
+    }
+    if (parsed._compactionRequest) {
+      const structuredCompactionRequired = parsed.modelId !== CHATGPT_WEB_LUNA_MODEL_ID
+        && configuredCapabilities.localToolsEnabled;
+      if (structuredCompactionRequired && (!retainedLauncherDescriptor || !structuredBroker)) {
         emit({
           type: "error",
-          message: exhaustedRetry.message,
-          status: exhaustedRetry.status,
-          errorType: exhaustedRetry.errorType,
-          code: exhaustedRetry.code,
+          message: "Full-mode ChatGPT compaction requires the launcher retained-conversation lease and its local one-shot control broker; the bridge will not replace it with a read-only summarizer.",
+          status: 409,
+          errorType: "invalid_request_error",
+          code: "compaction_control_unavailable",
           retryable: false,
         });
         return;
       }
-      let environment: ReturnType<typeof extractChatGptTurnEnvironment> | undefined;
-      if (mode.localTools) {
-        try {
-          environment = environmentStore.resolve(parsed);
-        } catch (error) {
-          const identity = extractChatGptTurnIdentity(parsed);
-          console.warn(
-            `[chatgpt-web] trusted environment unavailable (thread_id=${identity.threadId ? "present" : "missing"}, turn_id=${identity.turnId ? "present" : "missing"}, previous_response_id=${parsed.previousResponseId ?? "none"}, replay_prefix_items=${parsed._replayPrefixLen ?? 0}, context_messages=${parsed.context.messages.length})`,
+      if (structuredCompactionRequired) {
+        const compactionExecutionKey = `${executionNamespace}:${chatGptTurnExecutionKey(parsed)}`;
+        const handoffTraceId = createHash("sha256")
+          .update(`${compactionExecutionKey}:handoff`)
+          .digest("hex")
+          .slice(0, 12);
+        const runFreshCompactionFallback = async (reason: string): Promise<string> => {
+          console.warn(`[chatgpt-web] retained compaction fallback=${reason}`);
+          const fallbackRuntime = startRuntime(
+            parsed,
+            undefined,
+            `${handoffTraceId}_fallback`,
+            turnCapabilities,
           );
-          throw error;
-        }
-      }
-      if (parsed._compactionRequest) {
-        const structuredCompactionRequired = parsed.modelId !== CHATGPT_WEB_LUNA_MODEL_ID
-          && configuredCapabilities.localToolsEnabled;
-        if (structuredCompactionRequired && (!retainedLauncherDescriptor || !structuredBroker)) {
-          emit({
-            type: "error",
-            message: "Full-mode ChatGPT compaction requires the launcher retained-conversation lease and its local one-shot control broker; the bridge will not replace it with a read-only summarizer.",
-            status: 409,
-            errorType: "invalid_request_error",
-            code: "compaction_control_unavailable",
-            retryable: false,
-          });
-          return;
-        }
-        if (structuredCompactionRequired) {
-          const compactionExecutionKey = `${executionNamespace}:${chatGptTurnExecutionKey(parsed)}`;
-          const handoffTraceId = createHash("sha256")
-            .update(`${compactionExecutionKey}:handoff`)
-            .digest("hex")
-            .slice(0, 12);
-          const runFreshCompactionFallback = async (reason: string): Promise<string> => {
-            console.warn(`[chatgpt-web] retained compaction fallback=${reason}`);
-            const fallbackRuntime = startRuntime(
-              parsed,
-              undefined,
-              `${handoffTraceId}_fallback`,
-              turnCapabilities,
-            );
-            try {
-              const rawSummary = await fallbackRuntime.browser;
-              await fallbackRuntime.physicalSettlement;
-              return canonicalizeCompactionHandoff(parsed, rawSummary);
-            } catch (error) {
-              fallbackRuntime.cancel(error instanceof Error ? error : new Error(String(error)));
-              await fallbackRuntime.physicalSettlement.catch(() => {});
-              throw error;
-            }
-          };
-          let sharedSummary = existingStructuredCompactionRun(compactionExecutionKey);
-          if (!sharedSummary) {
-            const sourceConversationKey = chatGptConversationKey(parsed, executionNamespace);
-            const source = sourceConversationKey
-              ? chatGptTurnSessions.findConversationHead(sourceConversationKey)
-              : undefined;
-            sharedSummary = runStructuredCompactionOnce(
-              compactionExecutionKey,
-              async () => {
-                const retainedKey = source?.conversationKey();
-                if (!source || !retainedKey) {
-                  return runFreshCompactionFallback("source_unavailable_before_handoff");
-                }
-                try {
-                  let rawSummary: string;
-                  if (source.isActive() && source.runtime.mode === "tools") {
-                    rawSummary = await settleActiveCompactionSource(parsed, source, structuredBroker!)
-                      ?? await requestRetainedCompactionHandoff(
-                        worker,
-                        parsed,
-                        source,
-                        structuredBroker!,
-                        configuredCapabilities,
-                        handoffTraceId,
-                        undefined,
-                        timeoutMs,
-                      );
-                  } else {
-                    if (source.isActive()) {
-                      const outcome = await source.browserOutcome;
-                      if (outcome.type === "error") throw outcome.error;
-                      await source.physicalSettlement;
-                    }
-                    rawSummary = await requestRetainedCompactionHandoff(
+          try {
+            const rawSummary = await fallbackRuntime.browser;
+            await fallbackRuntime.physicalSettlement;
+            return canonicalizeCompactionHandoff(parsed, rawSummary);
+          } catch (error) {
+            fallbackRuntime.cancel(error instanceof Error ? error : new Error(String(error)));
+            await fallbackRuntime.physicalSettlement.catch(() => {});
+            throw error;
+          }
+        };
+        let sharedSummary = existingStructuredCompactionRun(compactionExecutionKey);
+        if (!sharedSummary) {
+          const sourceConversationKey = chatGptConversationKey(parsed, executionNamespace);
+          const source = sourceConversationKey
+            ? chatGptTurnSessions.findConversationHead(sourceConversationKey)
+            : undefined;
+          sharedSummary = runStructuredCompactionOnce(
+            compactionExecutionKey,
+            async () => {
+              const retainedKey = source?.conversationKey();
+              if (!source || !retainedKey) {
+                return runFreshCompactionFallback("source_unavailable_before_handoff");
+              }
+              try {
+                let rawSummary: string;
+                if (source.isActive() && source.runtime.mode === "tools") {
+                  rawSummary = await settleActiveCompactionSource(parsed, source, structuredBroker!)
+                    ?? await requestRetainedCompactionHandoff(
                       worker,
                       parsed,
                       source,
@@ -575,290 +574,320 @@ export function createChatGptWebAdapter(
                       undefined,
                       timeoutMs,
                     );
+                } else {
+                  if (source.isActive()) {
+                    const outcome = await source.browserOutcome;
+                    if (outcome.type === "error") throw outcome.error;
+                    await source.physicalSettlement;
                   }
-                  const summary = canonicalizeCompactionHandoff(parsed, rawSummary);
-                  await chatGptTurnSessions.retireConversationAndWait(retainedKey);
-                  return summary;
-                } catch (error) {
-                  let handoffError = error instanceof Error ? error : new Error(String(error));
-                  try {
-                    await chatGptTurnSessions.retireConversationAndWait(retainedKey);
-                  } catch (retirementError) {
-                    handoffError = new AggregateError(
-                      [handoffError, retirementError instanceof Error ? retirementError : new Error(String(retirementError))],
-                      "Structured compaction failed and its retained conversation could not be retired",
-                    );
-                  }
-                  if (handoffError instanceof ChatGptWebAdapterError
-                    && handoffError.code === "compaction_source_unavailable") {
-                    return runFreshCompactionFallback("source_disappeared_before_handoff");
-                  }
-                  throw handoffError;
+                  rawSummary = await requestRetainedCompactionHandoff(
+                    worker,
+                    parsed,
+                    source,
+                    structuredBroker!,
+                    configuredCapabilities,
+                    handoffTraceId,
+                    undefined,
+                    timeoutMs,
+                  );
                 }
-              },
-            );
-          }
-          emit({ type: "heartbeat" });
-          let summary: string;
-          try {
-            summary = await withAbort(sharedSummary, incoming.abortSignal);
-          } catch (error) {
-            if (incoming.abortSignal?.aborted
-              && error instanceof DOMException
-              && error.name === "AbortError") {
-              // The observer detached; the shared exact compaction round continues and remains
-              // available to a canonical reconnect without a second browser submission.
-              throw error;
-            }
-            const handoffError = error instanceof Error ? error : new Error(String(error));
-            emit({
-              type: "error",
-              message: `The retained ChatGPT agent did not complete the structured context handoff: ${handoffError.message}`,
-              status: 409,
-              errorType: "invalid_request_error",
-              code: "compaction_handoff_failed",
-              retryable: false,
-            });
-            return;
-          }
-          emit({ type: "text_delta", text: summary, phase: "final_answer" });
-          emitBrowserCompletion(
-            { type: "final", answer: summary },
-            estimateChatGptWebUsage(parsed, { answer: summary, reasoning: [] }, turnCapabilities),
-            emit,
+                const summary = canonicalizeCompactionHandoff(parsed, rawSummary);
+                await chatGptTurnSessions.retireConversationAndWait(retainedKey);
+                return summary;
+              } catch (error) {
+                let handoffError = error instanceof Error ? error : new Error(String(error));
+                try {
+                  await chatGptTurnSessions.retireConversationAndWait(retainedKey);
+                } catch (retirementError) {
+                  handoffError = new AggregateError(
+                    [handoffError, retirementError instanceof Error ? retirementError : new Error(String(retirementError))],
+                    "Structured compaction failed and its retained conversation could not be retired",
+                  );
+                }
+                if (handoffError instanceof ChatGptWebAdapterError
+                  && handoffError.code === "compaction_source_unavailable") {
+                  return runFreshCompactionFallback("source_disappeared_before_handoff");
+                }
+                throw handoffError;
+              }
+            },
           );
+        }
+        emit({ type: "heartbeat" });
+        let summary: string;
+        try {
+          summary = await withAbort(sharedSummary, incoming.abortSignal);
+        } catch (error) {
+          if (incoming.abortSignal?.aborted
+            && error instanceof DOMException
+            && error.name === "AbortError") {
+            // The observer detached; the shared exact compaction round continues and remains
+            // available to a canonical reconnect without a second browser submission.
+            throw error;
+          }
+          const handoffError = error instanceof Error ? error : new Error(String(error));
+          emit({
+            type: "error",
+            message: `The retained ChatGPT agent did not complete the structured context handoff: ${handoffError.message}`,
+            status: 409,
+            errorType: "invalid_request_error",
+            code: "compaction_handoff_failed",
+            retryable: false,
+          });
+          return;
+        }
+        emit({ type: "text_delta", text: summary, phase: "final_answer" });
+        emitBrowserCompletion(
+          { type: "final", answer: summary },
+          estimateChatGptWebUsage(parsed, { answer: summary, reasoning: [] }, turnCapabilities),
+          emit,
+        );
+        chatGptWebTurnRetryPolicy.clear(retryKey);
+        return;
+      }
+      const responseExecutionKey = `${executionNamespace}:${chatGptCompactionSourceExecutionKey(parsed)}`;
+      await chatGptTurnSessions.retireAndWait(responseExecutionKey);
+    }
+    const executionKey = `${executionNamespace}:${chatGptTurnExecutionKey(parsed)}`;
+    const ownerKey = `${executionNamespace}:${chatGptThreadOwnershipKey(parsed)}`;
+    const traceId = createHash("sha256").update(executionKey).digest("hex").slice(0, 12);
+    const session = await chatGptTurnSessions.getOrCreateAfterOwnerRetirement(
+      executionKey,
+      ownerKey,
+      () => startRuntime(parsed, environment, traceId, turnCapabilities),
+      traceId,
+    );
+    const roundKey = chatGptTurnRoundKey(parsed);
+    const emitRoundEvents = (events: readonly AdapterEvent[]): void => {
+      // Journal the complete synchronous event batch before touching the HTTP observer. If the
+      // observer disconnects midway through emission, an exact reconnect can replay the entire
+      // canonical batch instead of losing the already-drained tail.
+      session.appendRoundEvents(roundKey, events);
+      for (const event of events) emit(event);
+    };
+    const emitRoundBatch = (
+      produce: (buffer: (event: AdapterEvent) => void) => void,
+    ): void => {
+      const events: AdapterEvent[] = [];
+      produce(event => events.push(event));
+      emitRoundEvents(events);
+    };
+    const emitRoundEvent = (event: AdapterEvent): void => emitRoundEvents([event]);
+    try {
+      emit({ type: "heartbeat" });
+      await session.runExclusive(async () => {
+        const replay = session.roundEvents(roundKey);
+        replayEvents(replay, emit);
+        if (session.roundCompleted(roundKey)) {
+          const failure = session.roundFailure(roundKey);
+          if (failure) throw failure;
+          return;
+        }
+        if (session.roundHasTerminalEvent(roundKey)) {
+          session.completeRound(roundKey);
+          return;
+        }
+        const settled = session.settledOutcome();
+        if (settled) {
+          if (settled.type === "error") throw settled.error;
+          const trace = session.runtime.trace.drain();
+          session.appendRoundReasoning(roundKey, trace.map(event => event.text));
+          if (replay.length === 0 && !parsed._compactionRequest) {
+            emitRoundBatch(buffer => emitReadOnlyContextWarning(parsed, turnCapabilities, buffer));
+          }
+          emitRoundBatch(buffer => emitTraceEvents(trace, buffer));
+          emitRoundBatch(buffer => emitTextDeltas(session.runtime.text.drain(), buffer));
+          if (session.runtime.text.value() !== settled.answer) {
+            throw new Error("ChatGPT browser Markdown stream did not reproduce the completed answer");
+          }
+          const reasoning = session.roundReasoning(roundKey);
+          session.setFinalReasoning(reasoning);
+          session.setFinalEvents(session.roundEvents(roundKey));
+          emitRoundBatch(buffer => emitBrowserCompletion(
+            settled,
+            estimateChatGptWebUsage(currentUsageInput(parsed), { answer: settled.answer, reasoning }, turnCapabilities),
+            buffer,
+          ));
+          session.completeRound(roundKey);
           chatGptWebTurnRetryPolicy.clear(retryKey);
           return;
         }
-        const responseExecutionKey = `${executionNamespace}:${chatGptCompactionSourceExecutionKey(parsed)}`;
-        await chatGptTurnSessions.retireAndWait(responseExecutionKey);
-      }
-      const executionKey = `${executionNamespace}:${chatGptTurnExecutionKey(parsed)}`;
-      const ownerKey = `${executionNamespace}:${chatGptThreadOwnershipKey(parsed)}`;
-      const traceId = createHash("sha256").update(executionKey).digest("hex").slice(0, 12);
-      const session = await chatGptTurnSessions.getOrCreateAfterOwnerRetirement(
-        executionKey,
-        ownerKey,
-        () => startRuntime(parsed, environment, traceId, turnCapabilities),
-        traceId,
-      );
-      const roundKey = chatGptTurnRoundKey(parsed);
-      const emitRoundEvents = (events: readonly AdapterEvent[]): void => {
-        // Journal the complete synchronous event batch before touching the HTTP observer. If the
-        // observer disconnects midway through emission, an exact reconnect can replay the entire
-        // canonical batch instead of losing the already-drained tail.
-        session.appendRoundEvents(roundKey, events);
-        for (const event of events) emit(event);
-      };
-      const emitRoundBatch = (
-        produce: (buffer: (event: AdapterEvent) => void) => void,
-      ): void => {
-        const events: AdapterEvent[] = [];
-        produce(event => events.push(event));
-        emitRoundEvents(events);
-      };
-      const emitRoundEvent = (event: AdapterEvent): void => emitRoundEvents([event]);
-      const heartbeat = setInterval(() => emit({ type: "heartbeat" }), 10_000);
-      try {
-        emit({ type: "heartbeat" });
-        await session.runExclusive(async () => {
-          const replay = session.roundEvents(roundKey);
-          replayEvents(replay, emit);
-          if (session.roundCompleted(roundKey)) {
-            const failure = session.roundFailure(roundKey);
-            if (failure) throw failure;
-            return;
-          }
-          if (session.roundHasTerminalEvent(roundKey)) {
-            session.completeRound(roundKey);
-            return;
-          }
-          const settled = session.settledOutcome();
-          if (settled) {
-            if (settled.type === "error") throw settled.error;
-            const trace = session.runtime.trace.drain();
-            session.appendRoundReasoning(roundKey, trace.map(event => event.text));
-            if (replay.length === 0 && !parsed._compactionRequest) {
-              emitRoundBatch(buffer => emitReadOnlyContextWarning(parsed, turnCapabilities, buffer));
-            }
-            emitRoundBatch(buffer => emitTraceEvents(trace, buffer));
-            emitRoundBatch(buffer => emitTextDeltas(session.runtime.text.drain(), buffer));
-            if (session.runtime.text.value() !== settled.answer) {
-              throw new Error("ChatGPT browser Markdown stream did not reproduce the completed answer");
-            }
-            const reasoning = session.roundReasoning(roundKey);
-            session.setFinalReasoning(reasoning);
-            session.setFinalEvents(session.roundEvents(roundKey));
-            emitRoundBatch(buffer => emitBrowserCompletion(
-              settled,
-              estimateChatGptWebUsage(currentUsageInput(parsed), { answer: settled.answer, reasoning }, turnCapabilities),
-              buffer,
-            ));
-            session.completeRound(roundKey);
-            chatGptWebTurnRetryPolicy.clear(retryKey);
-            return;
-          }
 
-          let turnToken: string | undefined;
-          if (session.runtime.mode === "tools") {
-            turnToken = await withAbort(session.runtime.token, incoming.abortSignal);
-            if (!environment) throw new Error("Tool-capable ChatGPT web runtime lost its trusted environment");
-            await broker.updateEnvironment(turnToken, environment);
+        let turnToken: string | undefined;
+        if (session.runtime.mode === "tools") {
+          turnToken = await withAbort(session.runtime.token, incoming.abortSignal);
+          if (!environment) throw new Error("Tool-capable ChatGPT web runtime lost its trusted environment");
+          await broker.updateEnvironment(turnToken, environment);
 
-            const outstanding = session.outstanding();
-            if (outstanding.length > 0) {
-              const results = currentToolResults(parsed, session);
-              if (results.length === 0) {
-                const reasoning = session.reasoningForOutstandingReplay();
-                if (replay.length === 0) emitRoundEvents(session.eventsForOutstandingReplay());
-                emitRoundBatch(buffer => emitToolBatch(
-                  outstanding,
-                  estimateChatGptWebUsage(currentUsageInput(parsed), { reasoning, toolRequests: outstanding }, turnCapabilities),
-                  buffer,
-                ));
-                session.completeRound(roundKey);
-                return;
-              }
-              if (results.length !== outstanding.length) {
-                throw new Error(`Codex returned ${results.length} of ${outstanding.length} results for a parallel ChatGPT tool batch`);
-              }
-              for (const message of results) {
-                await broker.completeTool(turnToken, message.toolCallId, brokerResult(message));
-                session.runtime.externalProgress.recordToolResult();
-                session.markResultDelivered(message.toolCallId);
-              }
-            }
-          } else if (session.outstanding().length > 0) {
-            throw new Error("Read-only ChatGPT Web runtime cannot own local tool calls");
-          }
-
-          const toolWaitAbort = new AbortController();
-          try {
-            const roundReasoning = session.roundReasoning(roundKey);
-            const emitNewTrace = (trace: ChatGptTraceEvent[]) => {
-              roundReasoning.push(...trace.map(event => event.text));
-              session.appendRoundReasoning(roundKey, trace.map(event => event.text));
-              emitRoundBatch(buffer => emitTraceEvents(trace, buffer));
-            };
-            const emitNewText = (deltas: string[]) => emitRoundBatch(buffer => emitTextDeltas(deltas, buffer));
-            if (replay.length === 0 && !parsed._compactionRequest) {
-              emitRoundBatch(buffer => emitReadOnlyContextWarning(parsed, turnCapabilities, buffer));
-            }
-            emitNewTrace(session.runtime.trace.drain());
-            emitNewText(session.runtime.text.drain());
-            const externalProgress = session.runtime.mode === "tools"
-              ? session.runtime.externalProgress
-              : undefined;
-            const nextTools = turnToken
-              ? broker.nextToolBatch(turnToken, toolWaitAbort.signal).then(requests => {
-                if (!externalProgress) {
-                  throw new Error("ChatGPT broker returned tools for a read-only browser turn");
-                }
-                externalProgress.recordToolBatch(requests.length);
-                return { type: "tools" as const, requests };
-              })
-              : undefined;
-            const browserOutcome = session.browserOutcome.then(outcome => ({ type: "browser" as const, outcome }));
-            let nextTrace = session.runtime.trace.wait(toolWaitAbort.signal).then(() => ({ type: "trace" as const }));
-            let nextText = session.runtime.text.wait(toolWaitAbort.signal).then(() => ({ type: "text" as const }));
-            for (;;) {
-              const next = await withAbort(
-                Promise.race([
-                  ...(nextTools ? [nextTools] : []),
-                  browserOutcome,
-                  nextTrace,
-                  nextText,
-                ]),
-                incoming.abortSignal,
-              );
-              if (next.type === "trace") {
-                emitNewTrace(session.runtime.trace.drain());
-                nextTrace = session.runtime.trace.wait(toolWaitAbort.signal).then(() => ({ type: "trace" as const }));
-                continue;
-              }
-              if (next.type === "text") {
-                emitNewText(session.runtime.text.drain());
-                nextText = session.runtime.text.wait(toolWaitAbort.signal).then(() => ({ type: "text" as const }));
-                continue;
-              }
-              emitNewTrace(session.runtime.trace.drain());
-              emitNewText(session.runtime.text.drain());
-              if (next.type === "browser") {
-                const completedOutcome = next.outcome;
-                session.setFinalReasoning(roundReasoning);
-                session.setFinalEvents(session.roundEvents(roundKey));
-                if (turnToken) await broker.revoke(turnToken);
-                if (completedOutcome.type === "error") throw completedOutcome.error;
-                if (session.runtime.text.value() !== completedOutcome.answer) {
-                  throw new Error("ChatGPT browser Markdown stream did not reproduce the completed answer");
-                }
-                emitRoundBatch(buffer => emitBrowserCompletion(
-                  completedOutcome,
-                  estimateChatGptWebUsage(currentUsageInput(parsed), { answer: completedOutcome.answer, reasoning: roundReasoning }, turnCapabilities),
-                  buffer,
-                ));
-                session.completeRound(roundKey);
-                chatGptWebTurnRetryPolicy.clear(retryKey);
-                return;
-              }
-              if (!turnToken || session.runtime.mode !== "tools") {
-                throw new Error("Read-only ChatGPT Web runtime received a broker tool batch");
-              }
-              if (next.requests.length === 0) throw new Error("ChatGPT tool bridge returned an empty batch");
-              validateBatchTools(parsed, next.requests);
-              session.setOutstanding(next.requests, roundReasoning, session.roundEvents(roundKey));
+          const outstanding = session.outstanding();
+          if (outstanding.length > 0) {
+            const results = currentToolResults(parsed, session);
+            if (results.length === 0) {
+              const reasoning = session.reasoningForOutstandingReplay();
+              if (replay.length === 0) emitRoundEvents(session.eventsForOutstandingReplay());
               emitRoundBatch(buffer => emitToolBatch(
-                next.requests,
-                estimateChatGptWebUsage(currentUsageInput(parsed), { reasoning: roundReasoning, toolRequests: next.requests }, turnCapabilities),
+                outstanding,
+                estimateChatGptWebUsage(currentUsageInput(parsed), { reasoning, toolRequests: outstanding }, turnCapabilities),
                 buffer,
               ));
               session.completeRound(roundKey);
               return;
             }
-          } finally {
-            toolWaitAbort.abort();
+            if (results.length !== outstanding.length) {
+              throw new Error(`Codex returned ${results.length} of ${outstanding.length} results for a parallel ChatGPT tool batch`);
+            }
+            for (const message of results) {
+              await broker.completeTool(turnToken, message.toolCallId, brokerResult(message));
+              session.runtime.externalProgress.recordToolResult();
+              session.markResultDelivered(message.toolCallId);
+            }
           }
-        });
-      } catch (error) {
-        if (incoming.abortSignal?.aborted && error instanceof DOMException && error.name === "AbortError") {
-          // The HTTP observer detached. Keep the exact browser execution and its round journal so
-          // the same canonical request can reconnect without another ChatGPT submission.
-          throw error;
+        } else if (session.outstanding().length > 0) {
+          throw new Error("Read-only ChatGPT Web runtime cannot own local tool calls");
         }
-        const turnError = submittedTurnFailure(session, error);
-        const handledError = turnError instanceof ChatGptWebAdapterError && turnError.retryable
-          ? chatGptWebTurnRetryPolicy.recordRetryableFailure(retryKey, turnError)
-          : turnError;
-        if (!(turnError instanceof ChatGptWebAdapterError && turnError.retryable)) {
-          chatGptWebTurnRetryPolicy.clear(retryKey);
+
+        const toolWaitAbort = new AbortController();
+        try {
+          const roundReasoning = session.roundReasoning(roundKey);
+          const emitNewTrace = (trace: ChatGptTraceEvent[]) => {
+            roundReasoning.push(...trace.map(event => event.text));
+            session.appendRoundReasoning(roundKey, trace.map(event => event.text));
+            emitRoundBatch(buffer => emitTraceEvents(trace, buffer));
+          };
+          const emitNewText = (deltas: string[]) => emitRoundBatch(buffer => emitTextDeltas(deltas, buffer));
+          if (replay.length === 0 && !parsed._compactionRequest) {
+            emitRoundBatch(buffer => emitReadOnlyContextWarning(parsed, turnCapabilities, buffer));
+          }
+          emitNewTrace(session.runtime.trace.drain());
+          emitNewText(session.runtime.text.drain());
+          const externalProgress = session.runtime.mode === "tools"
+            ? session.runtime.externalProgress
+            : undefined;
+          const nextTools = turnToken
+            ? broker.nextToolBatch(turnToken, toolWaitAbort.signal).then(requests => {
+              if (!externalProgress) {
+                throw new Error("ChatGPT broker returned tools for a read-only browser turn");
+              }
+              externalProgress.recordToolBatch(requests.length);
+              return { type: "tools" as const, requests };
+            })
+            : undefined;
+          const browserOutcome = session.browserOutcome.then(outcome => ({ type: "browser" as const, outcome }));
+          let nextTrace = session.runtime.trace.wait(toolWaitAbort.signal).then(() => ({ type: "trace" as const }));
+          let nextText = session.runtime.text.wait(toolWaitAbort.signal).then(() => ({ type: "text" as const }));
+          for (;;) {
+            const next = await withAbort(
+              Promise.race([
+                ...(nextTools ? [nextTools] : []),
+                browserOutcome,
+                nextTrace,
+                nextText,
+              ]),
+              incoming.abortSignal,
+            );
+            if (next.type === "trace") {
+              emitNewTrace(session.runtime.trace.drain());
+              nextTrace = session.runtime.trace.wait(toolWaitAbort.signal).then(() => ({ type: "trace" as const }));
+              continue;
+            }
+            if (next.type === "text") {
+              emitNewText(session.runtime.text.drain());
+              nextText = session.runtime.text.wait(toolWaitAbort.signal).then(() => ({ type: "text" as const }));
+              continue;
+            }
+            emitNewTrace(session.runtime.trace.drain());
+            emitNewText(session.runtime.text.drain());
+            if (next.type === "browser") {
+              const completedOutcome = next.outcome;
+              session.setFinalReasoning(roundReasoning);
+              session.setFinalEvents(session.roundEvents(roundKey));
+              if (turnToken) await broker.revoke(turnToken);
+              if (completedOutcome.type === "error") throw completedOutcome.error;
+              if (session.runtime.text.value() !== completedOutcome.answer) {
+                throw new Error("ChatGPT browser Markdown stream did not reproduce the completed answer");
+              }
+              emitRoundBatch(buffer => emitBrowserCompletion(
+                completedOutcome,
+                estimateChatGptWebUsage(currentUsageInput(parsed), { answer: completedOutcome.answer, reasoning: roundReasoning }, turnCapabilities),
+                buffer,
+              ));
+              session.completeRound(roundKey);
+              chatGptWebTurnRetryPolicy.clear(retryKey);
+              return;
+            }
+            if (!turnToken || session.runtime.mode !== "tools") {
+              throw new Error("Read-only ChatGPT Web runtime received a broker tool batch");
+            }
+            if (next.requests.length === 0) throw new Error("ChatGPT tool bridge returned an empty batch");
+            validateBatchTools(parsed, next.requests);
+            session.setOutstanding(next.requests, roundReasoning, session.roundEvents(roundKey));
+            emitRoundBatch(buffer => emitToolBatch(
+              next.requests,
+              estimateChatGptWebUsage(currentUsageInput(parsed), { reasoning: roundReasoning, toolRequests: next.requests }, turnCapabilities),
+              buffer,
+            ));
+            session.completeRound(roundKey);
+            return;
+          }
+        } finally {
+          toolWaitAbort.abort();
         }
-        if (handledError instanceof ChatGptWebAdapterError && !handledError.retryable) {
-          // A deterministic request failure remains replayable so a native reconnect cannot burn
-          // another browser attempt. Every other failure retires the browser session: client
-          // disconnects, stage failures, and retryable ChatGPT errors must start a fresh surface
-          // instead of replaying one rejected browser outcome for the registry's full TTL.
-          session.cancel();
-        } else {
-          chatGptTurnSessions.retire(executionKey, session);
-        }
-        if (session.runtime.mode === "tools") {
-          void session.runtime.token.then(turnToken => broker.revoke(turnToken)).catch(() => {});
-        }
-        if (handledError instanceof ChatGptWebAdapterError) {
-          emitRoundEvent({
-            type: "error",
-            message: handledError.message,
-            status: handledError.status,
-            errorType: handledError.errorType,
-            code: handledError.code,
-            retryable: handledError.retryable,
-          });
-          session.completeRound(roundKey);
-          return;
-        }
-        session.failRound(roundKey, turnError);
+      });
+    } catch (error) {
+      if (incoming.abortSignal?.aborted && error instanceof DOMException && error.name === "AbortError") {
+        // The HTTP observer detached. Keep the exact browser execution and its round journal so
+        // the same canonical request can reconnect without another ChatGPT submission.
+        throw error;
+      }
+      const turnError = submittedTurnFailure(session, error);
+      const handledError = turnError instanceof ChatGptWebAdapterError && turnError.retryable
+        ? chatGptWebTurnRetryPolicy.recordRetryableFailure(retryKey, turnError)
+        : turnError;
+      if (!(turnError instanceof ChatGptWebAdapterError && turnError.retryable)) {
         chatGptWebTurnRetryPolicy.clear(retryKey);
-        throw turnError;
+      }
+      if (handledError instanceof ChatGptWebAdapterError && !handledError.retryable) {
+        // A deterministic request failure remains replayable so a native reconnect cannot burn
+        // another browser attempt. Every other failure retires the browser session: client
+        // disconnects, stage failures, and retryable ChatGPT errors must start a fresh surface
+        // instead of replaying one rejected browser outcome for the registry's full TTL.
+        session.cancel();
+      } else {
+        chatGptTurnSessions.retire(executionKey, session);
+      }
+      if (session.runtime.mode === "tools") {
+        void session.runtime.token.then(turnToken => broker.revoke(turnToken)).catch(() => {});
+      }
+      if (handledError instanceof ChatGptWebAdapterError) {
+        emitRoundEvent({
+          type: "error",
+          message: handledError.message,
+          status: handledError.status,
+          errorType: handledError.errorType,
+          code: handledError.code,
+          retryable: handledError.retryable,
+        });
+        session.completeRound(roundKey);
+        return;
+      }
+      session.failRound(roundKey, turnError);
+      chatGptWebTurnRetryPolicy.clear(retryKey);
+      throw turnError;
+    }
+  };
+
+  return {
+    name: "chatgpt-web",
+    async runTurn(parsed, incoming, emit) {
+      // Armed before any awaited work and cleared only when the turn settles: a silent window
+      // anywhere in runTurn is a turn the bridge cancels with upstream_stall_timeout.
+      const heartbeat = setInterval(
+        () => emit({ type: "heartbeat" }),
+        CHATGPT_WEB_ADAPTER_HEARTBEAT_MS,
+      );
+      emit({ type: "heartbeat" });
+      try {
+        await runChatGptWebTurn(parsed, incoming, emit);
       } finally {
         clearInterval(heartbeat);
       }

--- a/src/adapters/chatgpt-web/launcher-helper-client.ts
+++ b/src/adapters/chatgpt-web/launcher-helper-client.ts
@@ -1,6 +1,6 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { existsSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { createInterface } from "node:readline";
 import { notifyLauncherTurn, readLauncherBrowserHostDescriptor } from "../../launcher-browser-host";
 import { ChatGptWebAdapterError } from "./adapter-error";
@@ -163,7 +163,11 @@ export class LauncherBrowserHelperClient {
    */
   private bundledHelperScript(): string | undefined {
     const entrypoint = process.argv[1];
-    if (typeof entrypoint !== "string" || !entrypoint) return undefined;
+    // Only the packaged runtime layout is claimed: the bundle builder emits cli.js and
+    // browser-helper.cjs into one directory. Matching on that entrypoint name keeps a source
+    // checkout, or any other launch shape, on the launcher-advertised helper rather than adopting
+    // an unrelated sibling that merely shares a filename.
+    if (typeof entrypoint !== "string" || basename(entrypoint) !== "cli.js") return undefined;
     const sibling = join(dirname(entrypoint), "browser-helper.cjs");
     return existsSync(sibling) ? sibling : undefined;
   }

--- a/src/adapters/chatgpt-web/launcher-helper-client.ts
+++ b/src/adapters/chatgpt-web/launcher-helper-client.ts
@@ -17,6 +17,7 @@ interface PendingTurn {
   sent?: boolean;
   prepared?: CompiledChatGptWebPrompt & { release: () => void };
   localFailure?: Error;
+  progressForwarding?: AbortController;
 }
 
 type HelperMessage =
@@ -179,6 +180,9 @@ export class LauncherBrowserHelperClient {
         // Setting this before the synchronous write call makes an abort either prevent dispatch or
         // queue an `abort` after the `run` frame; it can never overtake the run frame in the pipe.
         pending.sent = true;
+        const progressForwarding = new AbortController();
+        pending.progressForwarding = progressForwarding;
+        this.forwardProgress(turn, progressForwarding.signal);
         void this.send({
           type: "run",
           id: turn.traceId,
@@ -406,12 +410,37 @@ export class LauncherBrowserHelperClient {
     });
   }
 
+  /**
+   * Mirrors daemon-recorded MCP progress into the helper process for the life of the turn.
+   *
+   * The browser worker runs out of process, so without this the worker sees no external progress
+   * and cancels turns whose tool calls are still completing.
+   */
+  private forwardProgress(turn: BrowserTurn, stop: AbortSignal): void {
+    const progress = turn.externalProgress;
+    if (!progress) return;
+    void (async () => {
+      let revision = 0;
+      while (!stop.aborted) {
+        const snapshot = await progress.waitForChange(revision, stop);
+        revision = snapshot.revision;
+        if (stop.aborted) return;
+        await this.send({ type: "progress", id: turn.traceId, snapshot });
+      }
+    })().catch(() => {
+      // A turn that ends, aborts, or loses its helper stops the mirror; the worker then falls back
+      // to DOM-only health, which is the pre-existing behaviour rather than a new failure mode.
+    });
+  }
+
   private finish(id: string): void {
     const pending = this.pending.get(id);
     if (!pending) return;
     if (pending.abortListener && pending.turn.abortSignal) {
       pending.turn.abortSignal.removeEventListener("abort", pending.abortListener);
     }
+    pending.progressForwarding?.abort();
+    pending.progressForwarding = undefined;
     pending.prepared?.release();
     pending.prepared = undefined;
     this.pending.delete(id);

--- a/src/adapters/chatgpt-web/launcher-helper-client.ts
+++ b/src/adapters/chatgpt-web/launcher-helper-client.ts
@@ -21,7 +21,7 @@ interface PendingTurn {
 }
 
 type HelperMessage =
-  | { type: "ready" }
+  | { type: "ready"; features?: string[] }
   | { type: "event"; id: string; event: "heartbeat" | "send_activated" | "submitted" | "reasoning" | "commentary" | "text"; text?: string; continuation?: boolean }
   | { type: "event"; id: string; event: "prepared_selected"; reused: boolean }
   | { type: "event"; id: string; event: "luna_checkpoint"; checkpoint: ChatGptLunaCheckpoint; answerHash: string }
@@ -43,7 +43,14 @@ function parseHelperMessage(line: string): HelperMessage {
     throw new Error("Launcher browser helper message is not an object");
   }
   const message = value as Record<string, unknown>;
-  if (message.type === "ready") return { type: "ready" };
+  if (message.type === "ready") {
+    const features = message.features;
+    if (features !== undefined
+      && (!Array.isArray(features) || features.some(feature => typeof feature !== "string"))) {
+      throw new Error("Launcher browser helper advertised invalid features");
+    }
+    return { type: "ready", ...(features ? { features: features as string[] } : {}) };
+  }
   if (typeof message.id !== "string" || !message.id) {
     throw new Error("Launcher browser helper message has no turn identity");
   }
@@ -140,6 +147,7 @@ export class LauncherBrowserHelperClient {
   private readyResolve?: () => void;
   private readyReject?: (error: Error) => void;
   private readonly pending = new Map<string, PendingTurn>();
+  private helperFeatures = new Set<string>();
 
   constructor(private readonly config: ResolvedBrowserConfig) {}
 
@@ -311,6 +319,9 @@ export class LauncherBrowserHelperClient {
       return;
     }
     if (message.type === "ready") {
+      // An older helper advertises nothing and must never be sent optional frames: it would route
+      // them to its run handler and destroy the turn with an opaque TypeError.
+      this.helperFeatures = new Set(message.features ?? []);
       this.readyResolve?.();
       this.readyResolve = undefined;
       this.readyReject = undefined;
@@ -419,6 +430,13 @@ export class LauncherBrowserHelperClient {
   private forwardProgress(turn: BrowserTurn, stop: AbortSignal): void {
     const progress = turn.externalProgress;
     if (!progress) return;
+    if (!this.helperFeatures.has("progress")) {
+      console.warn(
+        `[chatgpt-web] browser turn ${turn.traceId} runs without an MCP progress mirror:`
+        + " the launcher browser helper predates the progress frame",
+      );
+      return;
+    }
     void (async () => {
       let revision = 0;
       while (!stop.aborted) {

--- a/src/adapters/chatgpt-web/launcher-helper-client.ts
+++ b/src/adapters/chatgpt-web/launcher-helper-client.ts
@@ -207,7 +207,6 @@ export class LauncherBrowserHelperClient {
         pending.sent = true;
         const progressForwarding = new AbortController();
         pending.progressForwarding = progressForwarding;
-        this.forwardProgress(turn, progressForwarding.signal);
         void this.send({
           type: "run",
           id: turn.traceId,
@@ -231,7 +230,13 @@ export class LauncherBrowserHelperClient {
             ...(turn.compaction ? { compaction: true } : {}),
             ...(turn.captureLunaCheckpoint ? { captureLunaCheckpoint: true } : {}),
           },
-        }).catch(error => this.finishWithError(turn.traceId, error instanceof Error ? error : new Error(String(error))));
+        })
+          // Only mirror once the run frame is on the wire, so the helper never sees progress for a
+          // turn it has not been told about and cannot accumulate state for unknown ids.
+          .then(() => {
+            if (!progressForwarding.signal.aborted) this.forwardProgress(turn, progressForwarding.signal);
+          })
+          .catch(error => this.finishWithError(turn.traceId, error instanceof Error ? error : new Error(String(error))));
       });
   }
 

--- a/src/adapters/chatgpt-web/launcher-helper-client.ts
+++ b/src/adapters/chatgpt-web/launcher-helper-client.ts
@@ -1,4 +1,6 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { createInterface } from "node:readline";
 import { notifyLauncherTurn, readLauncherBrowserHostDescriptor } from "../../launcher-browser-host";
 import { ChatGptWebAdapterError } from "./adapter-error";
@@ -151,6 +153,21 @@ export class LauncherBrowserHelperClient {
 
   constructor(private readonly config: ResolvedBrowserConfig) {}
 
+  /**
+   * The helper that shipped with this daemon, when one sits beside its own entrypoint.
+   *
+   * The launcher advertises the helper inside its application bundle while the daemon runs from a
+   * versioned runtime directory, so the two sides update independently and can disagree about the
+   * protocol. Preferring the sibling keeps daemon and helper on the same build by construction;
+   * anything else — a source checkout, an unbundled entrypoint — falls back to the advertised path.
+   */
+  private bundledHelperScript(): string | undefined {
+    const entrypoint = process.argv[1];
+    if (typeof entrypoint !== "string" || !entrypoint) return undefined;
+    const sibling = join(dirname(entrypoint), "browser-helper.cjs");
+    return existsSync(sibling) ? sibling : undefined;
+  }
+
   async run(turn: BrowserTurn): Promise<string> {
     if (turn.abortSignal?.aborted) throw new DOMException("ChatGPT web turn aborted", "AbortError");
     await this.ensureChild();
@@ -243,7 +260,7 @@ export class LauncherBrowserHelperClient {
     const descriptor = readLauncherBrowserHostDescriptor(this.config.browserHostDescriptorPath!);
     const child = spawn(
       descriptor.helper.executable,
-      [this.config.browserHelperScriptPath ?? descriptor.helper.script],
+      [this.config.browserHelperScriptPath ?? this.bundledHelperScript() ?? descriptor.helper.script],
       {
         env: {
           ...process.env,

--- a/src/adapters/chatgpt-web/launcher-helper-client.ts
+++ b/src/adapters/chatgpt-web/launcher-helper-client.ts
@@ -427,9 +427,15 @@ export class LauncherBrowserHelperClient {
         if (stop.aborted) return;
         await this.send({ type: "progress", id: turn.traceId, snapshot });
       }
-    })().catch(() => {
-      // A turn that ends, aborts, or loses its helper stops the mirror; the worker then falls back
-      // to DOM-only health, which is the pre-existing behaviour rather than a new failure mode.
+    })().catch(error => {
+      // Ending, aborting, or losing the helper stops the mirror by design and is not a fault.
+      // Anything else leaves the worker on DOM-only health without saying so, which is exactly the
+      // silent degradation this transport exists to remove, so it is surfaced rather than dropped.
+      if (stop.aborted || (error instanceof DOMException && error.name === "AbortError")) return;
+      console.warn(
+        `[chatgpt-web] browser turn ${turn.traceId} lost its MCP progress mirror:`
+        + ` ${error instanceof Error ? error.message : String(error)}`,
+      );
     });
   }
 

--- a/src/adapters/chatgpt-web/turn-broker.ts
+++ b/src/adapters/chatgpt-web/turn-broker.ts
@@ -161,6 +161,13 @@ export interface TurnBrokerOwner {
   revoke(token: string, reason?: Error): void | Promise<void>;
 }
 
+/**
+ * Bytes available for a Unix socket path. Linux allows 108, macOS and the BSDs 104; the smaller
+ * bound is used everywhere so a path that works on one developer's machine is not silently
+ * unbindable on another's.
+ */
+const MAX_UNIX_SOCKET_PATH_BYTES = 104;
+
 export class TurnBroker implements TurnBrokerOwner {
   static forSocket(path: string): TurnBroker {
     let broker = brokers.get(path);
@@ -415,7 +422,20 @@ export class TurnBroker implements TurnBrokerOwner {
     if (this.startPromise) return this.startPromise;
     this.startPromise = new Promise<void>((resolveStart, rejectStart) => {
       const windowsPipe = isWindowsPipeEndpoint(this.socketPath);
-      if (!windowsPipe) mkdirSync(dirname(this.socketPath), { recursive: true, mode: 0o700 });
+      if (!windowsPipe) {
+        // sun_path is a fixed-size field in the kernel, so an over-long path fails inside listen()
+        // with nothing but "Failed to listen" and no hint that the length is the problem. Say so.
+        const encodedLength = Buffer.byteLength(this.socketPath);
+        if (encodedLength > MAX_UNIX_SOCKET_PATH_BYTES) {
+          rejectStart(new Error(
+            `ChatGPT web broker socket path is ${encodedLength} bytes, over the`
+            + ` ${MAX_UNIX_SOCKET_PATH_BYTES}-byte limit this platform allows for a Unix socket:`
+            + ` ${this.socketPath}. Choose a shorter runtime directory.`,
+          ));
+          return;
+        }
+        mkdirSync(dirname(this.socketPath), { recursive: true, mode: 0o700 });
+      }
       const listen = () => {
         const server = createServer(socket => this.handleSocket(socket));
         this.server = server;

--- a/src/adapters/chatgpt-web/turn-progress.ts
+++ b/src/adapters/chatgpt-web/turn-progress.ts
@@ -134,6 +134,16 @@ export class ChatGptMirroredTurnProgress extends ChatGptTurnProgressBroadcaster 
   apply(next: ChatGptExternalTurnProgressSnapshot): boolean {
     assertChatGptTurnProgressSnapshot(next);
     if (next.revision <= this.current.revision) return false;
+    // A frame that advances the revision must not contradict what it already reported: the
+    // recorder only ever moves these forward, so a regression means a corrupt or forged frame
+    // rather than an ordering artefact, and accepting it would desynchronise observed liveness.
+    if (next.lastToolBatchRevision < this.current.lastToolBatchRevision
+      || (next.lastProgressAt === undefined && this.current.lastProgressAt !== undefined)
+      || (next.lastProgressAt !== undefined
+        && this.current.lastProgressAt !== undefined
+        && next.lastProgressAt < this.current.lastProgressAt)) {
+      throw new Error("ChatGPT external progress snapshot regressed against the observed state");
+    }
     this.current = { ...next };
     this.notify(this.snapshot());
     return true;
@@ -149,7 +159,10 @@ export function assertChatGptTurnProgressSnapshot(
     || !finiteIndex(value.lastToolBatchRevision)
     || !finiteIndex(value.activeToolCalls)
     || value.lastToolBatchRevision > value.revision
-    || (value.lastProgressAt !== undefined && !Number.isFinite(value.lastProgressAt))) {
+    || (value.lastProgressAt !== undefined && !Number.isFinite(value.lastProgressAt))
+    // Any recorded activity stamps a timestamp, so a frame claiming progress without one is
+    // malformed and would otherwise report liveness the daemon never observed.
+    || (value.revision > 0 && value.lastProgressAt === undefined)) {
     throw new Error("ChatGPT external progress snapshot is invalid");
   }
 }

--- a/src/adapters/chatgpt-web/turn-progress.ts
+++ b/src/adapters/chatgpt-web/turn-progress.ts
@@ -14,18 +14,68 @@ interface ProgressWaiter {
 }
 
 /**
+ * The read surface the browser worker depends on.
+ *
+ * The worker never records progress; it only observes it. Declaring the dependency as this
+ * interface lets the launcher helper process observe a mirrored copy of the daemon's progress
+ * without owning the recording side.
+ */
+export interface ChatGptTurnProgressReader {
+  snapshot(): ChatGptExternalTurnProgressSnapshot;
+  waitForChange(afterRevision: number, signal?: AbortSignal): Promise<ChatGptExternalTurnProgressSnapshot>;
+}
+
+/**
  * Carries only proven Codex MCP activity into the browser worker.
  *
  * It is deliberately not a completion channel: browser-visible text and terminal state remain
  * owned by the ChatGPT DOM. A valid current-turn tool request only proves that submission was
  * accepted and that the model is still making progress while its DOM is temporarily unavailable.
  */
-export class ChatGptExternalTurnProgress {
+abstract class ChatGptTurnProgressBroadcaster implements ChatGptTurnProgressReader {
+  private readonly waiters = new Set<ProgressWaiter>();
+
+  abstract snapshot(): ChatGptExternalTurnProgressSnapshot;
+
+  waitForChange(afterRevision: number, signal?: AbortSignal): Promise<ChatGptExternalTurnProgressSnapshot> {
+    if (!Number.isSafeInteger(afterRevision) || afterRevision < 0) {
+      throw new Error("ChatGPT external progress revision must be a non-negative safe integer");
+    }
+    const current = this.snapshot();
+    if (current.revision > afterRevision) return Promise.resolve(current);
+    if (signal?.aborted) {
+      return Promise.reject(new DOMException("ChatGPT external progress wait aborted", "AbortError"));
+    }
+    return new Promise((resolve, reject) => {
+      const waiter: ProgressWaiter = { afterRevision, resolve, reject, ...(signal ? { signal } : {}) };
+      if (signal) {
+        waiter.onAbort = () => {
+          this.waiters.delete(waiter);
+          reject(new DOMException("ChatGPT external progress wait aborted", "AbortError"));
+        };
+        signal.addEventListener("abort", waiter.onAbort, { once: true });
+      }
+      this.waiters.add(waiter);
+    });
+  }
+
+  protected notify(snapshot: ChatGptExternalTurnProgressSnapshot): void {
+    for (const waiter of [...this.waiters]) {
+      if (snapshot.revision <= waiter.afterRevision) continue;
+      this.waiters.delete(waiter);
+      if (waiter.signal && waiter.onAbort) {
+        waiter.signal.removeEventListener("abort", waiter.onAbort);
+      }
+      waiter.resolve(snapshot);
+    }
+  }
+}
+
+export class ChatGptExternalTurnProgress extends ChatGptTurnProgressBroadcaster {
   private revision = 0;
   private lastToolBatchRevision = 0;
   private activeToolCalls = 0;
   private lastProgressAt?: number;
-  private readonly waiters = new Set<ProgressWaiter>();
 
   snapshot(): ChatGptExternalTurnProgressSnapshot {
     return {
@@ -52,42 +102,55 @@ export class ChatGptExternalTurnProgress {
     this.advance(now, "tool_result");
   }
 
-  waitForChange(afterRevision: number, signal?: AbortSignal): Promise<ChatGptExternalTurnProgressSnapshot> {
-    if (!Number.isSafeInteger(afterRevision) || afterRevision < 0) {
-      throw new Error("ChatGPT external progress revision must be a non-negative safe integer");
-    }
-    const current = this.snapshot();
-    if (current.revision > afterRevision) return Promise.resolve(current);
-    if (signal?.aborted) {
-      return Promise.reject(new DOMException("ChatGPT external progress wait aborted", "AbortError"));
-    }
-    return new Promise((resolve, reject) => {
-      const waiter: ProgressWaiter = { afterRevision, resolve, reject, ...(signal ? { signal } : {}) };
-      if (signal) {
-        waiter.onAbort = () => {
-          this.waiters.delete(waiter);
-          reject(new DOMException("ChatGPT external progress wait aborted", "AbortError"));
-        };
-        signal.addEventListener("abort", waiter.onAbort, { once: true });
-      }
-      this.waiters.add(waiter);
-    });
-  }
-
   private advance(now: number, event: "tool_batch" | "tool_result"): void {
     if (!Number.isFinite(now)) throw new Error("ChatGPT external progress timestamp must be finite");
     this.revision += 1;
     if (event === "tool_batch") this.lastToolBatchRevision = this.revision;
     this.lastProgressAt = now;
-    const snapshot = this.snapshot();
-    for (const waiter of [...this.waiters]) {
-      if (snapshot.revision <= waiter.afterRevision) continue;
-      this.waiters.delete(waiter);
-      if (waiter.signal && waiter.onAbort) {
-        waiter.signal.removeEventListener("abort", waiter.onAbort);
-      }
-      waiter.resolve(snapshot);
-    }
+    this.notify(this.snapshot());
+  }
+}
+
+/**
+ * Replays daemon-recorded progress inside the launcher browser helper process.
+ *
+ * The browser worker runs out of process from the Codex MCP broker, so the recording instance
+ * cannot be shared with it. Without a mirror the worker observes no progress at all and its
+ * liveness guards silently degrade to "never live", which lets a turn be cancelled while its tool
+ * calls are still completing.
+ */
+export class ChatGptMirroredTurnProgress extends ChatGptTurnProgressBroadcaster {
+  private current: ChatGptExternalTurnProgressSnapshot = {
+    revision: 0,
+    lastToolBatchRevision: 0,
+    activeToolCalls: 0,
+  };
+
+  snapshot(): ChatGptExternalTurnProgressSnapshot {
+    return { ...this.current };
+  }
+
+  /** Ignores stale or replayed frames so out-of-order delivery cannot rewind observed liveness. */
+  apply(next: ChatGptExternalTurnProgressSnapshot): boolean {
+    assertChatGptTurnProgressSnapshot(next);
+    if (next.revision <= this.current.revision) return false;
+    this.current = { ...next };
+    this.notify(this.snapshot());
+    return true;
+  }
+}
+
+export function assertChatGptTurnProgressSnapshot(
+  value: ChatGptExternalTurnProgressSnapshot,
+): void {
+  const finiteIndex = (candidate: number): boolean => Number.isSafeInteger(candidate) && candidate >= 0;
+  if (!value
+    || !finiteIndex(value.revision)
+    || !finiteIndex(value.lastToolBatchRevision)
+    || !finiteIndex(value.activeToolCalls)
+    || value.lastToolBatchRevision > value.revision
+    || (value.lastProgressAt !== undefined && !Number.isFinite(value.lastProgressAt))) {
+    throw new Error("ChatGPT external progress snapshot is invalid");
   }
 }
 

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -201,6 +201,11 @@ export function bridgeToResponsesSSE(
 
       const heartbeatFrame = encoder.encode('event: response.heartbeat\ndata: {"type":"response.heartbeat"}\n\n');
       let stallTicks = 0;
+      let stallWarned = false;
+      let lastAdapterEventAt = Date.now();
+      let lastAdapterEventType = "<none>";
+      let adapterEventCount = 0;
+      const streamStartedAt = Date.now();
       const stallSec = resolveStallTimeoutSec(options?.stallTimeoutSec);
       const maxStallTicks = Math.ceil((stallSec * 1000) / heartbeatMs);
 
@@ -417,6 +422,10 @@ export function bridgeToResponsesSSE(
           let terminalEvent = false;
           activity = true;
           stallTicks = 0;
+          lastAdapterEventAt = Date.now();
+          lastAdapterEventType = event.type;
+          adapterEventCount += 1;
+          stallWarned = false;
           reportFirstOutput(event);
           // Compaction turns emit ONLY the synthetic compaction item + response.completed. The
           // summary text is accumulated silently: emitting it as a normal assistant message would
@@ -732,7 +741,25 @@ export function bridgeToResponsesSSE(
         beat = setInterval(() => {
           if (closed || gated) return;
           if (activity) { activity = false; stallTicks = 0; return; }
+          if (stallTicks === Math.ceil(maxStallTicks / 2) && !stallWarned) {
+            // Halfway to cancelling the turn. A healthy adapter heartbeats far more often than
+            // this, so reaching here at all means a keep-alive gap that should be found before it
+            // costs a user their turn.
+            stallWarned = true;
+            console.warn(
+              `[bridge] upstream silence halfway to the stall budget model=${modelId}`
+              + ` response=${responseId} stallSec=${stallSec} adapterEvents=${adapterEventCount}`
+              + ` lastEvent=${lastAdapterEventType} sinceLastEventMs=${Date.now() - lastAdapterEventAt}`,
+            );
+          }
           if (++stallTicks >= maxStallTicks) {
+            console.error(
+              `[bridge] upstream_stall_timeout model=${modelId} response=${responseId}`
+              + ` stallSec=${stallSec} adapterEvents=${adapterEventCount}`
+              + ` lastEvent=${lastAdapterEventType} sinceLastEventMs=${Date.now() - lastAdapterEventAt}`
+              + ` sinceStreamStartMs=${Date.now() - streamStartedAt}`
+              + ` iteratorStarted=${iteratorStarted} upstreamDone=${upstreamDone} emittedFrames=${emittedFrames}`,
+            );
             if (currentMsg) closeCurrentMessage();
             if (currentReasoning) closeCurrentReasoning();
             if (currentRawReasoning) closeCurrentRawReasoning();

--- a/src/native-passthrough.ts
+++ b/src/native-passthrough.ts
@@ -76,6 +76,59 @@ function endToEndHeaders(source: Headers): Headers {
   return headers;
 }
 
+/** Terminator every Responses SSE stream ends with; nothing after it carries meaning. */
+const SSE_TERMINATOR = "data: [DONE]";
+/** Enough trailing bytes to recognise the terminator across a chunk boundary. */
+const SSE_TAIL_WINDOW = 64;
+
+/**
+ * ChatGPT's backend routinely resets the native Codex connection instead of closing it cleanly,
+ * which Bun surfaces as ECONNRESET while reading the body. Passed through untouched that reaches
+ * Codex as a truncated HTTP body and the opaque "error decoding response body".
+ *
+ * A reset that arrives after the stream already delivered `data: [DONE]` is an unclean TCP close on
+ * a turn that finished: every byte the protocol defines has been forwarded, so the stream is closed
+ * normally rather than failed. A reset before that genuinely truncated the turn and is still raised,
+ * because inventing a terminal event there would tell Codex a turn ended when it did not.
+ */
+function withUncleanCloseTolerance(
+  body: ReadableStream<Uint8Array>,
+  isEventStream: boolean,
+  onUncleanClose?: (bytes: number) => void,
+): ReadableStream<Uint8Array> {
+  if (!isEventStream) return body;
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let tail = "";
+  let completed = false;
+  let bytes = 0;
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const chunk = await reader.read();
+        if (chunk.done) {
+          controller.close();
+          return;
+        }
+        bytes += chunk.value.byteLength;
+        tail = (tail + decoder.decode(chunk.value, { stream: true })).slice(-SSE_TAIL_WINDOW);
+        if (tail.includes(SSE_TERMINATOR)) completed = true;
+        controller.enqueue(chunk.value);
+      } catch (error) {
+        if (!completed) {
+          controller.error(error);
+          return;
+        }
+        onUncleanClose?.(bytes);
+        controller.close();
+      }
+    },
+    cancel(reason) {
+      return reader.cancel(reason);
+    },
+  });
+}
+
 export async function forwardNativeCodexRequest(
   request: Request,
   endpoint: NativeCodexEndpoint,
@@ -112,9 +165,21 @@ export async function forwardNativeCodexRequest(
     signal: request.signal,
   });
   const upstream = await fetchUpstream(upstreamRequest);
-  return new Response(upstream.body, {
-    status: upstream.status,
-    statusText: upstream.statusText,
-    headers: endToEndHeaders(upstream.headers),
-  });
+  const responseHeaders = endToEndHeaders(upstream.headers);
+  const isEventStream = (upstream.headers.get("content-type") ?? "").includes("text/event-stream");
+  return new Response(
+    upstream.body
+      ? withUncleanCloseTolerance(upstream.body, isEventStream, bytes => {
+        console.warn(
+          `[codex-chatgpt-web] native_upstream_unclean_close endpoint=${endpoint} bytes=${bytes}`
+          + " (turn had already completed; closing the client stream normally)",
+        );
+      })
+      : upstream.body,
+    {
+      status: upstream.status,
+      statusText: upstream.statusText,
+      headers: responseHeaders,
+    },
+  );
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -485,6 +485,9 @@ export async function responseRequest(
       2_000,
       {
         hideThinkingSummary: parsed.options.hideThinkingSummary,
+        ...(provider.chatgptWeb?.stallTimeoutSec !== undefined
+          ? { stallTimeoutSec: provider.chatgptWeb.stallTimeoutSec }
+          : {}),
         ...(compaction ? { compaction: true } : {
           ...(options.rememberState === false ? {} : {
             onCompletedResponse: (response: Record<string, unknown>) => rememberResponseState(parsed._rawBody, response, { force: true }),

--- a/src/types.ts
+++ b/src/types.ts
@@ -259,6 +259,13 @@ export interface CodexProviderConfig {
     lunaCheckpointStatePath?: string;
     /** Optional explicit safety ceiling. Browser turns have no absolute deadline by default. */
     turnTimeoutMs?: number;
+    /**
+     * Seconds of adapter silence before the Responses bridge cancels a turn as a hung upstream.
+     * The adapter heartbeats every CHATGPT_WEB_ADAPTER_HEARTBEAT_MS for the whole of a turn, so a
+     * healthy turn never approaches this no matter how long it thinks; raise it only to tolerate a
+     * genuinely unresponsive upstream for longer. Defaults to DEFAULT_STALL_TIMEOUT_SEC.
+     */
+    stallTimeoutSec?: number;
     /** Keep the single controlled browser visible. */
     headed?: boolean;
     /** Attach the turn-bound Codex MCP capability for every connector-capable Web model. */

--- a/tests/bridge-stall-timeout.test.ts
+++ b/tests/bridge-stall-timeout.test.ts
@@ -1,0 +1,66 @@
+import { expect, test } from "bun:test";
+import { bridgeToResponsesSSE } from "../src/bridge";
+import { DEFAULT_STALL_TIMEOUT_SEC, resolveStallTimeoutSec } from "../src/stall-timeout";
+import type { AdapterEvent } from "../src/types";
+
+const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
+
+/**
+ * The watchdog exists to end a genuinely hung upstream, and it is the only thing standing between a
+ * slow turn and `upstream_stall_timeout`. Its contract is therefore the reason the chatgpt-web
+ * adapter must heartbeat for the whole of a turn: silence is the only signal the bridge has.
+ */
+function bridged(
+  events: AsyncGenerator<AdapterEvent>,
+  stallTimeoutSec: number,
+  heartbeatMs: number,
+): ReadableStream<Uint8Array> {
+  return bridgeToResponsesSSE(
+    events,
+    "chatgpt-web/test",
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    heartbeatMs,
+    { streamPlatform: "darwin", stallTimeoutSec },
+  );
+}
+
+test("an adapter that goes silent past the budget is cancelled as a hung upstream", async () => {
+  async function* silent(): AsyncGenerator<AdapterEvent> {
+    await sleep(1_500);
+    yield { type: "text_delta", text: "too late" };
+    yield { type: "done", endTurn: true };
+  }
+
+  const body = await new Response(bridged(silent(), 1, 10)).text();
+
+  expect(body).toContain("upstream_stall_timeout");
+  expect(body).not.toContain("too late");
+});
+
+test("an adapter that keeps heartbeating is never cancelled, however long it takes", async () => {
+  async function* thinkingHard(): AsyncGenerator<AdapterEvent> {
+    // Ten times the stall budget elapses, and nothing but keep-alives crosses the boundary.
+    for (let beat = 0; beat < 20; beat++) {
+      await sleep(100);
+      yield { type: "heartbeat" };
+    }
+    yield { type: "text_delta", text: "answer" };
+    yield { type: "done", endTurn: true };
+  }
+
+  const body = await new Response(bridged(thinkingHard(), 0.2, 10)).text();
+
+  expect(body).not.toContain("upstream_stall_timeout");
+  expect(body).toContain("answer");
+  expect(body).toContain("event: response.completed");
+});
+
+test("the stall budget is configurable and falls back to the shipped default", () => {
+  expect(resolveStallTimeoutSec(undefined)).toBe(DEFAULT_STALL_TIMEOUT_SEC);
+  expect(resolveStallTimeoutSec(Number.NaN)).toBe(DEFAULT_STALL_TIMEOUT_SEC);
+  expect(resolveStallTimeoutSec(900)).toBe(900);
+  expect(resolveStallTimeoutSec(0)).toBe(1);
+});

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import type { Page } from "playwright-core";
-import { CHATGPT_BROWSER_OBSERVATION_PROBE_TIMEOUT_MS, CHATGPT_EXTERNAL_PROGRESS_CLOCK_SKEW_MS, CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS, ChatGptCompletionTracker, chatGptExternalProgressSuppressesDomHealth, CHATGPT_RESPONSE_DOM_GRACE_MS, MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS, CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_STOPPED_THINKING_GRACE_MS, ChatGptBrowserObservationTimeoutError, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_PAGE_REBINDS, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, assertChatGptWebMultipartInputWithinLimits, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptConnectorAttachmentMode, chatGptEffortSelectionRequired, chatGptNewTurnIdentity, chatGptReboundTurnIdentity, chatGptSubmissionEvidence, dismissChatGptTemporaryChatOnboarding, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, resolveChatGptWebMultipartStagingMode, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert, withChatGptBrowserObservationTimeout } from "../src/adapters/chatgpt-web/browser-worker";
+import { CHATGPT_BROWSER_OBSERVATION_PROBE_TIMEOUT_MS, CHATGPT_EXTERNAL_PROGRESS_CLOCK_SKEW_MS, CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS, ChatGptCompletionTracker, chatGptExternalProgressSuppressesDomHealth, CHATGPT_RESPONSE_DOM_GRACE_MS, MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS, MAX_CHATGPT_MULTIPART_STAGE_ATTEMPTS, CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_STOPPED_THINKING_GRACE_MS, ChatGptBrowserObservationTimeoutError, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_PAGE_REBINDS, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, assertChatGptWebMultipartInputWithinLimits, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptConnectorAttachmentMode, chatGptEffortSelectionRequired, chatGptNewTurnIdentity, chatGptReboundTurnIdentity, chatGptSubmissionEvidence, dismissChatGptTemporaryChatOnboarding, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, resolveChatGptWebMultipartStagingMode, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert, withChatGptBrowserObservationTimeout } from "../src/adapters/chatgpt-web/browser-worker";
 import { chatGptStoppedThinkingError } from "../src/adapters/chatgpt-web/adapter-error";
 import { CHATGPT_WEB_MODEL_ID } from "../src/adapters/chatgpt-web/model";
 import { CHATGPT_CONNECTOR_NAME, DEV_CHATGPT_CONNECTOR_NAME, defaultChromeExecutable, legacyChatGptConnectorMigrationMessage } from "../src/config";
@@ -2451,4 +2451,20 @@ test("the bundled helper is adopted only for the packaged runtime layout", () =>
   const tryStart = worker.indexOf("       try {\n        observedThisIteration = false;");
   expect(heartbeat).toBeGreaterThan(0);
   expect(heartbeat).toBeLessThan(tryStart);
+});
+
+test("a Bigger Context stage that ChatGPT stops on is restaged instead of failing the turn", () => {
+  const worker = readFileSync("src/adapters/chatgpt-web/browser-worker.ts", "utf8");
+
+  // A stage carries inert transport keyed by transaction id, part index, and payload hash, so
+  // re-sending one is idempotent in a way a real prompt never is. ChatGPT answering a staging
+  // prompt with "Stopped thinking" previously destroyed an accepted turn that is never resent.
+  expect(MAX_CHATGPT_MULTIPART_STAGE_ATTEMPTS).toBeGreaterThan(1);
+  expect(worker).toMatch(/attempt >= MAX_CHATGPT_MULTIPART_STAGE_ATTEMPTS\) throw error;/);
+  expect(worker).toContain('error.code === "client_cancelled"');
+  expect(worker).toContain("restaging multipart part");
+  expect(worker).toMatch(/multipart-stage-\$\{index \+ 1\}-restaged/);
+
+  // Only the stop condition is retried; every other stage failure still fails immediately.
+  expect(worker).toContain("if (!stageStopped || attempt >= MAX_CHATGPT_MULTIPART_STAGE_ATTEMPTS) throw error;");
 });

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -1,12 +1,13 @@
 import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import type { Page } from "playwright-core";
-import { CHATGPT_BROWSER_OBSERVATION_PROBE_TIMEOUT_MS, CHATGPT_EXTERNAL_PROGRESS_CLOCK_SKEW_MS, CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS, ChatGptCompletionTracker, chatGptExternalProgressSuppressesDomHealth, CHATGPT_RESPONSE_DOM_GRACE_MS, MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS, MAX_CHATGPT_MULTIPART_STAGE_ATTEMPTS, CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_STOPPED_THINKING_GRACE_MS, ChatGptBrowserObservationTimeoutError, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_PAGE_REBINDS, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, assertChatGptWebMultipartInputWithinLimits, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptConnectorAttachmentMode, chatGptEffortSelectionRequired, chatGptNewTurnIdentity, chatGptReboundTurnIdentity, chatGptSubmissionEvidence, dismissChatGptTemporaryChatOnboarding, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, resolveChatGptWebMultipartStagingMode, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert, withChatGptBrowserObservationTimeout, CHATGPT_MULTIPART_RESPONSE_DOM_GRACE_MS, browserStageTimeouts } from "../src/adapters/chatgpt-web/browser-worker";
+import { CHATGPT_BROWSER_OBSERVATION_PROBE_TIMEOUT_MS, CHATGPT_EXTERNAL_PROGRESS_CLOCK_SKEW_MS, CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS, ChatGptCompletionTracker, chatGptExternalProgressSuppressesDomHealth, CHATGPT_RESPONSE_DOM_GRACE_MS, MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS, MAX_CHATGPT_MULTIPART_STAGE_ATTEMPTS, CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_STOPPED_THINKING_GRACE_MS, ChatGptBrowserObservationTimeoutError, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_PAGE_REBINDS, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, assertChatGptWebMultipartInputWithinLimits, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptConnectorAttachmentMode, chatGptEffortSelectionRequired, chatGptNewTurnIdentity, chatGptReboundTurnIdentity, chatGptSubmissionEvidence, dismissChatGptTemporaryChatOnboarding, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, resolveChatGptWebMultipartStagingMode, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert, withChatGptBrowserObservationTimeout, CHATGPT_MULTIPART_RESPONSE_DOM_GRACE_MS, browserStageTimeouts, ChatGptSuspensionClock, remainingStageBudgetMs } from "../src/adapters/chatgpt-web/browser-worker";
 import { chatGptStoppedThinkingError } from "../src/adapters/chatgpt-web/adapter-error";
 import { CHATGPT_WEB_MODEL_ID } from "../src/adapters/chatgpt-web/model";
 import { CHATGPT_CONNECTOR_NAME, DEV_CHATGPT_CONNECTOR_NAME, defaultChromeExecutable, legacyChatGptConnectorMigrationMessage } from "../src/config";
 import { parseChatGptEffortSliderState } from "../src/chatgpt-session";
 import { ChatGptExternalTurnProgress } from "../src/adapters/chatgpt-web/turn-progress";
+import type { CodexProviderConfig } from "../src/types";
 
 function personalizedTemporaryChatRole(
   _role: string,
@@ -2501,3 +2502,62 @@ test("a staged Bigger Context part gets an acknowledgement window sized to its p
   // It is the same budget the staged send already gets; the two bound the same oversized exchange.
   expect(CHATGPT_MULTIPART_RESPONSE_DOM_GRACE_MS).toBe(browserStageTimeouts.multipartStageSend);
 });
+
+test("the suspension clock charges only tick gaps that mean the process was frozen", () => {
+  const clock = new ChatGptSuspensionClock(1_000, 5_000);
+  clock.tick(1_000);
+  clock.tick(2_000);
+  clock.tick(3_100);
+  expect(clock.suspendedMs()).toBe(0);
+
+  // Fifteen minutes without a tick is a sleep; the ordinary interval is refunded from the charge.
+  clock.tick(3_100 + 15 * 60_000);
+  expect(clock.suspendedMs()).toBe(15 * 60_000 - 1_000);
+});
+
+test("remaining stage budget refunds slept time and stands once the awake budget is spent", () => {
+  expect(remainingStageBudgetMs(120_000, 901_000, 890_000)).toBe(109_000);
+  expect(remainingStageBudgetMs(120_000, 120_000, 0)).toBe(0);
+  expect(remainingStageBudgetMs(120_000, 901_000, 0)).toBe(0);
+  expect(remainingStageBudgetMs(200, 210, 50)).toBe(250);
+});
+
+test("a stage that spans a system sleep is not charged for the slept time", async () => {
+  // The live failure: effort_selection ran 901s against a 120s budget because the Mac slept
+  // 14 minutes of it, and the stage died on DarkWake. Here the fake clock reports a sleep longer
+  // than the whole budget, so the first timer firing must re-arm instead of failing.
+  const provider: CodexProviderConfig = {
+    adapter: "chatgpt-web",
+    baseUrl: `browser://suspension-stage-${Date.now()}`,
+    chatgptWeb: { localToolsEnabled: false, solAvailable: true, proAvailable: true },
+  };
+  const worker = ChatGptBrowserWorker.forProvider(provider) as unknown as {
+    runStage<T>(
+      traceId: string,
+      stage: string,
+      timeoutMs: number,
+      action: (signal: AbortSignal) => Promise<T>,
+      clock?: { suspendedMs(): number },
+    ): Promise<T>;
+  };
+
+  let suspended = 0;
+  const clock = { suspendedMs: () => suspended };
+  const outcome: string[] = [];
+  const stage = worker.runStage(
+    "suspension-test",
+    "probe",
+    200,
+    () => new Promise<never>(() => {}),
+    clock,
+  ).catch(error => { outcome.push((error as Error).message); });
+
+  // The sleep is discovered when the first timer fires: 300ms slept against a 200ms budget.
+  suspended = 300;
+  await Bun.sleep(320);
+  expect(outcome).toEqual([]);
+
+  // No further sleep: the re-armed timer now expires on genuinely awake time.
+  await stage;
+  expect(outcome).toEqual(["ChatGPT browser stage timed out: probe"]);
+}, 10_000);

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import type { Page } from "playwright-core";
-import { CHATGPT_BROWSER_OBSERVATION_PROBE_TIMEOUT_MS, CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS, chatGptExternalProgressSuppressesDomHealth, CHATGPT_RESPONSE_DOM_GRACE_MS, MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS, CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_STOPPED_THINKING_GRACE_MS, ChatGptBrowserObservationTimeoutError, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_PAGE_REBINDS, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, assertChatGptWebMultipartInputWithinLimits, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptConnectorAttachmentMode, chatGptEffortSelectionRequired, chatGptNewTurnIdentity, chatGptReboundTurnIdentity, chatGptSubmissionEvidence, dismissChatGptTemporaryChatOnboarding, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, resolveChatGptWebMultipartStagingMode, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert, withChatGptBrowserObservationTimeout } from "../src/adapters/chatgpt-web/browser-worker";
+import { CHATGPT_BROWSER_OBSERVATION_PROBE_TIMEOUT_MS, CHATGPT_EXTERNAL_PROGRESS_CLOCK_SKEW_MS, CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS, ChatGptCompletionTracker, chatGptExternalProgressSuppressesDomHealth, CHATGPT_RESPONSE_DOM_GRACE_MS, MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS, CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_STOPPED_THINKING_GRACE_MS, ChatGptBrowserObservationTimeoutError, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_PAGE_REBINDS, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, assertChatGptWebMultipartInputWithinLimits, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptConnectorAttachmentMode, chatGptEffortSelectionRequired, chatGptNewTurnIdentity, chatGptReboundTurnIdentity, chatGptSubmissionEvidence, dismissChatGptTemporaryChatOnboarding, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, resolveChatGptWebMultipartStagingMode, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert, withChatGptBrowserObservationTimeout } from "../src/adapters/chatgpt-web/browser-worker";
 import { chatGptStoppedThinkingError } from "../src/adapters/chatgpt-web/adapter-error";
 import { CHATGPT_WEB_MODEL_ID } from "../src/adapters/chatgpt-web/model";
 import { CHATGPT_CONNECTOR_NAME, DEV_CHATGPT_CONNECTOR_NAME, defaultChromeExecutable, legacyChatGptConnectorMigrationMessage } from "../src/config";
@@ -2393,4 +2393,62 @@ test("the shipped commentary classifier separates answer Markdown from reasoning
 
   // A turn with no status container at all is entirely answer.
   expect(answerFor('<div class="markdown">ONLY ANSWER</div>')).toBe("ONLY ANSWER");
+});
+
+test("proven MCP progress vetoes completion, not only the health verdicts", () => {
+  const tracker = new ChatGptCompletionTracker(500);
+  const finishedLooking = {
+    responsePresent: true,
+    running: false,
+    currentText: "partial answer so far",
+    currentHtml: "<p>partial answer so far</p>",
+    completionActionVisible: true,
+  };
+
+  // Between two tool calls the rendered message can look finished. Completing there returns a
+  // truncated answer and retires the turn while its own tool calls are still in flight.
+  expect(tracker.update({ ...finishedLooking, externalProgressLive: true }, 1_000)).toBeFalse();
+  expect(tracker.update({ ...finishedLooking, externalProgressLive: true }, 5_000)).toBeFalse();
+
+  // Once the model is genuinely idle the settle window starts fresh rather than completing at once.
+  expect(tracker.update(finishedLooking, 5_100)).toBeFalse();
+  expect(tracker.update(finishedLooking, 5_599)).toBeFalse();
+  expect(tracker.update(finishedLooking, 5_600)).toBeTrue();
+});
+
+test("a future progress timestamp is not treated as liveness", () => {
+  const base = { revision: 2, lastToolBatchRevision: 2, activeToolCalls: 1 };
+
+  // "now - lastProgressAt < ceiling" is satisfied by any future timestamp, which would have kept a
+  // stuck tool call suppressing DOM health forever.
+  expect(chatGptExternalProgressSuppressesDomHealth(
+    { ...base, lastProgressAt: 10_000 + CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS * 10 },
+    10_000,
+  )).toBeFalse();
+
+  // Modest skew between the recording daemon and the observing helper is still accepted.
+  expect(chatGptExternalProgressSuppressesDomHealth(
+    { ...base, lastProgressAt: 10_000 + CHATGPT_EXTERNAL_PROGRESS_CLOCK_SKEW_MS - 1 },
+    10_000,
+  )).toBeTrue();
+});
+
+test("the bundled helper is adopted only for the packaged runtime layout", () => {
+  const client = readFileSync("src/adapters/chatgpt-web/launcher-helper-client.ts", "utf8");
+
+  // Any daemon launched some other way keeps the launcher-advertised helper rather than adopting
+  // an unrelated sibling that merely shares a filename.
+  expect(client).toContain('basename(entrypoint) !== "cli.js"');
+
+  // Trace ids are derived deterministically and can repeat, so a run must not inherit revisions
+  // recorded for an earlier turn that happened to share the id.
+  const helper = readFileSync("src/adapters/chatgpt-web/browser-helper-main.ts", "utf8");
+  expect(helper).toContain("const progress = new ChatGptMirroredTurnProgress();");
+
+  // A consumer callback must not be retried as though the page could not be read.
+  const worker = readFileSync("src/adapters/chatgpt-web/browser-worker.ts", "utf8");
+  const heartbeat = worker.indexOf("turn.onHeartbeat?.();");
+  const tryStart = worker.indexOf("       try {\n        observedThisIteration = false;");
+  expect(heartbeat).toBeGreaterThan(0);
+  expect(heartbeat).toBeLessThan(tryStart);
 });

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -2468,3 +2468,19 @@ test("a Bigger Context stage that ChatGPT stops on is restaged instead of failin
   // Only the stop condition is retried; every other stage failure still fails immediately.
   expect(worker).toContain("if (!stageStopped || attempt >= MAX_CHATGPT_MULTIPART_STAGE_ATTEMPTS) throw error;");
 });
+
+test("Bigger Context stage sends get a budget sized for their payload", () => {
+  const worker = readFileSync("src/adapters/chatgpt-web/browser-worker.ts", "utf8");
+
+  // The send stage covers ChatGPT accepting the submission, not just the click. A stage posts a
+  // payload orders of magnitude larger than an ordinary prompt onto a conversation that already
+  // holds the earlier parts, and the ordinary budget expired mid-acceptance and killed the turn.
+  expect(worker).toContain("multipartStageSend: 180_000");
+  expect(worker).toContain("browserStageTimeouts.multipartStageSend,");
+
+  // The multipart commit lands on a conversation already carrying every staged part.
+  expect(worker).toContain("prepared.multipart ? browserStageTimeouts.multipartStageSend : browserStageTimeouts.send,");
+
+  // The ordinary send budget is unchanged for ordinary prompts.
+  expect(worker).toContain("send: 20_000,");
+});

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import type { Page } from "playwright-core";
-import { CHATGPT_BROWSER_OBSERVATION_PROBE_TIMEOUT_MS, CHATGPT_EXTERNAL_PROGRESS_CLOCK_SKEW_MS, CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS, ChatGptCompletionTracker, chatGptExternalProgressSuppressesDomHealth, CHATGPT_RESPONSE_DOM_GRACE_MS, MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS, MAX_CHATGPT_MULTIPART_STAGE_ATTEMPTS, CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_STOPPED_THINKING_GRACE_MS, ChatGptBrowserObservationTimeoutError, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_PAGE_REBINDS, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, assertChatGptWebMultipartInputWithinLimits, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptConnectorAttachmentMode, chatGptEffortSelectionRequired, chatGptNewTurnIdentity, chatGptReboundTurnIdentity, chatGptSubmissionEvidence, dismissChatGptTemporaryChatOnboarding, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, resolveChatGptWebMultipartStagingMode, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert, withChatGptBrowserObservationTimeout } from "../src/adapters/chatgpt-web/browser-worker";
+import { CHATGPT_BROWSER_OBSERVATION_PROBE_TIMEOUT_MS, CHATGPT_EXTERNAL_PROGRESS_CLOCK_SKEW_MS, CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS, ChatGptCompletionTracker, chatGptExternalProgressSuppressesDomHealth, CHATGPT_RESPONSE_DOM_GRACE_MS, MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS, MAX_CHATGPT_MULTIPART_STAGE_ATTEMPTS, CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_STOPPED_THINKING_GRACE_MS, ChatGptBrowserObservationTimeoutError, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_PAGE_REBINDS, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, assertChatGptWebMultipartInputWithinLimits, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptConnectorAttachmentMode, chatGptEffortSelectionRequired, chatGptNewTurnIdentity, chatGptReboundTurnIdentity, chatGptSubmissionEvidence, dismissChatGptTemporaryChatOnboarding, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, resolveChatGptWebMultipartStagingMode, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert, withChatGptBrowserObservationTimeout, CHATGPT_MULTIPART_RESPONSE_DOM_GRACE_MS, browserStageTimeouts } from "../src/adapters/chatgpt-web/browser-worker";
 import { chatGptStoppedThinkingError } from "../src/adapters/chatgpt-web/adapter-error";
 import { CHATGPT_WEB_MODEL_ID } from "../src/adapters/chatgpt-web/model";
 import { CHATGPT_CONNECTOR_NAME, DEV_CHATGPT_CONNECTOR_NAME, defaultChromeExecutable, legacyChatGptConnectorMigrationMessage } from "../src/config";
@@ -2483,4 +2483,21 @@ test("Bigger Context stage sends get a budget sized for their payload", () => {
 
   // The ordinary send budget is unchanged for ordinary prompts.
   expect(worker).toContain("send: 20_000,");
+});
+
+test("a staged Bigger Context part gets an acknowledgement window sized to its payload", () => {
+  // A staged part is two orders of magnitude larger than an ordinary prompt and ChatGPT reads all of
+  // it before answering. On this machine the same payload acknowledged at 19s and at 30s, and once
+  // took over 72s — which the ordinary grace turned into "ChatGPT accepted the message but did not
+  // expose its assistant turn in the DOM", losing an accepted turn that was merely slow.
+  expect(CHATGPT_MULTIPART_RESPONSE_DOM_GRACE_MS).toBeGreaterThan(CHATGPT_RESPONSE_DOM_GRACE_MS);
+
+  // No MCP activity exists yet while a part is being ingested, so nothing else can vouch for the
+  // turn: this window is the only thing between a slow ingest and a cancellation. Keep a wide margin
+  // over the slowest acknowledgement actually observed.
+  const slowestObservedAcknowledgementMs = 72_000;
+  expect(CHATGPT_MULTIPART_RESPONSE_DOM_GRACE_MS).toBeGreaterThan(slowestObservedAcknowledgementMs * 2);
+
+  // It is the same budget the staged send already gets; the two bound the same oversized exchange.
+  expect(CHATGPT_MULTIPART_RESPONSE_DOM_GRACE_MS).toBe(browserStageTimeouts.multipartStageSend);
 });

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -1898,7 +1898,8 @@ test("response DOM separates streaming commentary from the final Markdown answer
   expect(workerSource).toContain("const commentaryRoots = allMarkdownRoots.filter");
   expect(workerSource).toContain('candidate.closest("[data-streaming-response-status]") !== null');
   expect(workerSource).toContain("const streamingStatusContainers = [...root.querySelectorAll<HTMLElement>");
-  expect(workerSource).toContain("candidate.compareDocumentPosition(status) & Node.DOCUMENT_POSITION_FOLLOWING");
+  expect(workerSource).toContain("const firstStreamingStatusContainer = streamingStatusContainers[0]");
+  expect(workerSource).toContain("candidate.compareDocumentPosition(firstStreamingStatusContainer)");
   expect(workerSource).toContain("const renderedRoots = allMarkdownRoots.filter");
   expect(workerSource).toContain("!commentaryRoots.includes(candidate)");
   expect(workerSource).toContain('fullHtml: renderedRoots.map(candidate => candidate.innerHTML).join("")');
@@ -2239,4 +2240,17 @@ test("live external progress still records that a response DOM was observed", ()
   // The turn is reported as vanished rather than never created, so `sawResponse` survived.
   expect(tracker.update(absent, 2_000)).toBeUndefined();
   expect(tracker.update(absent, 3_000)).toContain("response DOM disappeared");
+});
+
+test("answer Markdown is not reclassified as commentary when a later tool call opens a status container", () => {
+  const worker = readFileSync("src/adapters/chatgpt-web/browser-worker.ts", "utf8");
+
+  // Commentary is Markdown that precedes the FIRST streaming status container. Keying it on "some
+  // status follows me" made every answer chunk emitted before a second tool call look like prior
+  // commentary, which zeroed the visible text and silently dropped answer content.
+  expect(worker).toContain("const firstStreamingStatusContainer = streamingStatusContainers[0]");
+  expect(worker).toMatch(/candidate\.compareDocumentPosition\(firstStreamingStatusContainer\)/);
+  expect(worker).not.toMatch(
+    /streamingStatusContainers\.some\(status => \(\s*Boolean\(candidate\.compareDocumentPosition\(status\)/,
+  );
 });

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -1895,13 +1895,13 @@ test("response DOM separates streaming commentary from the final Markdown answer
   expect(workerSource).toContain("if (options.knownKey === observerKey) return { key: observerKey }");
   expect(workerSource).toContain("new MutationObserver(() =>");
   expect(workerSource).toContain('const allMarkdownRoots = [...root.querySelectorAll<HTMLElement>(".markdown")]');
-  expect(workerSource).toContain("const commentaryRoots = allMarkdownRoots.filter");
+  expect(workerSource).toContain("const selectChatGptAnswerRoots = (");
   expect(workerSource).toContain('candidate.closest("[data-streaming-response-status]") !== null');
   expect(workerSource).toContain("const streamingStatusContainers = [...root.querySelectorAll<HTMLElement>");
-  expect(workerSource).toContain("const firstStreamingStatusContainer = streamingStatusContainers[0]");
-  expect(workerSource).toContain("candidate.compareDocumentPosition(firstStreamingStatusContainer)");
-  expect(workerSource).toContain("const renderedRoots = allMarkdownRoots.filter");
-  expect(workerSource).toContain("!commentaryRoots.includes(candidate)");
+  expect(workerSource).toContain("const firstStatusContainer = statusContainers[0]");
+  expect(workerSource).toContain("candidate.compareDocumentPosition(firstStatusContainer)");
+  expect(workerSource).toContain("const renderedRoots = classified.answerRoots;");
+  expect(workerSource).toContain("markdownRoots.filter(candidate => !commentary.includes(candidate))");
   expect(workerSource).toContain('fullHtml: renderedRoots.map(candidate => candidate.innerHTML).join("")');
   expect(workerSource).toContain("const flattenedMarkdownSegments:");
   expect(workerSource).toContain("Root boundaries and visible indices therefore are not identity");
@@ -2240,19 +2240,6 @@ test("live external progress still records that a response DOM was observed", ()
   expect(tracker.update(absent, 3_000)).toContain("response DOM disappeared");
 });
 
-test("answer Markdown is not reclassified as commentary when a later tool call opens a status container", () => {
-  const worker = readFileSync("src/adapters/chatgpt-web/browser-worker.ts", "utf8");
-
-  // Commentary is Markdown that precedes the FIRST streaming status container. Keying it on "some
-  // status follows me" made every answer chunk emitted before a second tool call look like prior
-  // commentary, which zeroed the visible text and silently dropped answer content.
-  expect(worker).toContain("const firstStreamingStatusContainer = streamingStatusContainers[0]");
-  expect(worker).toMatch(/candidate\.compareDocumentPosition\(firstStreamingStatusContainer\)/);
-  expect(worker).not.toMatch(
-    /streamingStatusContainers\.some\(status => \(\s*Boolean\(candidate\.compareDocumentPosition\(status\)/,
-  );
-});
-
 test("an accepted turn survives internal observation faults instead of being torn down", () => {
   const worker = readFileSync("src/adapters/chatgpt-web/browser-worker.ts", "utf8");
 
@@ -2337,4 +2324,73 @@ test("proven progress forgets a Stopped thinking window rather than merely ignor
   expect(tracker.update(true, 6_500)).toBeFalse();
   expect(tracker.update(true, 11_499)).toBeFalse();
   expect(tracker.update(true, 11_500)).toBeTrue();
+});
+
+test("the shipped commentary classifier separates answer Markdown from reasoning in a real DOM", () => {
+  // The classifier runs inside page.evaluate, so it cannot be imported. Extract and execute the
+  // exact shipped source instead of a copy, which is what lets this test detect a regression in
+  // the code that actually runs rather than in a restatement of it.
+  // domino ships without module typings; it is already present as a turndown dependency and is
+  // the only DOM implementation available to this suite.
+  const { createDocument } = require("@mixmark-io/domino") as {
+    createDocument: (html: string) => {
+      body: { querySelectorAll: (selector: string) => ArrayLike<HTMLElement> };
+    };
+  };
+  const worker = readFileSync("src/adapters/chatgpt-web/browser-worker.ts", "utf8");
+  const source = worker.split("// CHATGPT_COMMENTARY_CLASSIFIER_BEGIN")[1]?.split("// CHATGPT_COMMENTARY_CLASSIFIER_END")[0];
+  if (!source) throw new Error("commentary classifier sentinels are missing from browser-worker.ts");
+  const javascript = source
+    .replace(/:\s*HTMLElement\[\]/g, "")
+    .replace(/\):\s*\{[^}]*\}\s*=>/, ") =>");
+  const selectChatGptAnswerRoots = new Function(
+    `${javascript}; return selectChatGptAnswerRoots;`,
+  )() as (roots: unknown[], statuses: unknown[]) => { answerRoots: Array<{ textContent: string }> };
+
+  const answerFor = (html: string): string => {
+    const document = createDocument(`<body>${html}</body>`);
+    // domino's NodeList is array-like rather than iterable.
+    const roots = Array.from(document.body.querySelectorAll(".markdown"))
+      .filter(candidate => !candidate.parentElement?.closest(".markdown"));
+    const statuses = Array.from(document.body.querySelectorAll("[data-streaming-response-status]"));
+    return selectChatGptAnswerRoots(roots, statuses).answerRoots
+      .map(root => (root.textContent ?? "").trim())
+      .filter(Boolean)
+      .join(" | ");
+  };
+
+  // Commentary that precedes the live status, and commentary nested inside one, stay excluded.
+  expect(answerFor(
+    '<div class="markdown">COMMENTARY</div>'
+    + '<div data-streaming-response-status>live</div>'
+    + '<div class="markdown">ANSWER</div>',
+  )).toBe("ANSWER");
+  expect(answerFor(
+    '<div data-streaming-response-status><div class="markdown">NESTED</div></div>'
+    + '<div class="markdown">ANSWER</div>',
+  )).toBe("ANSWER");
+
+  // Reasoning rendered inside a chain-of-thought component is commentary wherever it sits.
+  expect(answerFor(
+    '<div data-streaming-response-status>s1</div>'
+    + '<div data-testid="cot-v5-block"><div class="markdown">THINKING</div></div>'
+    + '<div class="markdown">ANSWER</div>',
+  )).toBe("ANSWER");
+
+  // The regressions this rule exists for: a second tool call opening a status container below
+  // already-emitted answer text used to blank the visible text and drop answer chunks entirely.
+  expect(answerFor(
+    '<div data-streaming-response-status>s1</div>'
+    + '<div class="markdown">ANSWER</div>'
+    + '<div data-streaming-response-status>s2</div>',
+  )).toBe("ANSWER");
+  expect(answerFor(
+    '<div data-streaming-response-status>s1</div>'
+    + '<div class="markdown">PART ONE</div>'
+    + '<div data-streaming-response-status>s2</div>'
+    + '<div class="markdown">PART TWO</div>',
+  )).toBe("PART ONE | PART TWO");
+
+  // A turn with no status container at all is entirely answer.
+  expect(answerFor('<div class="markdown">ONLY ANSWER</div>')).toBe("ONLY ANSWER");
 });

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import type { Page } from "playwright-core";
-import { CHATGPT_BROWSER_OBSERVATION_PROBE_TIMEOUT_MS, CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_STOPPED_THINKING_GRACE_MS, ChatGptBrowserObservationTimeoutError, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_PAGE_REBINDS, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, assertChatGptWebMultipartInputWithinLimits, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptConnectorAttachmentMode, chatGptEffortSelectionRequired, chatGptNewTurnIdentity, chatGptReboundTurnIdentity, chatGptSubmissionEvidence, dismissChatGptTemporaryChatOnboarding, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, resolveChatGptWebMultipartStagingMode, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert, withChatGptBrowserObservationTimeout } from "../src/adapters/chatgpt-web/browser-worker";
+import { CHATGPT_BROWSER_OBSERVATION_PROBE_TIMEOUT_MS, CHATGPT_EXTERNAL_PROGRESS_SUPPRESSION_CEILING_MS, CHATGPT_RESPONSE_DOM_GRACE_MS, MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS, CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_STOPPED_THINKING_GRACE_MS, ChatGptBrowserObservationTimeoutError, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_PAGE_REBINDS, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, assertChatGptWebMultipartInputWithinLimits, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptConnectorAttachmentMode, chatGptEffortSelectionRequired, chatGptNewTurnIdentity, chatGptReboundTurnIdentity, chatGptSubmissionEvidence, dismissChatGptTemporaryChatOnboarding, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, resolveChatGptWebMultipartStagingMode, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert, withChatGptBrowserObservationTimeout } from "../src/adapters/chatgpt-web/browser-worker";
 import { chatGptStoppedThinkingError } from "../src/adapters/chatgpt-web/adapter-error";
 import { CHATGPT_WEB_MODEL_ID } from "../src/adapters/chatgpt-web/model";
 import { CHATGPT_CONNECTOR_NAME, DEV_CHATGPT_CONNECTOR_NAME, defaultChromeExecutable, legacyChatGptConnectorMigrationMessage } from "../src/config";
@@ -2253,4 +2253,23 @@ test("answer Markdown is not reclassified as commentary when a later tool call o
   expect(worker).not.toMatch(
     /streamingStatusContainers\.some\(status => \(\s*Boolean\(candidate\.compareDocumentPosition\(status\)/,
   );
+});
+
+test("an accepted turn survives internal observation faults instead of being torn down", () => {
+  const worker = readFileSync("src/adapters/chatgpt-web/browser-worker.ts", "utf8");
+
+  // A TypeError while reading the page is a defect in this worker, not evidence about ChatGPT.
+  // Failing the turn on one loses an accepted ChatGPT turn that is never resent.
+  expect(MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS).toBeGreaterThan(1);
+  expect(worker).toContain("if (!(error instanceof TypeError)) throw error;");
+  expect(worker).toContain("internalObservationFaults = 0;");
+  expect(worker).toMatch(/internalObservationFaults > MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS/);
+
+  // Liveness may postpone a verdict but never waive it, so a tool call that never returns cannot
+  // hold an undeadlined turn open forever.
+  expect(worker).toMatch(/Date\.now\(\) - sentAt < CHATGPT_EXTERNAL_PROGRESS_SUPPRESSION_CEILING_MS/);
+  expect(CHATGPT_EXTERNAL_PROGRESS_SUPPRESSION_CEILING_MS).toBeGreaterThan(CHATGPT_RESPONSE_DOM_GRACE_MS);
+
+  // Chain-of-thought containment is commentary regardless of document position.
+  expect(worker).toContain('candidate.closest(\'[data-testid^="cot-v5"]\') !== null');
 });

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -2180,11 +2180,9 @@ test("the launcher helper transport carries MCP progress into the out-of-process
 
 test("turn cancellation heuristics defer to proven MCP progress in both wait loops", () => {
   const worker = readFileSync("src/adapters/chatgpt-web/browser-worker.ts", "utf8");
-  const guarded = worker.match(/stoppedThinkingTracker\.update\([^)]*\)\s*&&\s*!externalProgressLive/g) ?? [];
-
   // A stale "Stopped thinking" label must not cancel a turn that is still driving tool calls, and
   // the multipart staging loop must not be the one place that skips the liveness guard.
-  expect(guarded.length).toBe(2);
+  expect((worker.match(/stoppedThinkingTracker\.clear\(\)/g) ?? []).length).toBe(2);
   expect((worker.match(/domHealthTracker\.clearMissingResponse\(\)/g) ?? []).length).toBe(2);
 });
 
@@ -2261,7 +2259,7 @@ test("an accepted turn survives internal observation faults instead of being tor
   // A TypeError while reading the page is a defect in this worker, not evidence about ChatGPT.
   // Failing the turn on one loses an accepted ChatGPT turn that is never resent.
   expect(MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS).toBeGreaterThan(1);
-  expect(worker).toContain("if (!(error instanceof TypeError)) throw error;");
+  expect(worker).toContain("if (!(error instanceof TypeError) || observedThisIteration) throw error;");
   expect(worker).toContain("internalObservationFaults = 0;");
   expect(worker).toMatch(/internalObservationFaults > MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS/);
 
@@ -2323,4 +2321,20 @@ test("the daemon prefers the browser helper that shipped beside its own entrypoi
 
   // A malformed liveness hint must not destroy an accepted turn that can never be resent.
   expect(helper).toContain("discarded an invalid MCP progress frame");
+});
+
+
+test("proven progress forgets a Stopped thinking window rather than merely ignoring it", () => {
+  const tracker = new ChatGptStoppedThinkingTracker(5_000);
+
+  // The label appears while a tool call is outstanding. Suppressing only the verdict let this
+  // window keep accruing, so the first observation after the tool result cancelled the turn.
+  expect(tracker.update(true, 1_000)).toBeFalse();
+  expect(tracker.update(true, 3_000)).toBeFalse();
+  tracker.clear();
+
+  // Progress has ended and the window starts again from here, not from the original sighting.
+  expect(tracker.update(true, 6_500)).toBeFalse();
+  expect(tracker.update(true, 11_499)).toBeFalse();
+  expect(tracker.update(true, 11_500)).toBeTrue();
 });

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -2186,3 +2186,57 @@ test("turn cancellation heuristics defer to proven MCP progress in both wait loo
   expect(guarded.length).toBe(2);
   expect((worker.match(/domHealthTracker\.clearMissingResponse\(\)/g) ?? []).length).toBe(2);
 });
+
+test("proven MCP progress vetoes every terminal DOM conclusion, not just a missing response", () => {
+  // Reproduces trace 970896e96e84: the response DOM is present and the renderer never exposes a
+  // completed-turn action, yet tool calls keep completing. "Stopped generating" is false there.
+  const stalled = new ChatGptTurnDomHealthTracker(1_000, 500, 750);
+  const answeredWithoutCompletionAction = {
+    responsePresent: true,
+    running: false,
+    currentText: "partial answer",
+    completionActionVisible: false,
+  };
+
+  expect(stalled.update({ ...answeredWithoutCompletionAction, externalProgressLive: true }, 1_000)).toBeUndefined();
+  expect(stalled.update({ ...answeredWithoutCompletionAction, externalProgressLive: true }, 10_000)).toBeUndefined();
+
+  // Once the model genuinely stops, the window starts fresh rather than charging the live stretch.
+  expect(stalled.update(answeredWithoutCompletionAction, 10_100)).toBeUndefined();
+  expect(stalled.update(answeredWithoutCompletionAction, 10_849)).toBeUndefined();
+  expect(stalled.update(answeredWithoutCompletionAction, 10_850)).toContain("did not expose its completed-turn action");
+
+  const empty = new ChatGptTurnDomHealthTracker(1_000, 500, 750);
+  const completedEmpty = {
+    responsePresent: true,
+    running: false,
+    currentText: "",
+    completionActionVisible: true,
+  };
+  expect(empty.update({ ...completedEmpty, externalProgressLive: true }, 1_000)).toBeUndefined();
+  expect(empty.update({ ...completedEmpty, externalProgressLive: true }, 9_000)).toBeUndefined();
+  expect(empty.update(completedEmpty, 9_100)).toBeUndefined();
+  expect(empty.update(completedEmpty, 9_600)).toContain("completed without a final answer");
+});
+
+test("live external progress still records that a response DOM was observed", () => {
+  const tracker = new ChatGptTurnDomHealthTracker(1_000, 500);
+  const absent = {
+    responsePresent: false,
+    running: true,
+    currentText: "",
+    completionActionVisible: false,
+  };
+
+  expect(tracker.update({
+    responsePresent: true,
+    running: true,
+    currentText: "",
+    completionActionVisible: false,
+    externalProgressLive: true,
+  }, 1_000)).toBeUndefined();
+
+  // The turn is reported as vanished rather than never created, so `sawResponse` survived.
+  expect(tracker.update(absent, 2_000)).toBeUndefined();
+  expect(tracker.update(absent, 3_000)).toContain("response DOM disappeared");
+});

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -2303,3 +2303,24 @@ test("stale MCP progress stops suppressing DOM health without penalising long ac
     1_000,
   )).toBeFalse();
 });
+
+test("the daemon prefers the browser helper that shipped beside its own entrypoint", () => {
+  const client = readFileSync("src/adapters/chatgpt-web/launcher-helper-client.ts", "utf8");
+  const helper = readFileSync("src/adapters/chatgpt-web/browser-helper-main.ts", "utf8");
+
+  // The launcher advertises the helper inside its signed application bundle while the daemon runs
+  // from a versioned runtime directory, so the two update independently. A daemon that spoke a
+  // newer protocol to an older helper had its frame routed to the run handler, which dereferenced
+  // a turn the frame never carried and destroyed the turn with an opaque TypeError.
+  expect(client).toContain("bundledHelperScript()");
+  expect(client).toMatch(/browserHelperScriptPath \?\? this\.bundledHelperScript\(\) \?\? descriptor\.helper\.script/);
+
+  // Belt and braces: negotiate the frame, and never treat an unrecognised frame as a run.
+  expect(client).toContain('this.helperFeatures.has("progress")');
+  expect(helper).toContain('features: ["progress"]');
+  expect(helper).toMatch(/message\.type === "run"/);
+  expect(helper).toContain("Browser helper received an unsupported message type");
+
+  // A malformed liveness hint must not destroy an accepted turn that can never be resent.
+  expect(helper).toContain("discarded an invalid MCP progress frame");
+});

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -2124,3 +2124,65 @@ test("visible reasoning keeps the browser turn healthy before final assistant ma
   expect(health.update(reasoning, 1_000)).toBeUndefined();
   expect(health.update(reasoning, 10_000)).toBeUndefined();
 });
+
+test("suspending DOM health for proven MCP progress restarts the missing-response window", () => {
+  const tracker = new ChatGptTurnDomHealthTracker(1_000, 500);
+  const absent = {
+    responsePresent: false,
+    running: true,
+    currentText: "",
+    completionActionVisible: false,
+  };
+
+  // The response DOM is unavailable from the first observation, so the window opens here.
+  expect(tracker.update(absent, 1_000)).toBeUndefined();
+
+  // Proven tool-call activity suspends the check. Charging that suspended stretch against the
+  // grace period is what let a live turn be cancelled the moment liveness lapsed.
+  tracker.clearMissingResponse();
+
+  expect(tracker.update(absent, 10_000)).toBeUndefined();
+  expect(tracker.update(absent, 10_999)).toBeUndefined();
+  expect(tracker.update(absent, 11_000)).toContain("did not create a response DOM");
+});
+
+test("clearing the missing-response window preserves whether a response was ever observed", () => {
+  const tracker = new ChatGptTurnDomHealthTracker(1_000, 500);
+  const present = {
+    responsePresent: true,
+    running: true,
+    currentText: "partial",
+    completionActionVisible: false,
+  };
+  const absent = { ...present, responsePresent: false, currentText: "" };
+
+  expect(tracker.update(present, 1_000)).toBeUndefined();
+  expect(tracker.update(absent, 1_500)).toBeUndefined();
+  tracker.clearMissingResponse();
+  expect(tracker.update(absent, 5_000)).toBeUndefined();
+  expect(tracker.update(absent, 6_000)).toContain("response DOM disappeared");
+});
+
+test("the launcher helper transport carries MCP progress into the out-of-process browser worker", () => {
+  const client = readFileSync("src/adapters/chatgpt-web/launcher-helper-client.ts", "utf8");
+  const helper = readFileSync("src/adapters/chatgpt-web/browser-helper-main.ts", "utf8");
+
+  // The browser worker runs in the helper process while the Codex MCP broker runs in the daemon.
+  // If progress stops crossing that boundary the worker silently observes "never live" and cancels
+  // turns whose tool calls are still completing, so both ends of the transport are asserted here.
+  expect(client).toContain("forwardProgress");
+  expect(client).toMatch(/type: "progress", id: turn\.traceId, snapshot/);
+  expect(helper).toMatch(/message\.type === "progress"/);
+  expect(helper).toContain("ChatGptMirroredTurnProgress");
+  expect(helper).toMatch(/externalProgress: progress/);
+});
+
+test("turn cancellation heuristics defer to proven MCP progress in both wait loops", () => {
+  const worker = readFileSync("src/adapters/chatgpt-web/browser-worker.ts", "utf8");
+  const guarded = worker.match(/stoppedThinkingTracker\.update\([^)]*\)\s*&&\s*!externalProgressLive/g) ?? [];
+
+  // A stale "Stopped thinking" label must not cancel a turn that is still driving tool calls, and
+  // the multipart staging loop must not be the one place that skips the liveness guard.
+  expect(guarded.length).toBe(2);
+  expect((worker.match(/domHealthTracker\.clearMissingResponse\(\)/g) ?? []).length).toBe(2);
+});

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import type { Page } from "playwright-core";
-import { CHATGPT_BROWSER_OBSERVATION_PROBE_TIMEOUT_MS, CHATGPT_EXTERNAL_PROGRESS_SUPPRESSION_CEILING_MS, CHATGPT_RESPONSE_DOM_GRACE_MS, MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS, CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_STOPPED_THINKING_GRACE_MS, ChatGptBrowserObservationTimeoutError, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_PAGE_REBINDS, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, assertChatGptWebMultipartInputWithinLimits, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptConnectorAttachmentMode, chatGptEffortSelectionRequired, chatGptNewTurnIdentity, chatGptReboundTurnIdentity, chatGptSubmissionEvidence, dismissChatGptTemporaryChatOnboarding, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, resolveChatGptWebMultipartStagingMode, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert, withChatGptBrowserObservationTimeout } from "../src/adapters/chatgpt-web/browser-worker";
+import { CHATGPT_BROWSER_OBSERVATION_PROBE_TIMEOUT_MS, CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS, chatGptExternalProgressSuppressesDomHealth, CHATGPT_RESPONSE_DOM_GRACE_MS, MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS, CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_STOPPED_THINKING_GRACE_MS, ChatGptBrowserObservationTimeoutError, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_PAGE_REBINDS, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, assertChatGptWebMultipartInputWithinLimits, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptConnectorAttachmentMode, chatGptEffortSelectionRequired, chatGptNewTurnIdentity, chatGptReboundTurnIdentity, chatGptSubmissionEvidence, dismissChatGptTemporaryChatOnboarding, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, resolveChatGptWebMultipartStagingMode, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert, withChatGptBrowserObservationTimeout } from "../src/adapters/chatgpt-web/browser-worker";
 import { chatGptStoppedThinkingError } from "../src/adapters/chatgpt-web/adapter-error";
 import { CHATGPT_WEB_MODEL_ID } from "../src/adapters/chatgpt-web/model";
 import { CHATGPT_CONNECTOR_NAME, DEV_CHATGPT_CONNECTOR_NAME, defaultChromeExecutable, legacyChatGptConnectorMigrationMessage } from "../src/config";
@@ -2267,9 +2267,39 @@ test("an accepted turn survives internal observation faults instead of being tor
 
   // Liveness may postpone a verdict but never waive it, so a tool call that never returns cannot
   // hold an undeadlined turn open forever.
-  expect(worker).toMatch(/Date\.now\(\) - sentAt < CHATGPT_EXTERNAL_PROGRESS_SUPPRESSION_CEILING_MS/);
-  expect(CHATGPT_EXTERNAL_PROGRESS_SUPPRESSION_CEILING_MS).toBeGreaterThan(CHATGPT_RESPONSE_DOM_GRACE_MS);
+  expect(CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS).toBeGreaterThan(CHATGPT_RESPONSE_DOM_GRACE_MS);
 
   // Chain-of-thought containment is commentary regardless of document position.
   expect(worker).toContain('candidate.closest(\'[data-testid^="cot-v5"]\') !== null');
+});
+
+test("stale MCP progress stops suppressing DOM health without penalising long active turns", () => {
+  const outstanding = { revision: 2, lastToolBatchRevision: 2, activeToolCalls: 1, lastProgressAt: 1_000 };
+
+  // An outstanding call reports liveness regardless of age, so age is bounded separately: a tool
+  // that never returns must not hold a turn open forever, since turns carry no deadline by default.
+  expect(chatGptExternalProgressSuppressesDomHealth(outstanding, 1_000)).toBeTrue();
+  expect(chatGptExternalProgressSuppressesDomHealth(
+    outstanding,
+    1_000 + CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS - 1,
+  )).toBeTrue();
+  expect(chatGptExternalProgressSuppressesDomHealth(
+    outstanding,
+    1_000 + CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS,
+  )).toBeFalse();
+
+  // A turn that keeps calling tools stays suppressed no matter how long it has been running, so
+  // the bound is silence since the last activity rather than total turn duration.
+  const hoursIn = 4 * 60 * 60_000;
+  expect(chatGptExternalProgressSuppressesDomHealth(
+    { ...outstanding, lastProgressAt: hoursIn },
+    hoursIn + 1_000,
+  )).toBeTrue();
+
+  // No recorded activity is never evidence.
+  expect(chatGptExternalProgressSuppressesDomHealth(undefined, 1_000)).toBeFalse();
+  expect(chatGptExternalProgressSuppressesDomHealth(
+    { revision: 0, lastToolBatchRevision: 0, activeToolCalls: 0 },
+    1_000,
+  )).toBeFalse();
 });

--- a/tests/chatgpt-web-harness.test.ts
+++ b/tests/chatgpt-web-harness.test.ts
@@ -11,7 +11,7 @@ import { ChatGptCompletionTracker, chatGptImageFilePayloads, chatGptPromptFilePa
 import { ChatGptBrowserWorker, type BrowserTurn } from "../src/adapters/chatgpt-web/browser-worker";
 import { chatGptConversationKey } from "../src/adapters/chatgpt-web/conversation-key";
 import { CHATGPT_TURN_REVISION_CONFLICT_MESSAGE, extractChatGptTurnEnvironment, extractChatGptTurnIdentity, extractChatGptTurnUserRevision } from "../src/adapters/chatgpt-web/environment";
-import { chatGptWebExecutionNamespace, chatGptWebTraceId, createChatGptWebAdapter } from "../src/adapters/chatgpt-web/index";
+import { CHATGPT_WEB_ADAPTER_HEARTBEAT_MS, chatGptWebExecutionNamespace, chatGptWebTraceId, createChatGptWebAdapter } from "../src/adapters/chatgpt-web/index";
 import { chatGptHtmlToMarkdown, ChatGptMarkdownBuffer } from "../src/adapters/chatgpt-web/markdown";
 import { CHATGPT_WEB_MODEL_ID } from "../src/adapters/chatgpt-web/model";
 import {
@@ -2909,4 +2909,117 @@ test("an interrupted turn's abort notice is not mistaken for the next turn's ins
   });
   expect(() => extractChatGptTurnUserRevision(steered))
     .toThrow(CHATGPT_TURN_REVISION_CONFLICT_MESSAGE);
+});
+
+describe("adapter liveness covers every path through a turn", () => {
+  // The Responses bridge cancels a turn after DEFAULT_STALL_TIMEOUT_SEC without a single adapter
+  // event (bridge.ts, `upstream_stall_timeout`). Any window inside runTurn that awaits without
+  // emitting is therefore a turn the user loses, and the waits that run before a session exists
+  // — the structured compaction handoff and the owner-retirement wait — used to be exactly that.
+  function livenessRequest(turnId: string, threadId: string, compaction: boolean): CodexParsedRequest {
+    const request = parsed();
+    if (compaction) request._compactionRequest = true;
+    request._rawBody = {
+      prompt_cache_key: threadId,
+      client_metadata: { "x-codex-turn-metadata": JSON.stringify({ thread_id: threadId, turn_id: turnId }) },
+      input: [
+        {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: environmentXml }],
+          internal_chat_message_metadata_passthrough: { turn_id: turnId },
+        },
+        {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "Inspect the project" }],
+          internal_chat_message_metadata_passthrough: { turn_id: turnId },
+        },
+      ],
+    };
+    return request;
+  }
+
+  async function observeLiveness(
+    label: string,
+    observeMs: number,
+    drive: (
+      provider: CodexProviderConfig,
+      run: (request: CodexParsedRequest, emit: (event: AdapterEvent) => void, signal: AbortSignal) => Promise<void>,
+    ) => Promise<{ heartbeats: number[]; stop: () => void }>,
+  ): Promise<number[]> {
+    const provider: CodexProviderConfig = {
+      adapter: "chatgpt-web",
+      baseUrl: `browser://liveness-${label}-${Date.now()}`,
+      chatgptWeb: { localToolsEnabled: false, solAvailable: true, proAvailable: true },
+    };
+    const worker = ChatGptBrowserWorker.forProvider(provider);
+    const originalRun = worker.run.bind(worker);
+    (worker as unknown as { run: (turn: BrowserTurn) => Promise<string> }).run = () => new Promise<string>(() => {});
+    try {
+      const run = async (
+        request: CodexParsedRequest,
+        emit: (event: AdapterEvent) => void,
+        signal: AbortSignal,
+      ) => {
+        await createChatGptWebAdapter(provider).runTurn!(request, { headers: new Headers(), abortSignal: signal }, emit);
+      };
+      const { heartbeats, stop } = await drive(provider, run);
+      await Bun.sleep(observeMs);
+      stop();
+      return heartbeats;
+    } finally {
+      (worker as unknown as { run: (turn: BrowserTurn) => Promise<string> }).run = originalRun;
+    }
+  }
+
+  test("a turn blocked waiting for the previous owner to retire still proves it is alive", async () => {
+    const started = Date.now();
+    const heartbeats = await observeLiveness(
+      "owner-retirement",
+      CHATGPT_WEB_ADAPTER_HEARTBEAT_MS + 2_000,
+      async (_provider, run) => {
+        const holder = new AbortController();
+        const blocked = new AbortController();
+        const beats: number[] = [];
+        // The first turn owns the thread and never physically settles, so the second turn parks in
+        // getOrCreateAfterOwnerRetirement before any session — and before any per-session wiring —
+        // exists to speak for it.
+        void run(livenessRequest("turn_live_1", "thread_live", false), () => {}, holder.signal).catch(() => {});
+        await Bun.sleep(250);
+        void run(
+          livenessRequest("turn_live_2", "thread_live", false),
+          event => { if (event.type === "heartbeat") beats.push(Date.now() - started); },
+          blocked.signal,
+        ).catch(() => {});
+        return { heartbeats: beats, stop: () => { blocked.abort(); holder.abort(); } };
+      },
+    );
+
+    expect(heartbeats.length).toBeGreaterThanOrEqual(2);
+    // One on entry, before the wait is even reached, then the armed interval.
+    expect(heartbeats[0]).toBeLessThan(2_000);
+    expect(heartbeats.at(-1)).toBeGreaterThanOrEqual(CHATGPT_WEB_ADAPTER_HEARTBEAT_MS);
+  }, 40_000);
+
+  test("a compaction turn proves it is alive while the summarizing browser turn runs", async () => {
+    const started = Date.now();
+    const heartbeats = await observeLiveness(
+      "compaction",
+      CHATGPT_WEB_ADAPTER_HEARTBEAT_MS + 2_000,
+      async (_provider, run) => {
+        const abort = new AbortController();
+        const beats: number[] = [];
+        void run(
+          livenessRequest("turn_compact_1", "thread_compact", true),
+          event => { if (event.type === "heartbeat") beats.push(Date.now() - started); },
+          abort.signal,
+        ).catch(() => {});
+        return { heartbeats: beats, stop: () => abort.abort() };
+      },
+    );
+
+    expect(heartbeats.length).toBeGreaterThanOrEqual(2);
+    expect(heartbeats.at(-1)).toBeGreaterThanOrEqual(CHATGPT_WEB_ADAPTER_HEARTBEAT_MS);
+  }, 40_000);
 });

--- a/tests/chatgpt-web-harness.test.ts
+++ b/tests/chatgpt-web-harness.test.ts
@@ -10,7 +10,7 @@ import { ChatGptWebAdapterError } from "../src/adapters/chatgpt-web/adapter-erro
 import { ChatGptCompletionTracker, chatGptImageFilePayloads, chatGptPromptFilePayloads, chatGptTurnIsComplete } from "../src/adapters/chatgpt-web/browser-worker";
 import { ChatGptBrowserWorker, type BrowserTurn } from "../src/adapters/chatgpt-web/browser-worker";
 import { chatGptConversationKey } from "../src/adapters/chatgpt-web/conversation-key";
-import { extractChatGptTurnEnvironment, extractChatGptTurnIdentity } from "../src/adapters/chatgpt-web/environment";
+import { CHATGPT_TURN_REVISION_CONFLICT_MESSAGE, extractChatGptTurnEnvironment, extractChatGptTurnIdentity, extractChatGptTurnUserRevision } from "../src/adapters/chatgpt-web/environment";
 import { chatGptWebExecutionNamespace, chatGptWebTraceId, createChatGptWebAdapter } from "../src/adapters/chatgpt-web/index";
 import { chatGptHtmlToMarkdown, ChatGptMarkdownBuffer } from "../src/adapters/chatgpt-web/markdown";
 import { CHATGPT_WEB_MODEL_ID } from "../src/adapters/chatgpt-web/model";
@@ -2877,4 +2877,36 @@ test("mirrored progress rejects frames that regress against the observed state",
   expect(mirror.snapshot()).toEqual({
     revision: 3, lastToolBatchRevision: 3, activeToolCalls: 1, lastProgressAt: 5_000,
   });
+});
+
+test("an interrupted turn's abort notice is not mistaken for the next turn's instruction", () => {
+  // Reproduces a real failure: the user stopped a turn, Codex appended <turn_aborted> carrying the
+  // interrupted turn's id, and the next turn read that notice as its own user revision. The ids
+  // disagreed and every following turn failed with a turn_id conflict.
+  const request = rawWireRequest(environmentXml);
+  const abortedNotice = "<turn_aborted>\nThe user interrupted the previous turn on purpose."
+    + " Any running unified exec processes may still be running in the background."
+    + "\n</turn_aborted>";
+  ((request._rawBody as { input: unknown[] }).input).push({
+    type: "message",
+    role: "user",
+    content: [{ type: "input_text", text: abortedNotice }],
+    internal_chat_message_metadata_passthrough: { turn_id: "turn_test_interrupted" },
+  });
+
+  // The instruction actually owned by this turn is still the human one that precedes the notice.
+  expect(extractChatGptTurnUserRevision(request)).toEqual([
+    { type: "input_text", text: "Inspect the project" },
+  ]);
+
+  // A genuine steering message from a foreign turn must still be rejected.
+  const steered = structuredClone(request);
+  ((steered._rawBody as { input: unknown[] }).input).push({
+    type: "message",
+    role: "user",
+    content: [{ type: "input_text", text: "Actually, stop and summarise instead" }],
+    internal_chat_message_metadata_passthrough: { turn_id: "turn_test_other" },
+  });
+  expect(() => extractChatGptTurnUserRevision(steered))
+    .toThrow(CHATGPT_TURN_REVISION_CONFLICT_MESSAGE);
 });

--- a/tests/chatgpt-web-harness.test.ts
+++ b/tests/chatgpt-web-harness.test.ts
@@ -2855,3 +2855,26 @@ test("mirrored turn progress wakes waiters exactly like the recording instance",
     lastProgressAt: 7_000,
   });
 });
+
+test("mirrored progress rejects frames that regress against the observed state", async () => {
+  const mirror = new ChatGptMirroredTurnProgress();
+  mirror.apply({ revision: 3, lastToolBatchRevision: 3, activeToolCalls: 1, lastProgressAt: 5_000 });
+
+  // Higher revision but contradicting what it already reported: a corrupt or forged frame, not an
+  // ordering artefact, and accepting it would desynchronise observed liveness.
+  expect(() => mirror.apply({
+    revision: 4, lastToolBatchRevision: 2, activeToolCalls: 1, lastProgressAt: 6_000,
+  })).toThrow("regressed against the observed state");
+  expect(() => mirror.apply({
+    revision: 4, lastToolBatchRevision: 3, activeToolCalls: 1, lastProgressAt: 4_000,
+  })).toThrow("regressed against the observed state");
+
+  // Recorded activity always stamps a timestamp, so a progress frame without one is malformed.
+  expect(() => mirror.apply({
+    revision: 5, lastToolBatchRevision: 3, activeToolCalls: 0,
+  })).toThrow("snapshot is invalid");
+
+  expect(mirror.snapshot()).toEqual({
+    revision: 3, lastToolBatchRevision: 3, activeToolCalls: 1, lastProgressAt: 5_000,
+  });
+});

--- a/tests/chatgpt-web-harness.test.ts
+++ b/tests/chatgpt-web-harness.test.ts
@@ -21,7 +21,7 @@ import { chatGptReadOnlyContextWarning, compileChatGptWebPrompt, withoutSupersed
 import { MAX_CHATGPT_WEB_TURN_RETRIES } from "../src/adapters/chatgpt-web/retry-policy";
 import { ChatGptTextFeed, ChatGptTraceFeed, ChatGptTurnSessions, chatGptCompactionSourceExecutionKey, chatGptThreadOwnershipKey, chatGptTurnExecutionKey, chatGptTurnSessions } from "../src/adapters/chatgpt-web/turn-execution";
 import { callTurnBroker, TurnBroker, type BrokerToolResult } from "../src/adapters/chatgpt-web/turn-broker";
-import { ChatGptExternalTurnProgress, chatGptExternalProgressIsLive } from "../src/adapters/chatgpt-web/turn-progress";
+import { ChatGptExternalTurnProgress, ChatGptMirroredTurnProgress, chatGptExternalProgressIsLive } from "../src/adapters/chatgpt-web/turn-progress";
 import { CHATGPT_WEB_MCP_INVOCATION_TIMEOUT_MS, chatGptMcpInvocationTimeout } from "../src/adapters/chatgpt-web/mcp-server";
 import { defaultBrokerEndpoint } from "../src/config";
 import { estimateChatGptWebUsage } from "../src/adapters/chatgpt-web/usage";
@@ -2798,4 +2798,60 @@ describe("ChatGPT outer-native harness v4", () => {
       await broker.close();
     }
   }, 10_000);
+});
+
+test("mirrored turn progress carries daemon MCP activity into the browser helper process", async () => {
+  const daemon = new ChatGptExternalTurnProgress();
+  const mirror = new ChatGptMirroredTurnProgress();
+
+  // A helper process with no mirrored progress reports "not live", which is exactly what let the
+  // DOM grace cancel turns whose tool calls were still completing.
+  expect(chatGptExternalProgressIsLive(mirror.snapshot(), 1_000, 60_000)).toBeFalse();
+
+  daemon.recordToolBatch(1, 1_000);
+  expect(mirror.apply(daemon.snapshot())).toBeTrue();
+  expect(chatGptExternalProgressIsLive(mirror.snapshot(), 30_000, 60_000)).toBeTrue();
+
+  daemon.recordToolResult(2_000);
+  expect(mirror.apply(daemon.snapshot())).toBeTrue();
+  expect(mirror.snapshot()).toEqual({
+    revision: 2,
+    lastToolBatchRevision: 1,
+    activeToolCalls: 0,
+    lastProgressAt: 2_000,
+  });
+
+  // Liveness still expires on the mirrored timestamp once the model genuinely stops working.
+  expect(chatGptExternalProgressIsLive(mirror.snapshot(), 61_999, 60_000)).toBeTrue();
+  expect(chatGptExternalProgressIsLive(mirror.snapshot(), 62_000, 60_000)).toBeFalse();
+});
+
+test("mirrored turn progress ignores replayed frames and rejects malformed ones", async () => {
+  const mirror = new ChatGptMirroredTurnProgress();
+  const first = { revision: 4, lastToolBatchRevision: 3, activeToolCalls: 1, lastProgressAt: 5_000 };
+
+  expect(mirror.apply(first)).toBeTrue();
+  expect(mirror.apply(first)).toBeFalse();
+  expect(mirror.apply({
+    revision: 2,
+    lastToolBatchRevision: 2,
+    activeToolCalls: 1,
+    lastProgressAt: 1_000,
+  })).toBeFalse();
+  expect(mirror.snapshot().lastProgressAt).toBe(5_000);
+
+  expect(() => mirror.apply({ ...first, revision: -1 })).toThrow("snapshot is invalid");
+  expect(() => mirror.apply({ ...first, revision: 5, lastToolBatchRevision: 9 })).toThrow("snapshot is invalid");
+});
+
+test("mirrored turn progress wakes waiters exactly like the recording instance", async () => {
+  const mirror = new ChatGptMirroredTurnProgress();
+  const changed = mirror.waitForChange(0);
+  mirror.apply({ revision: 1, lastToolBatchRevision: 1, activeToolCalls: 2, lastProgressAt: 7_000 });
+  expect(await changed).toEqual({
+    revision: 1,
+    lastToolBatchRevision: 1,
+    activeToolCalls: 2,
+    lastProgressAt: 7_000,
+  });
 });

--- a/tests/composer-insert.test.ts
+++ b/tests/composer-insert.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, expect, test } from "bun:test";
+import { insertPlainTextIntoComposer } from "../src/adapters/chatgpt-web/browser-worker";
+
+/**
+ * The composer insert runs inside the page, where the caret state is whatever the last UI
+ * interaction left behind. Effort selection closes a menu immediately before a staged part is
+ * attached, so these fixtures model the focus and selection states that actually occur there.
+ */
+interface FakeSelection {
+  isCollapsed: boolean;
+  anchorNode: object | null;
+  removeAllRanges(): void;
+  addRange(range: object): void;
+}
+
+const originals = { document: globalThis.document, window: globalThis.window };
+afterEach(() => {
+  (globalThis as Record<string, unknown>).document = originals.document;
+  (globalThis as Record<string, unknown>).window = originals.window;
+});
+
+function harness(options: {
+  focusable: boolean;
+  caretInsideComposer: boolean;
+  collapsed?: boolean;
+  execCommandResult?: boolean;
+}) {
+  const inside = { name: "text-node-inside-composer" };
+  const composer = {
+    focus() { if (options.focusable) fakeDocument.activeElement = composer; },
+    contains: (node: object | null) => node === inside || node === composer,
+  };
+  const calls: Array<{ command: string; value: string }> = [];
+  const selection: FakeSelection = {
+    isCollapsed: options.collapsed ?? true,
+    anchorNode: options.caretInsideComposer ? inside : { name: "node-in-the-effort-menu" },
+    removeAllRanges() { selection.anchorNode = null; },
+    addRange() { selection.anchorNode = inside; selection.isCollapsed = true; },
+  };
+  const fakeDocument = {
+    activeElement: null as unknown,
+    createRange: () => ({ selectNodeContents() {}, collapse() {} }),
+    execCommand(command: string, _ui: boolean, value: string) {
+      calls.push({ command, value });
+      return options.execCommandResult ?? true;
+    },
+  };
+  (globalThis as Record<string, unknown>).document = fakeDocument;
+  (globalThis as Record<string, unknown>).window = { getSelection: () => selection };
+  return { composer: composer as unknown as HTMLElement, calls, selection, fakeDocument };
+}
+
+test("places the caret itself when focus has not yet produced one in the composer", () => {
+  // The exact state left behind a tenth of a second after the effort menu closes.
+  const { composer, calls, selection } = harness({ focusable: true, caretInsideComposer: false });
+
+  expect(insertPlainTextIntoComposer(composer, "staged part")).toBeTrue();
+  expect(calls).toEqual([{ command: "insertText", value: "staged part" }]);
+  expect(selection.isCollapsed).toBeTrue();
+});
+
+test("leaves an existing caret inside the composer exactly where it is", () => {
+  const { composer, calls, selection } = harness({ focusable: true, caretInsideComposer: true });
+  const anchorBefore = selection.anchorNode;
+
+  expect(insertPlainTextIntoComposer(composer, "second part")).toBeTrue();
+  expect(selection.anchorNode).toBe(anchorBefore);
+  expect(calls).toEqual([{ command: "insertText", value: "second part" }]);
+});
+
+test("refuses to insert when the composer cannot take focus at all", () => {
+  // A covered or detached composer must still fail rather than have text typed somewhere else.
+  const { composer, calls } = harness({ focusable: false, caretInsideComposer: false });
+
+  expect(insertPlainTextIntoComposer(composer, "staged part")).toBeFalse();
+  expect(calls).toEqual([]);
+});
+
+test("reports a genuinely rejected edit as a failure", () => {
+  const { composer } = harness({
+    focusable: true,
+    caretInsideComposer: true,
+    execCommandResult: false,
+  });
+
+  expect(insertPlainTextIntoComposer(composer, "staged part")).toBeFalse();
+});

--- a/tests/native-passthrough.test.ts
+++ b/tests/native-passthrough.test.ts
@@ -223,3 +223,75 @@ test("forwards native model discovery as GET and preserves the client version qu
   expect(upstreamRequest!.method).toBe("GET");
   expect(upstreamRequest!.headers.get("if-none-match")).toBeNull();
 });
+
+/**
+ * ChatGPT's backend resets the native Codex connection instead of closing it, which Codex reports as
+ * "Transport error: network error: error decoding response body". Whether that is recoverable turns
+ * entirely on whether the turn had already finished when the socket died.
+ */
+function nativeRequest(): Request {
+  return new Request("http://127.0.0.1:17841/v1/responses", {
+    method: "POST",
+    headers: { authorization: "Bearer codex-oauth-token", "content-type": "application/json" },
+    body: '{"model":"gpt-5.6-sol","stream":true}',
+  });
+}
+
+function resettingEventStream(prefix: string[]): Response {
+  // A real socket delivers its frames and only then dies, so the chunks must be pulled out before
+  // the error lands; erroring in start() would discard them and test nothing.
+  const encoder = new TextEncoder();
+  let sent = 0;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (sent < prefix.length) {
+        controller.enqueue(encoder.encode(prefix[sent]!));
+        sent += 1;
+        return;
+      }
+      const reset = new Error("The socket connection was closed unexpectedly");
+      (reset as Error & { code?: string }).code = "ECONNRESET";
+      controller.error(reset);
+    },
+  });
+  return new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } });
+}
+
+test("an upstream reset after the turn completed closes the client stream normally", async () => {
+  const response = await forwardNativeCodexRequest(
+    nativeRequest(),
+    "responses",
+    async () => resettingEventStream([
+      'event: response.completed\ndata: {"type":"response.completed"}\n\n',
+      "data: [DONE]\n\n",
+    ]),
+  );
+
+  // Every byte the Responses protocol defines was forwarded, so the reset is an unclean TCP close on
+  // a finished turn. Failing here is what produced the decode error Codex reported.
+  const body = await response.text();
+  expect(body).toContain("response.completed");
+  expect(body).toEndWith("data: [DONE]\n\n");
+});
+
+test("an upstream reset that truncated the turn is still surfaced as a failure", async () => {
+  const response = await forwardNativeCodexRequest(
+    nativeRequest(),
+    "responses",
+    async () => resettingEventStream(['event: response.output_text.delta\ndata: {"delta":"half"}\n\n']),
+  );
+
+  // Nothing may invent a terminal event here: the turn really was cut short, and telling Codex it
+  // ended would silently truncate the answer instead of letting Codex retry.
+  await expect(response.text()).rejects.toThrow();
+});
+
+test("a non-event-stream body is passed through untouched", async () => {
+  const response = await forwardNativeCodexRequest(
+    nativeRequest(),
+    "responses",
+    async () => new Response('{"ok":true}', { status: 200, headers: { "content-type": "application/json" } }),
+  );
+
+  expect(await response.text()).toBe('{"ok":true}');
+});

--- a/tests/retained-compaction.test.ts
+++ b/tests/retained-compaction.test.ts
@@ -41,6 +41,16 @@ import {
 } from "../src/adapters/chatgpt-web/native-compaction-control";
 import type { AdapterEvent, CodexParsedRequest, CodexProviderConfig } from "../src/types";
 
+/**
+ * These fixtures hand the turn broker a Unix socket under their temp root. macOS puts TMPDIR at
+ * /var/folders/<32 chars>/T, which pushes `<root>/runtime/turn-broker.sock` past the 104-byte
+ * sun_path limit, and listen() then fails with nothing but "Failed to listen". Root them somewhere
+ * short so the socket is bindable.
+ */
+function shortSocketTempRoot(): string {
+  return process.platform === "win32" ? tmpdir() : "/tmp";
+}
+
 function request(compaction = false): CodexParsedRequest {
   return {
     modelId: "gpt-5.6-sol",
@@ -153,7 +163,7 @@ test("retained compaction provides one exact same-agent control binding", () => 
 });
 
 test("a compaction control token cannot claim the ordinary Codex tool environment", async () => {
-  const root = mkdtempSync(join(tmpdir(), "cgw-compaction-capability-"));
+  const root = mkdtempSync(join(shortSocketTempRoot(), "cgw-compaction-capability-"));
   const broker = TurnBroker.forSocket(defaultBrokerEndpoint(root));
   try {
     const transaction = await broker.beginCompactionTransaction("trace_capability", 1_000);
@@ -175,7 +185,7 @@ test("a compaction control token cannot claim the ordinary Codex tool environmen
 });
 
 test("active compaction delivers the current result and converts every later MCP call into the checkpoint request", async () => {
-  const root = mkdtempSync(join(tmpdir(), "cgw-active-compaction-gate-"));
+  const root = mkdtempSync(join(shortSocketTempRoot(), "cgw-active-compaction-gate-"));
   const broker = TurnBroker.forSocket(defaultBrokerEndpoint(root));
   try {
     const token = await broker.register({
@@ -228,7 +238,7 @@ test("active compaction delivers the current result and converts every later MCP
 });
 
 test("active compaction drains an MCP call already queued without an outer Codex waiter", async () => {
-  const root = mkdtempSync(join(tmpdir(), "cgw-queued-before-compaction-"));
+  const root = mkdtempSync(join(shortSocketTempRoot(), "cgw-queued-before-compaction-"));
   const broker = TurnBroker.forSocket(defaultBrokerEndpoint(root));
   try {
     const token = await broker.register({
@@ -407,7 +417,7 @@ test("active compaction turns the final canonical tool result into the same-resp
 });
 
 test("active compaction interrupts a queued MCP call that Codex never started waiting for", async () => {
-  const root = mkdtempSync(join(tmpdir(), "cgw-compaction-queued-call-"));
+  const root = mkdtempSync(join(shortSocketTempRoot(), "cgw-compaction-queued-call-"));
   const broker = TurnBroker.forSocket(defaultBrokerEndpoint(root));
   try {
     const token = await broker.register({
@@ -562,7 +572,7 @@ test("retained conversation release waits for physical settlement", async () => 
 });
 
 test("adapter compact returns only the same-agent MCP handoff and retires the old epoch", async () => {
-  const root = mkdtempSync(join(tmpdir(), "cgw-adapter-retained-compact-"));
+  const root = mkdtempSync(join(shortSocketTempRoot(), "cgw-adapter-retained-compact-"));
   const provider: CodexProviderConfig = {
     adapter: "chatgpt-web",
     baseUrl: `browser://retained-compact-${Date.now()}`,
@@ -653,7 +663,7 @@ test("adapter compact returns only the same-agent MCP handoff and retires the ol
 });
 
 test("a compact HTTP observer can reconnect without sending a second retained-chat message", async () => {
-  const root = mkdtempSync(join(tmpdir(), "cgw-compact-reconnect-"));
+  const root = mkdtempSync(join(shortSocketTempRoot(), "cgw-compact-reconnect-"));
   const provider: CodexProviderConfig = {
     adapter: "chatgpt-web",
     baseUrl: `browser://compact-reconnect-${Date.now()}`,
@@ -750,7 +760,7 @@ test("a compact HTTP observer can reconnect without sending a second retained-ch
 });
 
 test("structured compact rebuilds canonical context when its retained source is absent", async () => {
-  const root = mkdtempSync(join(tmpdir(), "cgw-missing-retained-compact-"));
+  const root = mkdtempSync(join(shortSocketTempRoot(), "cgw-missing-retained-compact-"));
   const provider: CodexProviderConfig = {
     adapter: "chatgpt-web",
     baseUrl: `browser://missing-retained-${Date.now()}`,
@@ -799,7 +809,7 @@ test("structured compact rebuilds canonical context when its retained source is 
 });
 
 test("structured compact rebuilds canonical context when its retained browser disappeared", async () => {
-  const root = mkdtempSync(join(tmpdir(), "cgw-stale-retained-compact-"));
+  const root = mkdtempSync(join(shortSocketTempRoot(), "cgw-stale-retained-compact-"));
   const provider: CodexProviderConfig = {
     adapter: "chatgpt-web",
     baseUrl: `browser://stale-retained-${Date.now()}`,


### PR DESCRIPTION
Fixes the class of failures in #221: Full-harness turns cancelled with `stream disconnected before completion` while their MCP tool calls are still completing.

## Root cause

In launcher mode the ChatGPT browser worker runs in a **separate helper process** spawned by `launcher-helper-client.ts`, while the Codex MCP broker runs in the daemon. `BrowserTurn.externalProgress` was never forwarded across that boundary — `browser-helper-main.ts` built its `BrowserTurn` without the field, and the client sent no progress frames.

So in the helper `turn.externalProgress` was always `undefined`, and `chatGptExternalProgressIsLive(undefined, …)` returns `false` on its first line. **Every liveness guard was dead code in the mode most users run.** The guard at `browser-worker.ts:3511` exists and is correct; it simply never fired.

That explains the reported timings: one turn failed 29.8s after its last recorded tool progress, well inside the 60s `CHATGPT_RESPONSE_DOM_GRACE_MS` window, and another completed a tool call *one second after* the harness declared the response DOM never existed.

## What this changes

**Transport.** Mirror daemon progress into the helper via a `progress` frame and `ChatGptMirroredTurnProgress`. `BrowserTurn.externalProgress` is now a read-only `ChatGptTurnProgressReader`, since the worker only observes. Mirrors reject replayed, regressing, and malformed frames.

**Liveness vetoes terminal verdicts.** All three `ChatGptTurnDomHealthTracker` branches — missing response, empty completion, missing completed-turn action — assert that ChatGPT stopped producing this turn, which an in-flight tool call disproves. While live, every window is cleared; each restarts fresh once liveness lapses, so a live stretch is never charged against the grace. `sawResponse` still records, preserving "disappeared" vs "never created".

**"Stopped thinking" defers to progress**, and the window is *cleared* rather than merely ignored — suppressing only the verdict let it accrue during a tool call and fire the instant progress ended.

**Bounded by staleness, not duration.** An outstanding call reports liveness regardless of age, so a stuck call is bounded by silence since last activity (`CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS`). Nothing in this repo sets `turnTimeoutMs`, so turns have no deadline by default; bounding total duration instead would have cancelled legitimate multi-hour agent turns. The same rule now bounds the pre-response wait, which previously deferred unconditionally while a call was outstanding.

**Multipart staging** gets the progress reader in both its discovery and acknowledgement paths; it previously had no guard at all.

**Answer Markdown is no longer misclassified as commentary.** Commentary was any Markdown root with *some* status container after it, which holds only while a turn has one live status. Once a second tool call opened another status container below already-emitted answer text, that answer was reclassified. Verified in a real browser, old rule vs fix:

| layout | old | fixed |
|---|---|---|
| Pro commentary, live status, answer | `ANSWER` | `ANSWER` |
| commentary nested inside status, answer | `ANSWER` | `ANSWER` |
| status, answer | `ANSWER` | `ANSWER` |
| status, answer, **second tool status** | `` (empty) | `ANSWER` |
| status, part one, second status, part two | `PART TWO` | `PART ONE \| PART TWO` |

The empty row reproduces the reported `textChars=0`. The interleaved row is worse and had not been noticed: **answer content emitted between tool calls was silently dropped.** Commentary now means Markdown preceding the *first* status container, plus chain-of-thought containment as a position-independent signal, since position alone cannot separate "commentary between two statuses" from "answer between two tool calls".

**An accepted turn survives internal faults.** A `TypeError` while reading the page is a defect in this worker, not evidence about ChatGPT, and failing on one destroys an accepted turn that is never resent. A bounded consecutive run is retried; faults raised *after* observation succeeded belong to consumers and still fail immediately. Deliberate signals — adapter errors, aborts, closed tabs, DOM-health verdicts — are untouched.

**Protocol compatibility.** The launcher advertises the helper inside its signed application bundle while the daemon runs from a versioned runtime directory, so the two update independently. Three changes: the daemon prefers the helper beside its own entrypoint, keeping both halves on one build; the helper advertises optional frames on `ready` and the daemon withholds anything unadvertised; and unrecognised frames are answered with a protocol error instead of being routed to the run handler. That last path is how a newer daemon against an older helper produced `Cannot read properties of undefined (reading 'traceId')`, reported as "ChatGPT failed after accepting the Web prompt".

**Completion is vetoed too, not just DOM health.** `ChatGptCompletionTracker` concluded a turn had finished whenever the composer looked idle. During a tool call the composer *is* idle — ChatGPT is waiting on the harness — so a live progress mirror now vetoes that conclusion as well. Without this, the DOM-health veto merely moved the failure one tracker over.

**A turn-abort notice is context, not the next instruction.** Interrupting a turn makes Codex send `<turn_aborted>…</turn_aborted>` as the following user message. `contextualUserMessage` did not recognise it, so it was staged as a fresh prompt carrying the aborted turn's `turn_id`, and every later turn in the thread failed with `ChatGPT web current user message conflicts with native Codex turn_id metadata`. One interrupt poisoned the whole session. The notice is now classified as context like the other Codex-generated wrappers.

**A Bigger Context part that stalls is restaged.** Multipart staging sends the payload in parts and waits for each to be acknowledged. When ChatGPT settled into "Stopped thinking" on a part, the turn was cancelled outright even though nothing had been committed yet and the part was safe to resend. Attach, send, and acknowledge are now wrapped in a bounded retry (`MAX_CHATGPT_MULTIPART_STAGE_ATTEMPTS = 3`) that re-sends only on that cancellation, leaving every other error to fail immediately. Reproducing the stall itself was not possible — the same prompt succeeded at default, Pro, and 136k-char payloads across 21 samples — so this bounds the symptom rather than removing its cause.

**Staged sends get a budget sized for their payload.** Staged parts reused the ordinary 20s `send` budget, but a part is two orders of magnitude larger than a normal prompt and ChatGPT's composer takes proportionally longer to accept it. Observed stage-2 sends timed out at exactly 20001ms and 20002ms — the budget, not the site. Staged sends and the multipart commit now use `multipartStageSend: 180_000`; single-part turns keep the 20s budget.

## A second failure class: turns cancelled while healthy

The bridge cancels any turn whose adapter emits no event for `DEFAULT_STALL_TIMEOUT_SEC`, reporting `upstream_stall_timeout`. The chatgpt-web adapter's only periodic keep-alive was armed part-way through `runTurn`, after several unbounded awaits, so every path reaching those awaits was invisible to the watchdog. Two are reachable in ordinary use, both measured against the real adapter:

- A turn parked in `getOrCreateAfterOwnerRetirement`, waiting for the previous owner of its thread to physically settle, emitted **nothing at all for 25 seconds**.
- A structured compaction turn returns before the interval is ever armed, so a whole summarizing browser turn runs behind a single one-shot heartbeat.

Both exceed five minutes routinely on Pro. `runTurn`'s body moved to `runChatGptWebTurn`; `runTurn` now arms the heartbeat as its first act and clears it in a `finally`. The body cannot reach the timer, so no future path can quietly become a silent one. Read with `git diff -w` the change is 34 lines — the rest of that file's churn is dedent.

The cancellation also wrote nothing to any log, which is why the two windows had to be found by reading source rather than evidence. It now records the last adapter event, its age, the event count and the stream position, and warns at half the budget so a keep-alive gap surfaces before it costs a turn. `stallTimeoutSec` was declared on the bridge options and read when resolving the budget but never passed by any caller; it is now reachable from provider config.

## An upstream reset after the turn had already finished

ChatGPT's backend resets the native Codex connection rather than closing it. Forwarded verbatim that reached Codex as a truncated body and the opaque `Transport error: network error: error decoding response body`. On this machine it lands at a byte-identical offset across independent turns — 111876 bytes, on chunk counts from 10 to 53 — which is a deterministic upstream close, not a flaky network.

A reset arriving after the stream has already delivered `data: [DONE]` is an unclean TCP close on a turn that completed, so the client stream is now closed normally. A reset before that genuinely truncated the turn and is still raised: fabricating a terminal event there would tell Codex a turn ended when it did not, turning a retryable transport failure into a silently short answer.

## A composer insert that raced ChatGPT's focus

Attaching a staged part failed with `ChatGPT composer rejected the plain-text editing command` 84ms after effort selection closed its menu. Nothing had rejected anything — the guard required the caret to already sit inside the composer, and that soon after a menu closes it often does not. The caret is now placed explicitly; an existing collapsed caret inside the composer is left where it is, so sequential staged parts still append correctly, and only a missing or foreign one is replaced. The page-side logic moved to `insertPlainTextIntoComposer` so it can be tested against the focus and selection states the effort menu actually leaves behind.

## A staged part that was merely slow

A staged part was sent, ChatGPT accepted it, and 72 seconds later the turn died with `ChatGPT accepted the message but did not expose its assistant turn in the DOM`. Nothing had gone wrong — a staged part is two orders of magnitude larger than an ordinary prompt and ChatGPT reads all of it before answering. The same payload acknowledged at 19s on one attempt and 30s on the next, so the ordinary 60s DOM grace is not a budget staging can be held to.

The window matters more here than anywhere else: a part still being ingested has produced no MCP activity, so nothing else can vouch for the turn and this grace is the only thing between a slow ingest and a cancellation. Staged parts now get the same budget as the staged send, which bounds the other half of the same oversized exchange. Ordinary turns keep the 60s grace unchanged.

## System sleep no longer costs turns

pmset matched a whole failure cluster to the second: the Mac entered Idle Sleep 41 seconds after two turns started, and on each DarkWake both died at once — `effort_selection` "timed out" at 901s of a 120s budget, both tabs reaped as `orphan_turn_reaped`, heartbeats rejected with `was already released`, and the retries then failing on pages the reaper had closed. Sleep freezes both sides of the lease protocol together, so the launcher's first sweep after a wake saw fifteen-minute-stale heartbeats and read them as a dead helper.

Three layers, in order of preference. The launcher holds a `prevent-app-suspension` power blocker exactly while a browser turn is running, so an idle Mac no longer sleeps mid-turn at all (verified live: `pmset -g assertions` shows the Electron assertion up during a turn and the release logged the moment it ends). When sleep happens anyway, the wake side stops punishing it: the lease sweep knows its own cadence, treats a gap of many multiples of it as its own suspension, and re-baselines every running lease instead of reaping — a helper that is genuinely gone still dies on the ordinary sixty-second cadence. And stage budgets stop charging for slept time: a suspension clock watches for tick gaps, and a stage timer that fires with slept time on the books re-arms for what the stage is still owed awake.

## The suite is green

Seven tests failed on every macOS checkout, including `main`, which is enough noise to hide a regression. Six were the retained-compaction fixtures: they bind the turn broker to a Unix socket under `TMPDIR`, and macOS puts that at `/var/folders/<32 chars>/T`, so the socket path came to 106 bytes against a 104-byte `sun_path` limit and `listen()` failed with nothing but "Failed to listen". The fixtures root themselves somewhere short, and the broker now rejects an over-long path with a message naming the length and the limit — the same wall a real install with a long runtime directory would hit. The seventh is Linux-only and already declared `skip`, which Bun's `node:test` shim ignores; it returns early instead.

**678 tests, 0 failures.**

## Note on the cot-v5 locator hypothesis

#221 speculated that `cot-v5-*` rendering had broken the response *locator*. Instrumenting live turns shows that does not hold: during the `cot-v5` phase there are zero `.markdown` roots, so `visibleText` of `0` is correct — the chain-of-thought is reasoning, not the answer, and the answer has not been written yet.

```
cot:2  mdRoots:0  statusContainers:1  visibleTextChars:0    stopBtn:1  copyBtn:0   <- thinking / tool phase
cot:0  mdRoots:1  statusContainers:0  visibleTextChars:139  stopBtn:1  copyBtn:0   <- answer streaming
cot:0  mdRoots:1  statusContainers:0  visibleTextChars:262  stopBtn:0  copyBtn:1   <- complete
```

`ui.response.textChars` counts the whole response element including CoT status text, a different measure from the tracker's `visibleText`. The reported `textChars=0` therefore has two causes: this correct-by-design reading, and the genuine misclassification above once a second tool call starts.

## Testing

- `bun run typecheck` clean. `bun test`: 656 pass; the 7 failures are identical to `main` on this machine (Linux `/proc` AppImage test plus pre-existing compaction tests).
- Behavioural tests for mirror apply/staleness/validation/waiters, staleness-bounded suppression, the terminal-branch veto, `sawResponse` preservation, the Stopped-thinking window reset, the completion veto, future-dated timestamps, and the fault budget.
- Wiring-contract tests for both ends of the progress transport, helper pinning, capability negotiation, and unknown-frame handling.
- The commentary classifier is now covered: the test extracts the shipped source between two sentinels in `browser-worker.ts` and executes it against a real DOM built with `@mixmark-io/domino`, so the five layouts in the table above are asserted on the code that actually runs, not a copy of it.
- Every fix was mutation-tested: reverting it makes its test fail.

### Verified in production

Built and installed into a real launcher, then driven with live multi-tool Full-harness turns. The two most recent fixes both fired and recovered rather than being merely theoretical:

```
turn 8f30e4e38202 restaging multipart part 1/3 (attempt 1/3):
    ChatGPT remained in 'Stopped thinking' for 5 seconds, so the Codex turn was cancelled.
turn 8f30e4e38202 stage=multipart_stage_1_send completed durationMs=13316
turn 8f30e4e38202 multipart part 1/3 submission accepted evidence=user_turn
```

```
turn c9bd3e0bf01b stage=multipart_stage_2_send completed durationMs=41853
turn c9bd3e0bf01b stage=send             completed durationMs=41575
turn c9bd3e0bf01b completed (markdownChars=9686, domFullScans=90, domCacheHits=302)
```

Both sends exceed the old 20s budget and are exactly the `multipart_stage_2_send` timeout reported on #221. That turn ran five minutes across eight MCP tool calls, all `completed pending=0`. Across the session: zero `stream disconnected`, zero `traceId` protocol errors, zero unadvertised-frame rejections, zero turns lost to a missing progress mirror.

**Remaining caveats:** the CoT-containment signal assumes Pro commentary renders inside a `cot-v5` component — consistent with the testids in the reports on #221, but not confirmed against captured Pro markup. If Pro emits top-level commentary outside CoT between two status containers, it would be appended to the answer rather than dropped; that direction was chosen deliberately, since leaking commentary is visible and recoverable while losing answer text is not.

The "Stopped thinking" stall on a staged part is bounded, not explained — it could not be reproduced on demand, so the retry is a mitigation. And the 180s staged-send budget is sized from observed sends of ~42s with headroom; a pathologically slow upload would still time out, now after three minutes instead of twenty seconds.


