### PR TITLE
fix: support current ChatGPT Allow approval label

### DIFF
--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -421,9 +421,14 @@ export async function resolveChatGptToolConfirmation(
   await onVisible?.();
 
   if (autoApprove) {
-    const allowOnce = dialog.getByRole("button", { name: "Allow once", exact: true }).last();
-    await allowOnce.waitFor({ state: "visible", timeout: 10_000 });
-    await allowOnce.press("Enter");
+    // ChatGPT exposes either "Allow once" or the shorter "Allow" for the
+    // current one-shot approval. Keep the matcher anchored so persistent
+    // actions such as "Always allow" cannot match.
+    const allowCurrentAction = dialog
+      .getByRole("button", { name: /^Allow(?: once)?$/ })
+      .last();
+    await allowCurrentAction.waitFor({ state: "visible", timeout: 10_000 });
+    await allowCurrentAction.press("Enter");
     return true;
   }
 

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -1495,6 +1495,7 @@ test("unrelated ChatGPT alerts are not terminal", async () => {
 function toolConfirmationPage(options: {
   disappearAfterReads?: number;
   surface?: "dialog" | "card";
+  allowLabel?: "Allow once" | "Allow";
 } = {}): {
   page: Page;
   pressed: string[];
@@ -1502,14 +1503,23 @@ function toolConfirmationPage(options: {
   let reads = 0;
   let visible = true;
   const pressed: string[] = [];
-  const button = (name: string) => ({
-    last: () => button(name),
-    waitFor: async () => {},
-    press: async (key: string) => {
-      pressed.push(`${name}:${key}`);
-      visible = false;
-    },
-  });
+  const availableButtons = [options.allowLabel ?? "Allow once", "Deny"] as const;
+  const button = (name: string | RegExp) => {
+    const actualName = availableButtons.find(candidate => (
+      typeof name === "string" ? candidate === name : name.test(candidate)
+    ));
+    return {
+      last: () => button(name),
+      waitFor: async () => {
+        if (!actualName) throw new Error(`Approval button not found: ${String(name)}`);
+      },
+      press: async (key: string) => {
+        if (!actualName) throw new Error(`Approval button not found: ${String(name)}`);
+        pressed.push(`${actualName}:${key}`);
+        visible = false;
+      },
+    };
+  };
   const dialog = {
     filter: ({ hasText }: { hasText: string }) => {
       expect(hasText).toBe("Allow ChatGPT to use Codex Native?");
@@ -1521,7 +1531,7 @@ function toolConfirmationPage(options: {
       if (options.disappearAfterReads !== undefined && reads >= options.disappearAfterReads) visible = false;
       return visible;
     },
-    getByRole: (_role: string, input: { name: string }) => button(input.name),
+    getByRole: (_role: string, input: { name: string | RegExp }) => button(input.name),
     waitFor: async ({ state }: { state: string }) => {
       expect(state).toBe("hidden");
       expect(visible).toBeFalse();
@@ -1564,6 +1574,13 @@ test("explicit connector auto-approval still selects Allow once", async () => {
 
   expect(await resolveChatGptToolConfirmation(fixture.page, "Codex Native", true)).toBeTrue();
   expect(fixture.pressed).toEqual(["Allow once:Enter"]);
+});
+
+test("connector auto-approval accepts the current shortened Allow action", async () => {
+  const fixture = toolConfirmationPage({ allowLabel: "Allow" });
+
+  expect(await resolveChatGptToolConfirmation(fixture.page, "Codex Native", true)).toBeTrue();
+  expect(fixture.pressed).toEqual(["Allow:Enter"]);
 });
 
 test("auto-approval recognizes the observed non-dialog approval card", async () => {


### PR DESCRIPTION
## Summary

Fix automatic connector approval after ChatGPT changed the current-action button from `Allow once` to `Allow` for the observed approval UI.

The connector approval card itself is detected successfully, but the bridge currently waits only for an exact `Allow once` button. Current ChatGPT UI can expose `Allow` instead, causing a 10-second locator timeout.

## Fix

Accept only the two anchored current-action labels:

- `Allow once`
- `Allow`

The matcher does not match persistent actions such as `Always allow`.

## Reproduction

Observed with Codex Native2 while `autoApproveToolCalls=true`.

The bridge reached `tool-confirmation-visible`, then failed with:

`locator.waitFor: Timeout 10000ms exceeded`

while waiting for:

`getByRole('button', { name: 'Allow once', exact: true })`

The visible approval surface exposed `Deny` and `Allow`.

## Verification

- legacy `Allow once` behavior remains covered
- regression coverage added for `Allow`
- targeted browser-worker contract suite: 81 passed, 0 failed
- `git diff --check` passed
- TypeScript `tsc --noEmit` passed locally via bundled Bun