### PR TITLE
fix: disconnect stalled browser before launcher rebind

### DIFF
--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -3195,6 +3195,18 @@ export class ChatGptBrowserWorker {
           + ` ${redactChatGptUiDiagnostic(cause.message)}`,
         );
         const previousConnection = turnConnection;
+        if (previousConnection) {
+          // The observation timeout races the Playwright operation but cannot cancel the
+          // underlying page.evaluate by itself. Disconnect the stale CDP transport before
+          // opening its replacement so the hung probe cannot contend with its own recovery.
+          turnConnection = undefined;
+          await previousConnection.close().catch(error => {
+            console.warn(
+              `[chatgpt-web] previous browser observation connection did not close before rebind:`
+              + ` ${error instanceof Error ? error.message : String(error)}`,
+            );
+          });
+        }
         const connection = await this.runStage(
           turn.traceId,
           `response_page_rebind_${attempt}`,
@@ -3216,14 +3228,6 @@ export class ChatGptBrowserWorker {
         turnConnection = connection.browser;
         page = connection.page;
         diagnosticPage = page;
-        if (previousConnection && previousConnection !== connection.browser) {
-          await previousConnection.close().catch(error => {
-            console.warn(
-              `[chatgpt-web] previous browser observation connection did not close after rebind:`
-              + ` ${error instanceof Error ? error.message : String(error)}`,
-            );
-          });
-        }
         console.warn(
           `[chatgpt-web] browser turn ${turn.traceId} rebound its existing launcher page after a stalled DOM probe`,
         );

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -249,9 +249,43 @@ test("a stalled post-submit DOM probe is bounded before same-page launcher recov
   const submissionAccepted = runBrowserTurn.indexOf("submission accepted evidence=");
   const recovery = runBrowserTurn.indexOf("await rebindLauncherPage(", submissionAccepted);
   const duplicateSend = runBrowserTurn.indexOf("sendAttachedPrompt(", recovery);
+
+  const rebindDefinition = runBrowserTurn.indexOf("const rebindLauncherPage");
+  const previousConnection = runBrowserTurn.indexOf(
+    "const previousConnection = turnConnection;",
+    rebindDefinition,
+  );
+  const detachOldConnection = runBrowserTurn.indexOf(
+    "turnConnection = undefined;",
+    previousConnection,
+  );
+  const disconnectOldConnection = runBrowserTurn.indexOf(
+    "await previousConnection.close()",
+    detachOldConnection,
+  );
+  const reconnectStage = runBrowserTurn.indexOf(
+    "const connection = await this.runStage(",
+    disconnectOldConnection,
+  );
+  const reconnectTransport = runBrowserTurn.indexOf(
+    "const rebound = await connectLauncherBrowserHost(",
+    reconnectStage,
+  );
+
   expect(recovery).toBeGreaterThan(submissionAccepted);
   expect(duplicateSend).toBe(-1);
-  expect(runBrowserTurn).toContain("if (!launcherSurfaceId || !this.config.browserHostDescriptorPath) throw cause");
+  expect(rebindDefinition).toBeGreaterThan(-1);
+  expect(previousConnection).toBeGreaterThan(rebindDefinition);
+  expect(detachOldConnection).toBeGreaterThan(previousConnection);
+  expect(disconnectOldConnection).toBeGreaterThan(detachOldConnection);
+  expect(reconnectStage).toBeGreaterThan(disconnectOldConnection);
+  expect(reconnectTransport).toBeGreaterThan(reconnectStage);
+  expect(runBrowserTurn).not.toContain(
+    "previous browser observation connection did not close after rebind",
+  );
+  expect(runBrowserTurn).toContain(
+    "if (!launcherSurfaceId || !this.config.browserHostDescriptorPath) throw cause",
+  );
   expect(runBrowserTurn.slice(recovery)).toContain("responseTurn.identity");
 });
 


### PR DESCRIPTION
## Summary

Disconnect a stalled launcher Playwright/CDP observation transport before opening the same-page recovery connection.

The existing post-submit DOM observation timeout is intentionally bounded, but it races the Playwright operation rather than cancelling the underlying `page.evaluate()` itself. The current recovery path leaves that old CDP connection alive while it tries to open and validate a replacement, then closes the old connection only after the rebind succeeds.

This changes the ordering to:

1. preserve the existing launcher surface identity
2. detach and close the stale observation transport
3. open a fresh CDP connection to the same launcher-owned surface
4. prove the operational viewport
5. continue observing the already-submitted response

No prompt is resent and the ChatGPT document is not reloaded.

## Real-world evidence

Observed on Codex Web GPT v4.0.5 on Windows during long-running Full Harness / retained-compaction work.

Safe diagnostics contained several `response_page_rebind_1` incidents:

- successful recovery in ~7.5 s
- failed recovery in ~37.5 s with `ChatGPT browser surface did not expose an operational viewport`
- two successful recoveries in one long-running trace in ~29.6 s and ~21.5 s
- a later recovery in that same trace timed out at the full 60 s stage limit

The final failure was:

`ChatGPT browser stage timed out: response_page_rebind_1`

The observation probe immediately before it had already reported:

`ChatGPT browser DOM observation did not respond within 5000ms`

## Why this is scoped

For launcher connections, Playwright `Browser.close()` on a `connectOverCDP` browser disconnects the local observation transport; it does not close or reload the launcher-owned Electron browser page.

The patch therefore does not:

- resend an accepted prompt
- reload the retained ChatGPT conversation
- allocate a replacement ChatGPT conversation
- change connector approval behavior
- weaken submission evidence
- force completion

## Regression coverage

The existing stalled-DOM recovery contract now also proves source ordering:

`previous connection -> detach -> close -> reconnect stage -> connectLauncherBrowserHost`

It continues to assert that recovery never calls `sendAttachedPrompt()` again.

## Verification

- browser-worker contract suite passed locally
- TypeScript `tsc --noEmit` passed locally
- `git diff --check` passed