### PR TITLE
fix: carry MCP turn progress into the launcher browser helper process

### DIFF
--- a/src/adapters/chatgpt-web/browser-helper-main.ts
+++ b/src/adapters/chatgpt-web/browser-helper-main.ts
@@ -167,8 +167,10 @@ async function run(message: RunMessage): Promise<void> {
   const abortController = new AbortController();
   abortControllers.set(message.id, abortController);
   // The Codex MCP broker runs in the daemon process, so this mirror is the only way the worker can
-  // observe that a turn is still executing while its ChatGPT DOM is unavailable.
-  const progress = turnProgress.get(message.id) ?? new ChatGptMirroredTurnProgress();
+  // observe that a turn is still executing while its ChatGPT DOM is unavailable. Trace ids are
+  // derived deterministically and can repeat, so each run starts a fresh mirror rather than
+  // inheriting revisions recorded for an earlier turn that happened to share the id.
+  const progress = new ChatGptMirroredTurnProgress();
   turnProgress.set(message.id, progress);
   const promptSelection = createBrowserHelperPromptSelection();
   preparedSelections.set(message.id, promptSelection);

--- a/src/adapters/chatgpt-web/browser-helper-main.ts
+++ b/src/adapters/chatgpt-web/browser-helper-main.ts
@@ -7,6 +7,8 @@ import type { ChatGptWebCapabilities } from "./model";
 import { createProcessLineWriter } from "./process-line-writer";
 import { createBrowserHelperPromptSelection } from "./browser-helper-prompt-selection";
 import type { CompiledChatGptWebPrompt } from "./prompt";
+import { ChatGptMirroredTurnProgress } from "./turn-progress";
+import type { ChatGptExternalTurnProgressSnapshot } from "./turn-progress";
 
 interface RunMessage {
   type: "run";
@@ -60,6 +62,7 @@ type InputMessage = RunMessage
   | MaintenanceMessage
   | { type: "prepared_selected_ack"; id: string; prepared: CompiledChatGptWebPrompt }
   | { type: "send_activation_ack"; id: string }
+  | { type: "progress"; id: string; snapshot: ChatGptExternalTurnProgressSnapshot }
   | { type: "abort"; id: string }
   | { type: "shutdown" };
 
@@ -82,6 +85,7 @@ console.warn = diagnostic;
 console.error = diagnostic;
 
 const abortControllers = new Map<string, AbortController>();
+const turnProgress = new Map<string, ChatGptMirroredTurnProgress>();
 const preparedSelections = new Map<string, ReturnType<typeof createBrowserHelperPromptSelection>>();
 const sendActivationWaiters = new Map<string, {
   resolve: () => void;
@@ -162,6 +166,10 @@ async function run(message: RunMessage): Promise<void> {
   };
   const abortController = new AbortController();
   abortControllers.set(message.id, abortController);
+  // The Codex MCP broker runs in the daemon process, so this mirror is the only way the worker can
+  // observe that a turn is still executing while its ChatGPT DOM is unavailable.
+  const progress = turnProgress.get(message.id) ?? new ChatGptMirroredTurnProgress();
+  turnProgress.set(message.id, progress);
   const promptSelection = createBrowserHelperPromptSelection();
   preparedSelections.set(message.id, promptSelection);
   const prepareSelected = async () => ({ ...await promptSelection.wait(), release: () => {} });
@@ -178,6 +186,7 @@ async function run(message: RunMessage): Promise<void> {
     ...(message.turn.conversationKey ? { conversationKey: message.turn.conversationKey } : {}),
     abortSignal: abortController.signal,
     ...(message.turn.compaction ? { compaction: true } : {}),
+    externalProgress: progress,
     onHeartbeat: () => writeProtocol({ type: "event", id: message.id, event: "heartbeat" }),
     onPreparedSelected: reused => {
       if (!writeProtocol({ type: "event", id: message.id, event: "prepared_selected", reused })) {
@@ -243,6 +252,7 @@ async function run(message: RunMessage): Promise<void> {
     sendActivationWaiters.delete(message.id);
     sendWaiter?.reject(new DOMException("Browser helper turn ended before Send acknowledgement", "AbortError"));
     abortControllers.delete(message.id);
+    turnProgress.delete(message.id);
   }
 }
 
@@ -340,6 +350,20 @@ input.on("line", line => {
     }
     sendActivationWaiters.delete(message.id);
     waiter.resolve();
+  } else if (message.type === "progress") {
+    // Progress can arrive before the run frame is processed, so the mirror is created on demand
+    // rather than requiring an established turn.
+    const progress = turnProgress.get(message.id) ?? new ChatGptMirroredTurnProgress();
+    turnProgress.set(message.id, progress);
+    try {
+      progress.apply(message.snapshot);
+    } catch (error) {
+      writeProtocol({
+        type: "error",
+        id: message.id,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
   } else if (message.type === "abort") {
     abortControllers.get(message.id)?.abort();
     preparedSelections.get(message.id)?.cancel();

--- a/src/adapters/chatgpt-web/browser-helper-main.ts
+++ b/src/adapters/chatgpt-web/browser-helper-main.ts
@@ -86,9 +86,6 @@ console.error = diagnostic;
 
 const abortControllers = new Map<string, AbortController>();
 const turnProgress = new Map<string, ChatGptMirroredTurnProgress>();
-/** Bounded record of finished turns so a late progress frame is dropped instead of resurrected. */
-const retiredTurns = new Set<string>();
-const MAX_RETIRED_TURN_IDS = 256;
 const preparedSelections = new Map<string, ReturnType<typeof createBrowserHelperPromptSelection>>();
 const sendActivationWaiters = new Map<string, {
   resolve: () => void;
@@ -256,11 +253,6 @@ async function run(message: RunMessage): Promise<void> {
     sendWaiter?.reject(new DOMException("Browser helper turn ended before Send acknowledgement", "AbortError"));
     abortControllers.delete(message.id);
     turnProgress.delete(message.id);
-    if (retiredTurns.size >= MAX_RETIRED_TURN_IDS) {
-      const oldest = retiredTurns.values().next();
-      if (!oldest.done) retiredTurns.delete(oldest.value);
-    }
-    retiredTurns.add(message.id);
   }
 }
 
@@ -359,15 +351,11 @@ input.on("line", line => {
     sendActivationWaiters.delete(message.id);
     waiter.resolve();
   } else if (message.type === "progress") {
-    // A frame can still be in flight when its turn ends. Recreating a mirror for a retired id would
-    // leak an entry that nothing ever removes, so only an id that is live or not yet started is
-    // accepted; anything else is dropped as late.
-    const existing = turnProgress.get(message.id);
-    const progress = existing
-      ?? (abortControllers.has(message.id) || !retiredTurns.has(message.id)
-        ? new ChatGptMirroredTurnProgress()
-        : undefined);
-    if (!progress) return;
+    // Progress is only meaningful for a turn this helper is actually running. Creating a mirror
+    // for any unrecognised id let late, malformed, or misaddressed frames grow this map without
+    // bound, since nothing would ever remove an entry that has no turn to end it.
+    if (!abortControllers.has(message.id)) return;
+    const progress = turnProgress.get(message.id) ?? new ChatGptMirroredTurnProgress();
     turnProgress.set(message.id, progress);
     try {
       progress.apply(message.snapshot);

--- a/src/adapters/chatgpt-web/browser-helper-main.ts
+++ b/src/adapters/chatgpt-web/browser-helper-main.ts
@@ -86,6 +86,9 @@ console.error = diagnostic;
 
 const abortControllers = new Map<string, AbortController>();
 const turnProgress = new Map<string, ChatGptMirroredTurnProgress>();
+/** Bounded record of finished turns so a late progress frame is dropped instead of resurrected. */
+const retiredTurns = new Set<string>();
+const MAX_RETIRED_TURN_IDS = 256;
 const preparedSelections = new Map<string, ReturnType<typeof createBrowserHelperPromptSelection>>();
 const sendActivationWaiters = new Map<string, {
   resolve: () => void;
@@ -253,6 +256,11 @@ async function run(message: RunMessage): Promise<void> {
     sendWaiter?.reject(new DOMException("Browser helper turn ended before Send acknowledgement", "AbortError"));
     abortControllers.delete(message.id);
     turnProgress.delete(message.id);
+    if (retiredTurns.size >= MAX_RETIRED_TURN_IDS) {
+      const oldest = retiredTurns.values().next();
+      if (!oldest.done) retiredTurns.delete(oldest.value);
+    }
+    retiredTurns.add(message.id);
   }
 }
 
@@ -351,9 +359,15 @@ input.on("line", line => {
     sendActivationWaiters.delete(message.id);
     waiter.resolve();
   } else if (message.type === "progress") {
-    // Progress can arrive before the run frame is processed, so the mirror is created on demand
-    // rather than requiring an established turn.
-    const progress = turnProgress.get(message.id) ?? new ChatGptMirroredTurnProgress();
+    // A frame can still be in flight when its turn ends. Recreating a mirror for a retired id would
+    // leak an entry that nothing ever removes, so only an id that is live or not yet started is
+    // accepted; anything else is dropped as late.
+    const existing = turnProgress.get(message.id);
+    const progress = existing
+      ?? (abortControllers.has(message.id) || !retiredTurns.has(message.id)
+        ? new ChatGptMirroredTurnProgress()
+        : undefined);
+    if (!progress) return;
     turnProgress.set(message.id, progress);
     try {
       progress.apply(message.snapshot);

--- a/src/adapters/chatgpt-web/browser-helper-main.ts
+++ b/src/adapters/chatgpt-web/browser-helper-main.ts
@@ -399,12 +399,21 @@ input.on("line", line => {
       id: message.id,
       message: error instanceof Error ? error.message : String(error),
     }));
-  } else {
+  } else if (message.type === "run") {
     void run(message).catch(error => writeProtocol({
       type: "error",
       id: message.id,
       message: error instanceof Error ? error.message : String(error),
     }));
+  } else {
+    // Never treat an unrecognised frame as a run. Doing so dereferenced `message.turn` on a frame
+    // that has none, so a newer daemon speaking to an older helper destroyed the turn with an
+    // opaque TypeError instead of degrading.
+    writeProtocol({
+      type: "error",
+      id: (message as { id?: string }).id ?? "unknown",
+      message: `Browser helper received an unsupported message type: ${String((message as { type?: unknown }).type)}`,
+    });
   }
 });
 input.on("close", () => {
@@ -417,4 +426,6 @@ process.once("SIGTERM", () => {
   void requestShutdown();
 });
 
-writeProtocol({ type: "ready" });
+// Advertise optional frames so a newer daemon can tell whether this helper understands them. An
+// older helper omits the field, and the daemon then withholds those frames instead of breaking it.
+writeProtocol({ type: "ready", features: ["progress"] });

--- a/src/adapters/chatgpt-web/browser-helper-main.ts
+++ b/src/adapters/chatgpt-web/browser-helper-main.ts
@@ -372,11 +372,14 @@ input.on("line", line => {
     try {
       progress.apply(message.snapshot);
     } catch (error) {
-      writeProtocol({
-        type: "error",
-        id: message.id,
-        message: error instanceof Error ? error.message : String(error),
-      });
+      // Progress is a liveness hint, never response content or completion. Failing the turn over a
+      // malformed frame would destroy an accepted ChatGPT turn that cannot be resent, so the frame
+      // is dropped and the turn falls back to DOM-only health, which is the behaviour it had
+      // before this transport existed.
+      diagnostic(
+        `[chatgpt-web] discarded an invalid MCP progress frame for ${message.id}:`,
+        error instanceof Error ? error.message : String(error),
+      );
     }
   } else if (message.type === "abort") {
     abortControllers.get(message.id)?.abort();

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -835,7 +835,17 @@ export class ChatGptCompletionTracker {
 
   constructor(private readonly stableMs = CHATGPT_COMPLETION_SETTLE_MS) {}
 
-  update(state: Parameters<typeof chatGptTurnIsComplete>[0], now = Date.now()): boolean {
+  update(
+    state: Parameters<typeof chatGptTurnIsComplete>[0] & { externalProgressLive?: boolean },
+    now = Date.now(),
+  ): boolean {
+    // An outstanding tool call proves the model has more to say, whatever the rendered message
+    // currently looks like. Completing here would return a truncated answer and retire the turn
+    // while its own tool calls were still in flight.
+    if (state.externalProgressLive) {
+      this.candidate = undefined;
+      return false;
+    }
     if (!chatGptTurnIsComplete(state)) {
       this.candidate = undefined;
       return false;
@@ -950,6 +960,9 @@ export const MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS = 8;
  */
 export const CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS = 10 * 60_000;
 
+/** Tolerated clock difference between the recording daemon and the observing helper process. */
+export const CHATGPT_EXTERNAL_PROGRESS_CLOCK_SKEW_MS = 5_000;
+
 /** Proven MCP activity, additionally required to be recent enough to still be evidence. */
 export function chatGptExternalProgressSuppressesDomHealth(
   snapshot: ChatGptExternalTurnProgressSnapshot | undefined,
@@ -957,8 +970,12 @@ export function chatGptExternalProgressSuppressesDomHealth(
 ): boolean {
   if (!chatGptExternalProgressIsLive(snapshot, now, CHATGPT_RESPONSE_DOM_GRACE_MS)) return false;
   const lastProgressAt = snapshot?.lastProgressAt;
-  return lastProgressAt !== undefined
-    && now - lastProgressAt < CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS;
+  if (lastProgressAt === undefined) return false;
+  const age = now - lastProgressAt;
+  // A timestamp from the future would keep `age` below the ceiling forever. Recorded activity can
+  // only precede the observation, so anything meaningfully ahead of now is not evidence at all.
+  return age >= -CHATGPT_EXTERNAL_PROGRESS_CLOCK_SKEW_MS
+    && age < CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS;
 }
 
 export class ChatGptStoppedThinkingTracker {
@@ -2451,6 +2468,7 @@ export class ChatGptBrowserWorker {
         currentText: snapshot.visibleText,
         currentHtml: snapshot.fullHtml,
         completionActionVisible: snapshot.completionActionVisible,
+        externalProgressLive,
       })) {
         const actual = snapshot.visibleText.trim();
         if (actual !== stage.acknowledgement) {
@@ -3543,6 +3561,12 @@ export class ChatGptBrowserWorker {
       let internalObservationFaults = 0;
       let observedThisIteration = false;
       for (;;) {
+        // The heartbeat is a consumer callback, so it stays outside the observation-fault region:
+        // a defect in the caller must not be retried as though the page could not be read.
+        if (Date.now() - lastHeartbeat >= 10_000) {
+          turn.onHeartbeat?.();
+          lastHeartbeat = Date.now();
+        }
        try {
         observedThisIteration = false;
         if (page.isClosed()) {
@@ -3556,11 +3580,6 @@ export class ChatGptBrowserWorker {
         if (deadline !== undefined && Date.now() >= deadline) {
           throw new Error("ChatGPT web turn timed out");
         }
-        if (Date.now() - lastHeartbeat >= 10_000) {
-          turn.onHeartbeat?.();
-          lastHeartbeat = Date.now();
-        }
-
         await throwIfChatGptSessionFailureAlert(page);
         await throwIfChatGptTerminalErrorAlert(responseTurn.locator);
 
@@ -3674,6 +3693,7 @@ export class ChatGptBrowserWorker {
             currentText: snapshot.visibleText,
             currentHtml: snapshot.fullHtml,
             completionActionVisible: snapshot.completionActionVisible,
+            externalProgressLive,
           })) {
             if (snapshot.visibleText === "api_tool unavailable") {
               throw new Error("ChatGPT selected mode rejected the Codex Native MCP tool (api_tool unavailable)");

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -964,6 +964,17 @@ export function chatGptExternalProgressSuppressesDomHealth(
 export class ChatGptStoppedThinkingTracker {
   private visibleSince?: number;
 
+  /**
+   * Forgets an in-progress "Stopped thinking" window.
+   *
+   * Suppressing only the throw let the window keep accruing while a tool call was outstanding, so
+   * the first observation after progress ended cancelled the turn instantly. Proven activity must
+   * reset the evidence, not merely postpone acting on it.
+   */
+  clear(): void {
+    this.visibleSince = undefined;
+  }
+
   constructor(private readonly graceMs = CHATGPT_STOPPED_THINKING_GRACE_MS) {
     if (!Number.isFinite(graceMs) || graceMs < 0) {
       throw new Error("ChatGPT Stopped thinking grace must be a non-negative finite number");
@@ -2035,7 +2046,8 @@ export class ChatGptBrowserWorker {
       if (deadline !== undefined && Date.now() >= deadline) {
         throw new Error("ChatGPT web turn timed out");
       }
-      if (Date.now() >= responseDeadline && (progress?.activeToolCalls ?? 0) === 0) {
+      if (Date.now() >= responseDeadline
+        && !chatGptExternalProgressSuppressesDomHealth(progress, Date.now())) {
         throw new Error("ChatGPT accepted the message but did not expose its assistant turn in the DOM");
       }
       await throwIfChatGptSessionFailureAlert(page);
@@ -2413,7 +2425,8 @@ export class ChatGptBrowserWorker {
         externalProgress?.snapshot(),
         Date.now(),
       );
-      if (stoppedThinkingTracker.update(snapshot.stoppedThinkingVisible) && !externalProgressLive) {
+      if (externalProgressLive) stoppedThinkingTracker.clear();
+      else if (stoppedThinkingTracker.update(snapshot.stoppedThinkingVisible)) {
         throw chatGptStoppedThinkingError();
       }
       if (!snapshot.responsePresent && externalProgressLive) {
@@ -3373,6 +3386,7 @@ export class ChatGptBrowserWorker {
             stageBaseline,
             deadline,
             turn.abortSignal,
+            turn.externalProgress,
           );
           console.info(
             `[chatgpt-web] browser turn ${turn.traceId} multipart part ${index + 1}/${prepared.multipart.parts.length} submission accepted evidence=${evidence}`,
@@ -3514,8 +3528,10 @@ export class ChatGptBrowserWorker {
       const responseDomCache: ChatGptResponseDomCache = {};
       let consecutiveObservationRebinds = 0;
       let internalObservationFaults = 0;
+      let observedThisIteration = false;
       for (;;) {
        try {
+        observedThisIteration = false;
         if (page.isClosed()) {
           throw chatGptBrowserTabClosedError();
         }
@@ -3543,6 +3559,7 @@ export class ChatGptBrowserWorker {
           CHATGPT_TOOL_CONFIRMATION_TIMEOUT_MS,
           () => diagnostics.capture(page, "tool-confirmation-visible"),
         )) {
+          internalObservationFaults = 0;
           await new Promise(resolveSleep => setTimeout(resolveSleep, 250));
           continue;
         }
@@ -3589,6 +3606,7 @@ export class ChatGptBrowserWorker {
         // The page was read successfully, so the fault budget is genuinely consecutive even when
         // this iteration goes on to `continue` for a rebind, confirmation, or liveness pause.
         internalObservationFaults = 0;
+        observedThisIteration = true;
         // Liveness may postpone a verdict, never waive it: once activity goes stale the DOM alone
         // decides, so a tool call that never returns cannot hold an undeadlined turn open forever.
         const externalProgressLive = chatGptExternalProgressSuppressesDomHealth(
@@ -3596,8 +3614,9 @@ export class ChatGptBrowserWorker {
           Date.now(),
         );
         // A stale "Stopped thinking" label is not terminal while the model is still driving tool
-        // calls, so the tracker keeps observing but may not cancel the turn.
-        if (stoppedThinkingTracker.update(snapshot.stoppedThinkingVisible) && !externalProgressLive) {
+        // calls, and the window must be forgotten rather than merely ignored.
+        if (externalProgressLive) stoppedThinkingTracker.clear();
+        else if (stoppedThinkingTracker.update(snapshot.stoppedThinkingVisible)) {
           throw chatGptStoppedThinkingError();
         }
         if (!snapshot.responsePresent && externalProgressLive) {
@@ -3692,7 +3711,10 @@ export class ChatGptBrowserWorker {
        } catch (error) {
         // Only a defect in this worker is retried here. Every deliberate signal — adapter errors,
         // aborts, closed tabs, DOM-health verdicts — still fails the turn immediately.
-        if (!(error instanceof TypeError)) throw error;
+        // Retry only faults raised while reading the page. Once observation succeeded, a
+        // TypeError belongs to a consumer - Markdown buffering, text/trace callbacks, checkpoint
+        // capture - and retrying it would rerun an iteration whose side effects already happened.
+        if (!(error instanceof TypeError) || observedThisIteration) throw error;
         internalObservationFaults += 1;
         if (internalObservationFaults > MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS) {
           throw new Error(

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -86,7 +86,10 @@ import {
 import {
   chatGptExternalProgressIsLive,
 } from "./turn-progress";
-import type { ChatGptTurnProgressReader } from "./turn-progress";
+import type {
+  ChatGptExternalTurnProgressSnapshot,
+  ChatGptTurnProgressReader,
+} from "./turn-progress";
 
 export { MAX_CHATGPT_BROWSER_TABS } from "./concurrency";
 
@@ -938,12 +941,25 @@ export const CHATGPT_STOPPED_THINKING_GRACE_MS = 5_000;
 export const MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS = 8;
 
 /**
- * Absolute ceiling on how long proven MCP progress may suppress DOM health checks.
+ * How stale recorded MCP progress may be and still suppress DOM health checks.
  *
- * Liveness is reported while a tool call is outstanding, so a tool that never returns would
- * otherwise hold a turn open forever whenever the caller supplied no turn deadline.
+ * An outstanding tool call reports liveness regardless of age, so a call that never returns would
+ * otherwise hold a turn open forever — turns carry no deadline unless a caller supplies one. This
+ * bounds the silence since the last recorded activity rather than the turn's total duration, so a
+ * long turn that keeps calling tools is never penalised for taking a long time.
  */
-export const CHATGPT_EXTERNAL_PROGRESS_SUPPRESSION_CEILING_MS = 30 * 60_000;
+export const CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS = 10 * 60_000;
+
+/** Proven MCP activity, additionally required to be recent enough to still be evidence. */
+export function chatGptExternalProgressSuppressesDomHealth(
+  snapshot: ChatGptExternalTurnProgressSnapshot | undefined,
+  now: number,
+): boolean {
+  if (!chatGptExternalProgressIsLive(snapshot, now, CHATGPT_RESPONSE_DOM_GRACE_MS)) return false;
+  const lastProgressAt = snapshot?.lastProgressAt;
+  return lastProgressAt !== undefined
+    && now - lastProgressAt < CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS;
+}
 
 export class ChatGptStoppedThinkingTracker {
   private visibleSince?: number;
@@ -2393,10 +2409,9 @@ export class ChatGptBrowserWorker {
           snapshot = await this.responseDomSnapshot(responseTurn.locator, responseDomCache);
         }
       }
-      const externalProgressLive = chatGptExternalProgressIsLive(
+      const externalProgressLive = chatGptExternalProgressSuppressesDomHealth(
         externalProgress?.snapshot(),
         Date.now(),
-        CHATGPT_RESPONSE_DOM_GRACE_MS,
       );
       if (stoppedThinkingTracker.update(snapshot.stoppedThinkingVisible) && !externalProgressLive) {
         throw chatGptStoppedThinkingError();
@@ -3571,14 +3586,15 @@ export class ChatGptBrowserWorker {
           }
         }
         if (snapshot.responsePresent) consecutiveObservationRebinds = 0;
-        // Liveness may postpone a verdict, never waive it: past the ceiling the DOM alone decides,
-        // so a tool call that never returns cannot hold an undeadlined turn open indefinitely.
-        const externalProgressLive = Date.now() - sentAt < CHATGPT_EXTERNAL_PROGRESS_SUPPRESSION_CEILING_MS
-          && chatGptExternalProgressIsLive(
-            turn.externalProgress?.snapshot(),
-            Date.now(),
-            CHATGPT_RESPONSE_DOM_GRACE_MS,
-          );
+        // The page was read successfully, so the fault budget is genuinely consecutive even when
+        // this iteration goes on to `continue` for a rebind, confirmation, or liveness pause.
+        internalObservationFaults = 0;
+        // Liveness may postpone a verdict, never waive it: once activity goes stale the DOM alone
+        // decides, so a tool call that never returns cannot hold an undeadlined turn open forever.
+        const externalProgressLive = chatGptExternalProgressSuppressesDomHealth(
+          turn.externalProgress?.snapshot(),
+          Date.now(),
+        );
         // A stale "Stopped thinking" label is not terminal while the model is still driving tool
         // calls, so the tracker keeps observing but may not cancel the turn.
         if (stoppedThinkingTracker.update(snapshot.stoppedThinkingVisible) && !externalProgressLive) {
@@ -3672,7 +3688,6 @@ export class ChatGptBrowserWorker {
           });
           if (domError) throw new Error(domError);
         }
-        internalObservationFaults = 0;
         await new Promise(resolveSleep => setTimeout(resolveSleep, 250));
        } catch (error) {
         // Only a defect in this worker is retried here. Every deliberate signal — adapter errors,

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -2671,10 +2671,16 @@ export class ChatGptBrowserWorker {
         .filter(renderedInDom);
       const streamingStatusContainers = [...root.querySelectorAll<HTMLElement>("[data-streaming-response-status]")]
         .filter(renderedInDom);
+      const firstStreamingStatusContainer = streamingStatusContainers[0];
       const commentaryRoots = allMarkdownRoots.filter(candidate => (
         candidate.closest("[data-streaming-response-status]") !== null
-        || streamingStatusContainers.some(status => (
-          Boolean(candidate.compareDocumentPosition(status) & Node.DOCUMENT_POSITION_FOLLOWING)
+        // Only Markdown that precedes the FIRST status container is prior commentary. Keying this
+        // on "some status follows me" silently reclassified answer text as commentary as soon as a
+        // second tool call opened another status container below it, which both zeroed the visible
+        // text and dropped every answer chunk emitted between tool calls.
+        || (firstStreamingStatusContainer !== undefined && Boolean(
+          candidate.compareDocumentPosition(firstStreamingStatusContainer)
+          & Node.DOCUMENT_POSITION_FOLLOWING,
         ))
       ));
       const renderedRoots = allMarkdownRoots.filter(candidate => (

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -84,9 +84,9 @@ import {
   type CapturedChatGptLunaCheckpoint,
 } from "./rolling-checkpoint";
 import {
-  ChatGptExternalTurnProgress,
   chatGptExternalProgressIsLive,
 } from "./turn-progress";
+import type { ChatGptTurnProgressReader } from "./turn-progress";
 
 export { MAX_CHATGPT_BROWSER_TABS } from "./concurrency";
 
@@ -707,7 +707,7 @@ export interface BrowserTurn {
   /** Append-only, structurally stable Markdown chunks. */
   onTextDelta: (delta: string) => void;
   /** Proven current-turn MCP activity; liveness only, never response content or completion. */
-  externalProgress?: ChatGptExternalTurnProgress;
+  externalProgress?: ChatGptTurnProgressReader;
   /** Allow one clean pre-submit composer retry for isolated history compaction only. */
   compaction?: boolean;
   /** Require and remove the private Luna checkpoint tail from the visible Markdown stream. */
@@ -857,6 +857,17 @@ export class ChatGptTurnDomHealthTracker {
     private readonly emptyCompletionMs = CHATGPT_EMPTY_RESPONSE_GRACE_MS,
     private readonly missingCompletionActionMs = CHATGPT_COMPLETION_ACTION_GRACE_MS,
   ) {}
+
+  /**
+   * Clears only the missing-response window, leaving `sawResponse` history intact.
+   *
+   * Callers use this when proven external progress suspends DOM health checks: the suspended
+   * stretch must not be charged against the grace period, or the first observation after it
+   * resumes would fail instantly against a timestamp recorded long before.
+   */
+  clearMissingResponse(): void {
+    this.missingResponseSince = undefined;
+  }
 
   update(state: {
     responsePresent: boolean;
@@ -1779,7 +1790,7 @@ export class ChatGptBrowserWorker {
   private async waitForTurnDomOrExternalProgress(
     page: Page,
     afterProgressRevision: number,
-    externalProgress?: ChatGptExternalTurnProgress,
+    externalProgress?: ChatGptTurnProgressReader,
     signal?: AbortSignal,
   ): Promise<void> {
     const domMutation = this.waitForTurnDomMutation(page);
@@ -1805,7 +1816,7 @@ export class ChatGptBrowserWorker {
     page: Page,
     baseline: ChatGptSubmissionBaseline,
     signal?: AbortSignal,
-    externalProgress?: ChatGptExternalTurnProgress,
+    externalProgress?: ChatGptTurnProgressReader,
     initialToolBatchRevision = externalProgress?.snapshot().lastToolBatchRevision ?? 0,
   ): Promise<ChatGptSubmissionEvidence> {
     if (signal?.aborted) throw new DOMException("ChatGPT web turn aborted", "AbortError");
@@ -1961,7 +1972,7 @@ export class ChatGptBrowserWorker {
     baseline: ChatGptSubmissionBaseline,
     deadline: number | undefined,
     signal?: AbortSignal,
-    externalProgress?: ChatGptExternalTurnProgress,
+    externalProgress?: ChatGptTurnProgressReader,
   ): Promise<ChatGptAssistantTurnBinding> {
     let responseDeadline = Math.min(
       deadline ?? Number.POSITIVE_INFINITY,
@@ -2290,7 +2301,7 @@ export class ChatGptBrowserWorker {
     baseline: ChatGptSubmissionBaseline,
     captureDiagnostic?: (checkpoint: string) => Promise<void>,
     abortSignal?: AbortSignal,
-    externalProgress?: ChatGptExternalTurnProgress,
+    externalProgress?: ChatGptTurnProgressReader,
     submissionLifecycle?: Pick<BrowserTurn, "onSendActivated" | "onSubmitted">,
   ): Promise<ChatGptSubmissionEvidence> {
     const composer = await this.activeComposer(page);
@@ -2325,6 +2336,7 @@ export class ChatGptBrowserWorker {
     stage: ChatGptWebMultipartStage,
     deadline: number | undefined,
     abortSignal?: AbortSignal,
+    externalProgress?: ChatGptTurnProgressReader,
   ): Promise<void> {
     const completionTracker = new ChatGptCompletionTracker();
     const domHealthTracker = new ChatGptTurnDomHealthTracker();
@@ -2353,8 +2365,20 @@ export class ChatGptBrowserWorker {
           snapshot = await this.responseDomSnapshot(responseTurn.locator, responseDomCache);
         }
       }
-      if (stoppedThinkingTracker.update(snapshot.stoppedThinkingVisible)) {
+      const externalProgressLive = chatGptExternalProgressIsLive(
+        externalProgress?.snapshot(),
+        Date.now(),
+        CHATGPT_RESPONSE_DOM_GRACE_MS,
+      );
+      if (stoppedThinkingTracker.update(snapshot.stoppedThinkingVisible) && !externalProgressLive) {
         throw chatGptStoppedThinkingError();
+      }
+      if (!snapshot.responsePresent && externalProgressLive) {
+        // Proven MCP activity outranks a momentarily unavailable staging DOM, exactly as it does
+        // in the main turn loop.
+        domHealthTracker.clearMissingResponse();
+        await new Promise(resolveSleep => setTimeout(resolveSleep, 250));
+        continue;
       }
       const running = await page.locator(CHATGPT_STOP_BUTTON_SELECTOR).last().isVisible().catch(() => false);
       const domError = domHealthTracker.update({
@@ -3306,6 +3330,7 @@ export class ChatGptBrowserWorker {
             stage,
             deadline,
             turn.abortSignal,
+            turn.externalProgress,
           );
           await diagnostics.capture(page, `multipart-stage-${index + 1}-acknowledged`);
         }
@@ -3505,17 +3530,21 @@ export class ChatGptBrowserWorker {
           }
         }
         if (snapshot.responsePresent) consecutiveObservationRebinds = 0;
-        if (stoppedThinkingTracker.update(snapshot.stoppedThinkingVisible)) {
-          throw chatGptStoppedThinkingError();
-        }
-        if (!snapshot.responsePresent && chatGptExternalProgressIsLive(
+        const externalProgressLive = chatGptExternalProgressIsLive(
           turn.externalProgress?.snapshot(),
           Date.now(),
           CHATGPT_RESPONSE_DOM_GRACE_MS,
-        )) {
+        );
+        // A stale "Stopped thinking" label is not terminal while the model is still driving tool
+        // calls, so the tracker keeps observing but may not cancel the turn.
+        if (stoppedThinkingTracker.update(snapshot.stoppedThinkingVisible) && !externalProgressLive) {
+          throw chatGptStoppedThinkingError();
+        }
+        if (!snapshot.responsePresent && externalProgressLive) {
           // Current-turn MCP activity proves that ChatGPT is still executing even if its renderer
           // temporarily cannot expose the response subtree. DOM remains authoritative for text and
           // completion; this only prevents a live turn from being misclassified as vanished.
+          domHealthTracker.clearMissingResponse();
           await new Promise(resolveSleep => setTimeout(resolveSleep, 250));
           continue;
         }

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -927,6 +927,24 @@ export class ChatGptTurnDomHealthTracker {
 
 export const CHATGPT_STOPPED_THINKING_GRACE_MS = 5_000;
 
+/**
+ * Consecutive internal observation faults tolerated before a turn is abandoned.
+ *
+ * A `TypeError` raised while reading the page is a defect in this worker, not evidence about
+ * ChatGPT. Tearing the turn down on one loses an accepted ChatGPT turn that cannot be resent, so
+ * the loop re-observes instead. The budget is consecutive: any successful observation resets it,
+ * and exhausting it still fails closed with the original fault as the cause.
+ */
+export const MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS = 8;
+
+/**
+ * Absolute ceiling on how long proven MCP progress may suppress DOM health checks.
+ *
+ * Liveness is reported while a tool call is outstanding, so a tool that never returns would
+ * otherwise hold a turn open forever whenever the caller supplied no turn deadline.
+ */
+export const CHATGPT_EXTERNAL_PROGRESS_SUPPRESSION_CEILING_MS = 30 * 60_000;
+
 export class ChatGptStoppedThinkingTracker {
   private visibleSince?: number;
 
@@ -2674,6 +2692,10 @@ export class ChatGptBrowserWorker {
       const firstStreamingStatusContainer = streamingStatusContainers[0];
       const commentaryRoots = allMarkdownRoots.filter(candidate => (
         candidate.closest("[data-streaming-response-status]") !== null
+        // Chain-of-thought components carry reasoning, never the final answer, so containment is a
+        // positional-independent commentary signal. Position alone cannot separate "commentary
+        // between two status containers" from "answer between two tool calls".
+        || candidate.closest('[data-testid^="cot-v5"]') !== null
         // Only Markdown that precedes the FIRST status container is prior commentary. Keying this
         // on "some status follows me" silently reclassified answer text as commentary as soon as a
         // second tool call opened another status container below it, which both zeroed the visible
@@ -3476,7 +3498,9 @@ export class ChatGptBrowserWorker {
       const stoppedThinkingTracker = new ChatGptStoppedThinkingTracker();
       const responseDomCache: ChatGptResponseDomCache = {};
       let consecutiveObservationRebinds = 0;
+      let internalObservationFaults = 0;
       for (;;) {
+       try {
         if (page.isClosed()) {
           throw chatGptBrowserTabClosedError();
         }
@@ -3547,11 +3571,14 @@ export class ChatGptBrowserWorker {
           }
         }
         if (snapshot.responsePresent) consecutiveObservationRebinds = 0;
-        const externalProgressLive = chatGptExternalProgressIsLive(
-          turn.externalProgress?.snapshot(),
-          Date.now(),
-          CHATGPT_RESPONSE_DOM_GRACE_MS,
-        );
+        // Liveness may postpone a verdict, never waive it: past the ceiling the DOM alone decides,
+        // so a tool call that never returns cannot hold an undeadlined turn open indefinitely.
+        const externalProgressLive = Date.now() - sentAt < CHATGPT_EXTERNAL_PROGRESS_SUPPRESSION_CEILING_MS
+          && chatGptExternalProgressIsLive(
+            turn.externalProgress?.snapshot(),
+            Date.now(),
+            CHATGPT_RESPONSE_DOM_GRACE_MS,
+          );
         // A stale "Stopped thinking" label is not terminal while the model is still driving tool
         // calls, so the tracker keeps observing but may not cancel the turn.
         if (stoppedThinkingTracker.update(snapshot.stoppedThinkingVisible) && !externalProgressLive) {
@@ -3645,7 +3672,28 @@ export class ChatGptBrowserWorker {
           });
           if (domError) throw new Error(domError);
         }
+        internalObservationFaults = 0;
         await new Promise(resolveSleep => setTimeout(resolveSleep, 250));
+       } catch (error) {
+        // Only a defect in this worker is retried here. Every deliberate signal — adapter errors,
+        // aborts, closed tabs, DOM-health verdicts — still fails the turn immediately.
+        if (!(error instanceof TypeError)) throw error;
+        internalObservationFaults += 1;
+        if (internalObservationFaults > MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS) {
+          throw new Error(
+            `ChatGPT browser observation failed ${internalObservationFaults} times in a row: ${error.message}`,
+            { cause: error },
+          );
+        }
+        console.warn(
+          `[chatgpt-web] browser turn ${turn.traceId} tolerated internal observation fault`
+          + ` ${internalObservationFaults}/${MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS}: ${error.message}`,
+        );
+        await diagnostics.capture(page, "internal-observation-fault");
+        responseDomCache.key = undefined;
+        responseDomCache.snapshot = undefined;
+        await new Promise(resolveSleep => setTimeout(resolveSleep, 250));
+       }
       }
 
       if (this.context && this.config.browserHost === "managed-chrome") {

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -874,9 +874,19 @@ export class ChatGptTurnDomHealthTracker {
     running: boolean;
     currentText: string;
     completionActionVisible: boolean;
+    externalProgressLive?: boolean;
   }, now = Date.now()): string | undefined {
+    if (state.responsePresent) this.sawResponse = true;
+    if (state.externalProgressLive) {
+      // Every conclusion below asserts that ChatGPT stopped producing this turn. A tool call that
+      // is still completing disproves all of them, whatever the renderer is currently exposing, so
+      // no window may accrue while the model is provably working.
+      this.missingResponseSince = undefined;
+      this.emptyCompletionSince = undefined;
+      this.missingCompletionAction = undefined;
+      return undefined;
+    }
     if (state.responsePresent) {
-      this.sawResponse = true;
       this.missingResponseSince = undefined;
     } else {
       this.missingResponseSince ??= now;
@@ -2386,6 +2396,7 @@ export class ChatGptBrowserWorker {
         running,
         currentText: snapshot.visibleText,
         completionActionVisible: snapshot.completionActionVisible,
+        externalProgressLive,
       });
       if (domError) throw new Error(domError);
       if (completionTracker.update({
@@ -3573,6 +3584,7 @@ export class ChatGptBrowserWorker {
             running,
             currentText: snapshot.visibleText,
             completionActionVisible: snapshot.completionActionVisible,
+            externalProgressLive,
           });
           if (domError) throw new Error(domError);
           if (completionTracker.update({
@@ -3623,6 +3635,7 @@ export class ChatGptBrowserWorker {
             running,
             currentText: "",
             completionActionVisible: false,
+            externalProgressLive,
           });
           if (domError) throw new Error(domError);
         }

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -2717,25 +2717,38 @@ export class ChatGptBrowserWorker {
         .filter(renderedInDom);
       const streamingStatusContainers = [...root.querySelectorAll<HTMLElement>("[data-streaming-response-status]")]
         .filter(renderedInDom);
-      const firstStreamingStatusContainer = streamingStatusContainers[0];
-      const commentaryRoots = allMarkdownRoots.filter(candidate => (
-        candidate.closest("[data-streaming-response-status]") !== null
-        // Chain-of-thought components carry reasoning, never the final answer, so containment is a
-        // positional-independent commentary signal. Position alone cannot separate "commentary
-        // between two status containers" from "answer between two tool calls".
-        || candidate.closest('[data-testid^="cot-v5"]') !== null
-        // Only Markdown that precedes the FIRST status container is prior commentary. Keying this
-        // on "some status follows me" silently reclassified answer text as commentary as soon as a
-        // second tool call opened another status container below it, which both zeroed the visible
-        // text and dropped every answer chunk emitted between tool calls.
-        || (firstStreamingStatusContainer !== undefined && Boolean(
-          candidate.compareDocumentPosition(firstStreamingStatusContainer)
-          & Node.DOCUMENT_POSITION_FOLLOWING,
-        ))
-      ));
-      const renderedRoots = allMarkdownRoots.filter(candidate => (
-        !commentaryRoots.includes(candidate)
-      ));
+      // CHATGPT_COMMENTARY_CLASSIFIER_BEGIN
+      // Self-contained so the test suite can execute this exact source against a synthetic DOM;
+      // it must not close over anything from the surrounding evaluate scope.
+      const selectChatGptAnswerRoots = (
+        markdownRoots: HTMLElement[],
+        statusContainers: HTMLElement[],
+      ): { commentaryRoots: HTMLElement[]; answerRoots: HTMLElement[] } => {
+        const firstStatusContainer = statusContainers[0];
+        const commentary = markdownRoots.filter(candidate => (
+          candidate.closest("[data-streaming-response-status]") !== null
+          // Chain-of-thought components carry reasoning, never the final answer, so containment is
+          // a position-independent commentary signal. Position alone cannot separate "commentary
+          // between two status containers" from "answer between two tool calls".
+          || candidate.closest('[data-testid^="cot-v5"]') !== null
+          // Only Markdown that precedes the FIRST status container is prior commentary. Keying
+          // this on "some status follows me" silently reclassified answer text as commentary as
+          // soon as a second tool call opened another status container below it, which both zeroed
+          // the visible text and dropped every answer chunk emitted between tool calls.
+          || (firstStatusContainer !== undefined && Boolean(
+            // 4 is Node.DOCUMENT_POSITION_FOLLOWING, inlined to keep this function standalone.
+            candidate.compareDocumentPosition(firstStatusContainer) & 4,
+          ))
+        ));
+        return {
+          commentaryRoots: commentary,
+          answerRoots: markdownRoots.filter(candidate => !commentary.includes(candidate)),
+        };
+      };
+      // CHATGPT_COMMENTARY_CLASSIFIER_END
+      const classified = selectChatGptAnswerRoots(allMarkdownRoots, streamingStatusContainers);
+      const commentaryRoots = classified.commentaryRoots;
+      const renderedRoots = classified.answerRoots;
       // ChatGPT may merge adjacent `.markdown` roots or virtualize an old prefix while a streamed
       // answer is finalized. Root boundaries and visible indices therefore are not identity:
       // flatten semantic blocks and preserve ChatGPT's source ranges across that reparenting.

--- a/src/adapters/chatgpt-web/launcher-helper-client.ts
+++ b/src/adapters/chatgpt-web/launcher-helper-client.ts
@@ -1,6 +1,6 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { existsSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { createInterface } from "node:readline";
 import { notifyLauncherTurn, readLauncherBrowserHostDescriptor } from "../../launcher-browser-host";
 import { ChatGptWebAdapterError } from "./adapter-error";
@@ -163,7 +163,11 @@ export class LauncherBrowserHelperClient {
    */
   private bundledHelperScript(): string | undefined {
     const entrypoint = process.argv[1];
-    if (typeof entrypoint !== "string" || !entrypoint) return undefined;
+    // Only the packaged runtime layout is claimed: the bundle builder emits cli.js and
+    // browser-helper.cjs into one directory. Matching on that entrypoint name keeps a source
+    // checkout, or any other launch shape, on the launcher-advertised helper rather than adopting
+    // an unrelated sibling that merely shares a filename.
+    if (typeof entrypoint !== "string" || basename(entrypoint) !== "cli.js") return undefined;
     const sibling = join(dirname(entrypoint), "browser-helper.cjs");
     return existsSync(sibling) ? sibling : undefined;
   }

--- a/src/adapters/chatgpt-web/launcher-helper-client.ts
+++ b/src/adapters/chatgpt-web/launcher-helper-client.ts
@@ -17,6 +17,7 @@ interface PendingTurn {
   sent?: boolean;
   prepared?: CompiledChatGptWebPrompt & { release: () => void };
   localFailure?: Error;
+  progressForwarding?: AbortController;
 }
 
 type HelperMessage =
@@ -179,6 +180,9 @@ export class LauncherBrowserHelperClient {
         // Setting this before the synchronous write call makes an abort either prevent dispatch or
         // queue an `abort` after the `run` frame; it can never overtake the run frame in the pipe.
         pending.sent = true;
+        const progressForwarding = new AbortController();
+        pending.progressForwarding = progressForwarding;
+        this.forwardProgress(turn, progressForwarding.signal);
         void this.send({
           type: "run",
           id: turn.traceId,
@@ -406,12 +410,37 @@ export class LauncherBrowserHelperClient {
     });
   }
 
+  /**
+   * Mirrors daemon-recorded MCP progress into the helper process for the life of the turn.
+   *
+   * The browser worker runs out of process, so without this the worker sees no external progress
+   * and cancels turns whose tool calls are still completing.
+   */
+  private forwardProgress(turn: BrowserTurn, stop: AbortSignal): void {
+    const progress = turn.externalProgress;
+    if (!progress) return;
+    void (async () => {
+      let revision = 0;
+      while (!stop.aborted) {
+        const snapshot = await progress.waitForChange(revision, stop);
+        revision = snapshot.revision;
+        if (stop.aborted) return;
+        await this.send({ type: "progress", id: turn.traceId, snapshot });
+      }
+    })().catch(() => {
+      // A turn that ends, aborts, or loses its helper stops the mirror; the worker then falls back
+      // to DOM-only health, which is the pre-existing behaviour rather than a new failure mode.
+    });
+  }
+
   private finish(id: string): void {
     const pending = this.pending.get(id);
     if (!pending) return;
     if (pending.abortListener && pending.turn.abortSignal) {
       pending.turn.abortSignal.removeEventListener("abort", pending.abortListener);
     }
+    pending.progressForwarding?.abort();
+    pending.progressForwarding = undefined;
     pending.prepared?.release();
     pending.prepared = undefined;
     this.pending.delete(id);

--- a/src/adapters/chatgpt-web/launcher-helper-client.ts
+++ b/src/adapters/chatgpt-web/launcher-helper-client.ts
@@ -21,7 +21,7 @@ interface PendingTurn {
 }
 
 type HelperMessage =
-  | { type: "ready" }
+  | { type: "ready"; features?: string[] }
   | { type: "event"; id: string; event: "heartbeat" | "send_activated" | "submitted" | "reasoning" | "commentary" | "text"; text?: string; continuation?: boolean }
   | { type: "event"; id: string; event: "prepared_selected"; reused: boolean }
   | { type: "event"; id: string; event: "luna_checkpoint"; checkpoint: ChatGptLunaCheckpoint; answerHash: string }
@@ -43,7 +43,14 @@ function parseHelperMessage(line: string): HelperMessage {
     throw new Error("Launcher browser helper message is not an object");
   }
   const message = value as Record<string, unknown>;
-  if (message.type === "ready") return { type: "ready" };
+  if (message.type === "ready") {
+    const features = message.features;
+    if (features !== undefined
+      && (!Array.isArray(features) || features.some(feature => typeof feature !== "string"))) {
+      throw new Error("Launcher browser helper advertised invalid features");
+    }
+    return { type: "ready", ...(features ? { features: features as string[] } : {}) };
+  }
   if (typeof message.id !== "string" || !message.id) {
     throw new Error("Launcher browser helper message has no turn identity");
   }
@@ -140,6 +147,7 @@ export class LauncherBrowserHelperClient {
   private readyResolve?: () => void;
   private readyReject?: (error: Error) => void;
   private readonly pending = new Map<string, PendingTurn>();
+  private helperFeatures = new Set<string>();
 
   constructor(private readonly config: ResolvedBrowserConfig) {}
 
@@ -311,6 +319,9 @@ export class LauncherBrowserHelperClient {
       return;
     }
     if (message.type === "ready") {
+      // An older helper advertises nothing and must never be sent optional frames: it would route
+      // them to its run handler and destroy the turn with an opaque TypeError.
+      this.helperFeatures = new Set(message.features ?? []);
       this.readyResolve?.();
       this.readyResolve = undefined;
       this.readyReject = undefined;
@@ -419,6 +430,13 @@ export class LauncherBrowserHelperClient {
   private forwardProgress(turn: BrowserTurn, stop: AbortSignal): void {
     const progress = turn.externalProgress;
     if (!progress) return;
+    if (!this.helperFeatures.has("progress")) {
+      console.warn(
+        `[chatgpt-web] browser turn ${turn.traceId} runs without an MCP progress mirror:`
+        + " the launcher browser helper predates the progress frame",
+      );
+      return;
+    }
     void (async () => {
       let revision = 0;
       while (!stop.aborted) {

--- a/src/adapters/chatgpt-web/launcher-helper-client.ts
+++ b/src/adapters/chatgpt-web/launcher-helper-client.ts
@@ -207,7 +207,6 @@ export class LauncherBrowserHelperClient {
         pending.sent = true;
         const progressForwarding = new AbortController();
         pending.progressForwarding = progressForwarding;
-        this.forwardProgress(turn, progressForwarding.signal);
         void this.send({
           type: "run",
           id: turn.traceId,
@@ -231,7 +230,13 @@ export class LauncherBrowserHelperClient {
             ...(turn.compaction ? { compaction: true } : {}),
             ...(turn.captureLunaCheckpoint ? { captureLunaCheckpoint: true } : {}),
           },
-        }).catch(error => this.finishWithError(turn.traceId, error instanceof Error ? error : new Error(String(error))));
+        })
+          // Only mirror once the run frame is on the wire, so the helper never sees progress for a
+          // turn it has not been told about and cannot accumulate state for unknown ids.
+          .then(() => {
+            if (!progressForwarding.signal.aborted) this.forwardProgress(turn, progressForwarding.signal);
+          })
+          .catch(error => this.finishWithError(turn.traceId, error instanceof Error ? error : new Error(String(error))));
       });
   }
 

--- a/src/adapters/chatgpt-web/launcher-helper-client.ts
+++ b/src/adapters/chatgpt-web/launcher-helper-client.ts
@@ -1,4 +1,6 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { createInterface } from "node:readline";
 import { notifyLauncherTurn, readLauncherBrowserHostDescriptor } from "../../launcher-browser-host";
 import { ChatGptWebAdapterError } from "./adapter-error";
@@ -151,6 +153,21 @@ export class LauncherBrowserHelperClient {
 
   constructor(private readonly config: ResolvedBrowserConfig) {}
 
+  /**
+   * The helper that shipped with this daemon, when one sits beside its own entrypoint.
+   *
+   * The launcher advertises the helper inside its application bundle while the daemon runs from a
+   * versioned runtime directory, so the two sides update independently and can disagree about the
+   * protocol. Preferring the sibling keeps daemon and helper on the same build by construction;
+   * anything else — a source checkout, an unbundled entrypoint — falls back to the advertised path.
+   */
+  private bundledHelperScript(): string | undefined {
+    const entrypoint = process.argv[1];
+    if (typeof entrypoint !== "string" || !entrypoint) return undefined;
+    const sibling = join(dirname(entrypoint), "browser-helper.cjs");
+    return existsSync(sibling) ? sibling : undefined;
+  }
+
   async run(turn: BrowserTurn): Promise<string> {
     if (turn.abortSignal?.aborted) throw new DOMException("ChatGPT web turn aborted", "AbortError");
     await this.ensureChild();
@@ -243,7 +260,7 @@ export class LauncherBrowserHelperClient {
     const descriptor = readLauncherBrowserHostDescriptor(this.config.browserHostDescriptorPath!);
     const child = spawn(
       descriptor.helper.executable,
-      [this.config.browserHelperScriptPath ?? descriptor.helper.script],
+      [this.config.browserHelperScriptPath ?? this.bundledHelperScript() ?? descriptor.helper.script],
       {
         env: {
           ...process.env,

--- a/src/adapters/chatgpt-web/launcher-helper-client.ts
+++ b/src/adapters/chatgpt-web/launcher-helper-client.ts
@@ -427,9 +427,15 @@ export class LauncherBrowserHelperClient {
         if (stop.aborted) return;
         await this.send({ type: "progress", id: turn.traceId, snapshot });
       }
-    })().catch(() => {
-      // A turn that ends, aborts, or loses its helper stops the mirror; the worker then falls back
-      // to DOM-only health, which is the pre-existing behaviour rather than a new failure mode.
+    })().catch(error => {
+      // Ending, aborting, or losing the helper stops the mirror by design and is not a fault.
+      // Anything else leaves the worker on DOM-only health without saying so, which is exactly the
+      // silent degradation this transport exists to remove, so it is surfaced rather than dropped.
+      if (stop.aborted || (error instanceof DOMException && error.name === "AbortError")) return;
+      console.warn(
+        `[chatgpt-web] browser turn ${turn.traceId} lost its MCP progress mirror:`
+        + ` ${error instanceof Error ? error.message : String(error)}`,
+      );
     });
   }
 

--- a/src/adapters/chatgpt-web/turn-progress.ts
+++ b/src/adapters/chatgpt-web/turn-progress.ts
@@ -134,6 +134,16 @@ export class ChatGptMirroredTurnProgress extends ChatGptTurnProgressBroadcaster 
   apply(next: ChatGptExternalTurnProgressSnapshot): boolean {
     assertChatGptTurnProgressSnapshot(next);
     if (next.revision <= this.current.revision) return false;
+    // A frame that advances the revision must not contradict what it already reported: the
+    // recorder only ever moves these forward, so a regression means a corrupt or forged frame
+    // rather than an ordering artefact, and accepting it would desynchronise observed liveness.
+    if (next.lastToolBatchRevision < this.current.lastToolBatchRevision
+      || (next.lastProgressAt === undefined && this.current.lastProgressAt !== undefined)
+      || (next.lastProgressAt !== undefined
+        && this.current.lastProgressAt !== undefined
+        && next.lastProgressAt < this.current.lastProgressAt)) {
+      throw new Error("ChatGPT external progress snapshot regressed against the observed state");
+    }
     this.current = { ...next };
     this.notify(this.snapshot());
     return true;
@@ -149,7 +159,10 @@ export function assertChatGptTurnProgressSnapshot(
     || !finiteIndex(value.lastToolBatchRevision)
     || !finiteIndex(value.activeToolCalls)
     || value.lastToolBatchRevision > value.revision
-    || (value.lastProgressAt !== undefined && !Number.isFinite(value.lastProgressAt))) {
+    || (value.lastProgressAt !== undefined && !Number.isFinite(value.lastProgressAt))
+    // Any recorded activity stamps a timestamp, so a frame claiming progress without one is
+    // malformed and would otherwise report liveness the daemon never observed.
+    || (value.revision > 0 && value.lastProgressAt === undefined)) {
     throw new Error("ChatGPT external progress snapshot is invalid");
   }
 }

--- a/src/adapters/chatgpt-web/turn-progress.ts
+++ b/src/adapters/chatgpt-web/turn-progress.ts
@@ -14,18 +14,68 @@ interface ProgressWaiter {
 }
 
 /**
+ * The read surface the browser worker depends on.
+ *
+ * The worker never records progress; it only observes it. Declaring the dependency as this
+ * interface lets the launcher helper process observe a mirrored copy of the daemon's progress
+ * without owning the recording side.
+ */
+export interface ChatGptTurnProgressReader {
+  snapshot(): ChatGptExternalTurnProgressSnapshot;
+  waitForChange(afterRevision: number, signal?: AbortSignal): Promise<ChatGptExternalTurnProgressSnapshot>;
+}
+
+/**
  * Carries only proven Codex MCP activity into the browser worker.
  *
  * It is deliberately not a completion channel: browser-visible text and terminal state remain
  * owned by the ChatGPT DOM. A valid current-turn tool request only proves that submission was
  * accepted and that the model is still making progress while its DOM is temporarily unavailable.
  */
-export class ChatGptExternalTurnProgress {
+abstract class ChatGptTurnProgressBroadcaster implements ChatGptTurnProgressReader {
+  private readonly waiters = new Set<ProgressWaiter>();
+
+  abstract snapshot(): ChatGptExternalTurnProgressSnapshot;
+
+  waitForChange(afterRevision: number, signal?: AbortSignal): Promise<ChatGptExternalTurnProgressSnapshot> {
+    if (!Number.isSafeInteger(afterRevision) || afterRevision < 0) {
+      throw new Error("ChatGPT external progress revision must be a non-negative safe integer");
+    }
+    const current = this.snapshot();
+    if (current.revision > afterRevision) return Promise.resolve(current);
+    if (signal?.aborted) {
+      return Promise.reject(new DOMException("ChatGPT external progress wait aborted", "AbortError"));
+    }
+    return new Promise((resolve, reject) => {
+      const waiter: ProgressWaiter = { afterRevision, resolve, reject, ...(signal ? { signal } : {}) };
+      if (signal) {
+        waiter.onAbort = () => {
+          this.waiters.delete(waiter);
+          reject(new DOMException("ChatGPT external progress wait aborted", "AbortError"));
+        };
+        signal.addEventListener("abort", waiter.onAbort, { once: true });
+      }
+      this.waiters.add(waiter);
+    });
+  }
+
+  protected notify(snapshot: ChatGptExternalTurnProgressSnapshot): void {
+    for (const waiter of [...this.waiters]) {
+      if (snapshot.revision <= waiter.afterRevision) continue;
+      this.waiters.delete(waiter);
+      if (waiter.signal && waiter.onAbort) {
+        waiter.signal.removeEventListener("abort", waiter.onAbort);
+      }
+      waiter.resolve(snapshot);
+    }
+  }
+}
+
+export class ChatGptExternalTurnProgress extends ChatGptTurnProgressBroadcaster {
   private revision = 0;
   private lastToolBatchRevision = 0;
   private activeToolCalls = 0;
   private lastProgressAt?: number;
-  private readonly waiters = new Set<ProgressWaiter>();
 
   snapshot(): ChatGptExternalTurnProgressSnapshot {
     return {
@@ -52,42 +102,55 @@ export class ChatGptExternalTurnProgress {
     this.advance(now, "tool_result");
   }
 
-  waitForChange(afterRevision: number, signal?: AbortSignal): Promise<ChatGptExternalTurnProgressSnapshot> {
-    if (!Number.isSafeInteger(afterRevision) || afterRevision < 0) {
-      throw new Error("ChatGPT external progress revision must be a non-negative safe integer");
-    }
-    const current = this.snapshot();
-    if (current.revision > afterRevision) return Promise.resolve(current);
-    if (signal?.aborted) {
-      return Promise.reject(new DOMException("ChatGPT external progress wait aborted", "AbortError"));
-    }
-    return new Promise((resolve, reject) => {
-      const waiter: ProgressWaiter = { afterRevision, resolve, reject, ...(signal ? { signal } : {}) };
-      if (signal) {
-        waiter.onAbort = () => {
-          this.waiters.delete(waiter);
-          reject(new DOMException("ChatGPT external progress wait aborted", "AbortError"));
-        };
-        signal.addEventListener("abort", waiter.onAbort, { once: true });
-      }
-      this.waiters.add(waiter);
-    });
-  }
-
   private advance(now: number, event: "tool_batch" | "tool_result"): void {
     if (!Number.isFinite(now)) throw new Error("ChatGPT external progress timestamp must be finite");
     this.revision += 1;
     if (event === "tool_batch") this.lastToolBatchRevision = this.revision;
     this.lastProgressAt = now;
-    const snapshot = this.snapshot();
-    for (const waiter of [...this.waiters]) {
-      if (snapshot.revision <= waiter.afterRevision) continue;
-      this.waiters.delete(waiter);
-      if (waiter.signal && waiter.onAbort) {
-        waiter.signal.removeEventListener("abort", waiter.onAbort);
-      }
-      waiter.resolve(snapshot);
-    }
+    this.notify(this.snapshot());
+  }
+}
+
+/**
+ * Replays daemon-recorded progress inside the launcher browser helper process.
+ *
+ * The browser worker runs out of process from the Codex MCP broker, so the recording instance
+ * cannot be shared with it. Without a mirror the worker observes no progress at all and its
+ * liveness guards silently degrade to "never live", which lets a turn be cancelled while its tool
+ * calls are still completing.
+ */
+export class ChatGptMirroredTurnProgress extends ChatGptTurnProgressBroadcaster {
+  private current: ChatGptExternalTurnProgressSnapshot = {
+    revision: 0,
+    lastToolBatchRevision: 0,
+    activeToolCalls: 0,
+  };
+
+  snapshot(): ChatGptExternalTurnProgressSnapshot {
+    return { ...this.current };
+  }
+
+  /** Ignores stale or replayed frames so out-of-order delivery cannot rewind observed liveness. */
+  apply(next: ChatGptExternalTurnProgressSnapshot): boolean {
+    assertChatGptTurnProgressSnapshot(next);
+    if (next.revision <= this.current.revision) return false;
+    this.current = { ...next };
+    this.notify(this.snapshot());
+    return true;
+  }
+}
+
+export function assertChatGptTurnProgressSnapshot(
+  value: ChatGptExternalTurnProgressSnapshot,
+): void {
+  const finiteIndex = (candidate: number): boolean => Number.isSafeInteger(candidate) && candidate >= 0;
+  if (!value
+    || !finiteIndex(value.revision)
+    || !finiteIndex(value.lastToolBatchRevision)
+    || !finiteIndex(value.activeToolCalls)
+    || value.lastToolBatchRevision > value.revision
+    || (value.lastProgressAt !== undefined && !Number.isFinite(value.lastProgressAt))) {
+    throw new Error("ChatGPT external progress snapshot is invalid");
   }
 }
 

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import type { Page } from "playwright-core";
-import { CHATGPT_BROWSER_OBSERVATION_PROBE_TIMEOUT_MS, CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS, chatGptExternalProgressSuppressesDomHealth, CHATGPT_RESPONSE_DOM_GRACE_MS, MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS, CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_STOPPED_THINKING_GRACE_MS, ChatGptBrowserObservationTimeoutError, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_PAGE_REBINDS, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, assertChatGptWebMultipartInputWithinLimits, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptConnectorAttachmentMode, chatGptEffortSelectionRequired, chatGptNewTurnIdentity, chatGptReboundTurnIdentity, chatGptSubmissionEvidence, dismissChatGptTemporaryChatOnboarding, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, resolveChatGptWebMultipartStagingMode, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert, withChatGptBrowserObservationTimeout } from "../src/adapters/chatgpt-web/browser-worker";
+import { CHATGPT_BROWSER_OBSERVATION_PROBE_TIMEOUT_MS, CHATGPT_EXTERNAL_PROGRESS_CLOCK_SKEW_MS, CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS, ChatGptCompletionTracker, chatGptExternalProgressSuppressesDomHealth, CHATGPT_RESPONSE_DOM_GRACE_MS, MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS, CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_STOPPED_THINKING_GRACE_MS, ChatGptBrowserObservationTimeoutError, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_PAGE_REBINDS, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, assertChatGptWebMultipartInputWithinLimits, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptConnectorAttachmentMode, chatGptEffortSelectionRequired, chatGptNewTurnIdentity, chatGptReboundTurnIdentity, chatGptSubmissionEvidence, dismissChatGptTemporaryChatOnboarding, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, resolveChatGptWebMultipartStagingMode, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert, withChatGptBrowserObservationTimeout } from "../src/adapters/chatgpt-web/browser-worker";
 import { chatGptStoppedThinkingError } from "../src/adapters/chatgpt-web/adapter-error";
 import { CHATGPT_WEB_MODEL_ID } from "../src/adapters/chatgpt-web/model";
 import { CHATGPT_CONNECTOR_NAME, DEV_CHATGPT_CONNECTOR_NAME, defaultChromeExecutable, legacyChatGptConnectorMigrationMessage } from "../src/config";
@@ -2393,4 +2393,62 @@ test("the shipped commentary classifier separates answer Markdown from reasoning
 
   // A turn with no status container at all is entirely answer.
   expect(answerFor('<div class="markdown">ONLY ANSWER</div>')).toBe("ONLY ANSWER");
+});
+
+test("proven MCP progress vetoes completion, not only the health verdicts", () => {
+  const tracker = new ChatGptCompletionTracker(500);
+  const finishedLooking = {
+    responsePresent: true,
+    running: false,
+    currentText: "partial answer so far",
+    currentHtml: "<p>partial answer so far</p>",
+    completionActionVisible: true,
+  };
+
+  // Between two tool calls the rendered message can look finished. Completing there returns a
+  // truncated answer and retires the turn while its own tool calls are still in flight.
+  expect(tracker.update({ ...finishedLooking, externalProgressLive: true }, 1_000)).toBeFalse();
+  expect(tracker.update({ ...finishedLooking, externalProgressLive: true }, 5_000)).toBeFalse();
+
+  // Once the model is genuinely idle the settle window starts fresh rather than completing at once.
+  expect(tracker.update(finishedLooking, 5_100)).toBeFalse();
+  expect(tracker.update(finishedLooking, 5_599)).toBeFalse();
+  expect(tracker.update(finishedLooking, 5_600)).toBeTrue();
+});
+
+test("a future progress timestamp is not treated as liveness", () => {
+  const base = { revision: 2, lastToolBatchRevision: 2, activeToolCalls: 1 };
+
+  // "now - lastProgressAt < ceiling" is satisfied by any future timestamp, which would have kept a
+  // stuck tool call suppressing DOM health forever.
+  expect(chatGptExternalProgressSuppressesDomHealth(
+    { ...base, lastProgressAt: 10_000 + CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS * 10 },
+    10_000,
+  )).toBeFalse();
+
+  // Modest skew between the recording daemon and the observing helper is still accepted.
+  expect(chatGptExternalProgressSuppressesDomHealth(
+    { ...base, lastProgressAt: 10_000 + CHATGPT_EXTERNAL_PROGRESS_CLOCK_SKEW_MS - 1 },
+    10_000,
+  )).toBeTrue();
+});
+
+test("the bundled helper is adopted only for the packaged runtime layout", () => {
+  const client = readFileSync("src/adapters/chatgpt-web/launcher-helper-client.ts", "utf8");
+
+  // Any daemon launched some other way keeps the launcher-advertised helper rather than adopting
+  // an unrelated sibling that merely shares a filename.
+  expect(client).toContain('basename(entrypoint) !== "cli.js"');
+
+  // Trace ids are derived deterministically and can repeat, so a run must not inherit revisions
+  // recorded for an earlier turn that happened to share the id.
+  const helper = readFileSync("src/adapters/chatgpt-web/browser-helper-main.ts", "utf8");
+  expect(helper).toContain("const progress = new ChatGptMirroredTurnProgress();");
+
+  // A consumer callback must not be retried as though the page could not be read.
+  const worker = readFileSync("src/adapters/chatgpt-web/browser-worker.ts", "utf8");
+  const heartbeat = worker.indexOf("turn.onHeartbeat?.();");
+  const tryStart = worker.indexOf("       try {\n        observedThisIteration = false;");
+  expect(heartbeat).toBeGreaterThan(0);
+  expect(heartbeat).toBeLessThan(tryStart);
 });

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -1898,7 +1898,8 @@ test("response DOM separates streaming commentary from the final Markdown answer
   expect(workerSource).toContain("const commentaryRoots = allMarkdownRoots.filter");
   expect(workerSource).toContain('candidate.closest("[data-streaming-response-status]") !== null');
   expect(workerSource).toContain("const streamingStatusContainers = [...root.querySelectorAll<HTMLElement>");
-  expect(workerSource).toContain("candidate.compareDocumentPosition(status) & Node.DOCUMENT_POSITION_FOLLOWING");
+  expect(workerSource).toContain("const firstStreamingStatusContainer = streamingStatusContainers[0]");
+  expect(workerSource).toContain("candidate.compareDocumentPosition(firstStreamingStatusContainer)");
   expect(workerSource).toContain("const renderedRoots = allMarkdownRoots.filter");
   expect(workerSource).toContain("!commentaryRoots.includes(candidate)");
   expect(workerSource).toContain('fullHtml: renderedRoots.map(candidate => candidate.innerHTML).join("")');
@@ -2239,4 +2240,17 @@ test("live external progress still records that a response DOM was observed", ()
   // The turn is reported as vanished rather than never created, so `sawResponse` survived.
   expect(tracker.update(absent, 2_000)).toBeUndefined();
   expect(tracker.update(absent, 3_000)).toContain("response DOM disappeared");
+});
+
+test("answer Markdown is not reclassified as commentary when a later tool call opens a status container", () => {
+  const worker = readFileSync("src/adapters/chatgpt-web/browser-worker.ts", "utf8");
+
+  // Commentary is Markdown that precedes the FIRST streaming status container. Keying it on "some
+  // status follows me" made every answer chunk emitted before a second tool call look like prior
+  // commentary, which zeroed the visible text and silently dropped answer content.
+  expect(worker).toContain("const firstStreamingStatusContainer = streamingStatusContainers[0]");
+  expect(worker).toMatch(/candidate\.compareDocumentPosition\(firstStreamingStatusContainer\)/);
+  expect(worker).not.toMatch(
+    /streamingStatusContainers\.some\(status => \(\s*Boolean\(candidate\.compareDocumentPosition\(status\)/,
+  );
 });

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -1895,13 +1895,13 @@ test("response DOM separates streaming commentary from the final Markdown answer
   expect(workerSource).toContain("if (options.knownKey === observerKey) return { key: observerKey }");
   expect(workerSource).toContain("new MutationObserver(() =>");
   expect(workerSource).toContain('const allMarkdownRoots = [...root.querySelectorAll<HTMLElement>(".markdown")]');
-  expect(workerSource).toContain("const commentaryRoots = allMarkdownRoots.filter");
+  expect(workerSource).toContain("const selectChatGptAnswerRoots = (");
   expect(workerSource).toContain('candidate.closest("[data-streaming-response-status]") !== null');
   expect(workerSource).toContain("const streamingStatusContainers = [...root.querySelectorAll<HTMLElement>");
-  expect(workerSource).toContain("const firstStreamingStatusContainer = streamingStatusContainers[0]");
-  expect(workerSource).toContain("candidate.compareDocumentPosition(firstStreamingStatusContainer)");
-  expect(workerSource).toContain("const renderedRoots = allMarkdownRoots.filter");
-  expect(workerSource).toContain("!commentaryRoots.includes(candidate)");
+  expect(workerSource).toContain("const firstStatusContainer = statusContainers[0]");
+  expect(workerSource).toContain("candidate.compareDocumentPosition(firstStatusContainer)");
+  expect(workerSource).toContain("const renderedRoots = classified.answerRoots;");
+  expect(workerSource).toContain("markdownRoots.filter(candidate => !commentary.includes(candidate))");
   expect(workerSource).toContain('fullHtml: renderedRoots.map(candidate => candidate.innerHTML).join("")');
   expect(workerSource).toContain("const flattenedMarkdownSegments:");
   expect(workerSource).toContain("Root boundaries and visible indices therefore are not identity");
@@ -2240,19 +2240,6 @@ test("live external progress still records that a response DOM was observed", ()
   expect(tracker.update(absent, 3_000)).toContain("response DOM disappeared");
 });
 
-test("answer Markdown is not reclassified as commentary when a later tool call opens a status container", () => {
-  const worker = readFileSync("src/adapters/chatgpt-web/browser-worker.ts", "utf8");
-
-  // Commentary is Markdown that precedes the FIRST streaming status container. Keying it on "some
-  // status follows me" made every answer chunk emitted before a second tool call look like prior
-  // commentary, which zeroed the visible text and silently dropped answer content.
-  expect(worker).toContain("const firstStreamingStatusContainer = streamingStatusContainers[0]");
-  expect(worker).toMatch(/candidate\.compareDocumentPosition\(firstStreamingStatusContainer\)/);
-  expect(worker).not.toMatch(
-    /streamingStatusContainers\.some\(status => \(\s*Boolean\(candidate\.compareDocumentPosition\(status\)/,
-  );
-});
-
 test("an accepted turn survives internal observation faults instead of being torn down", () => {
   const worker = readFileSync("src/adapters/chatgpt-web/browser-worker.ts", "utf8");
 
@@ -2337,4 +2324,73 @@ test("proven progress forgets a Stopped thinking window rather than merely ignor
   expect(tracker.update(true, 6_500)).toBeFalse();
   expect(tracker.update(true, 11_499)).toBeFalse();
   expect(tracker.update(true, 11_500)).toBeTrue();
+});
+
+test("the shipped commentary classifier separates answer Markdown from reasoning in a real DOM", () => {
+  // The classifier runs inside page.evaluate, so it cannot be imported. Extract and execute the
+  // exact shipped source instead of a copy, which is what lets this test detect a regression in
+  // the code that actually runs rather than in a restatement of it.
+  // domino ships without module typings; it is already present as a turndown dependency and is
+  // the only DOM implementation available to this suite.
+  const { createDocument } = require("@mixmark-io/domino") as {
+    createDocument: (html: string) => {
+      body: { querySelectorAll: (selector: string) => ArrayLike<HTMLElement> };
+    };
+  };
+  const worker = readFileSync("src/adapters/chatgpt-web/browser-worker.ts", "utf8");
+  const source = worker.split("// CHATGPT_COMMENTARY_CLASSIFIER_BEGIN")[1]?.split("// CHATGPT_COMMENTARY_CLASSIFIER_END")[0];
+  if (!source) throw new Error("commentary classifier sentinels are missing from browser-worker.ts");
+  const javascript = source
+    .replace(/:\s*HTMLElement\[\]/g, "")
+    .replace(/\):\s*\{[^}]*\}\s*=>/, ") =>");
+  const selectChatGptAnswerRoots = new Function(
+    `${javascript}; return selectChatGptAnswerRoots;`,
+  )() as (roots: unknown[], statuses: unknown[]) => { answerRoots: Array<{ textContent: string }> };
+
+  const answerFor = (html: string): string => {
+    const document = createDocument(`<body>${html}</body>`);
+    // domino's NodeList is array-like rather than iterable.
+    const roots = Array.from(document.body.querySelectorAll(".markdown"))
+      .filter(candidate => !candidate.parentElement?.closest(".markdown"));
+    const statuses = Array.from(document.body.querySelectorAll("[data-streaming-response-status]"));
+    return selectChatGptAnswerRoots(roots, statuses).answerRoots
+      .map(root => (root.textContent ?? "").trim())
+      .filter(Boolean)
+      .join(" | ");
+  };
+
+  // Commentary that precedes the live status, and commentary nested inside one, stay excluded.
+  expect(answerFor(
+    '<div class="markdown">COMMENTARY</div>'
+    + '<div data-streaming-response-status>live</div>'
+    + '<div class="markdown">ANSWER</div>',
+  )).toBe("ANSWER");
+  expect(answerFor(
+    '<div data-streaming-response-status><div class="markdown">NESTED</div></div>'
+    + '<div class="markdown">ANSWER</div>',
+  )).toBe("ANSWER");
+
+  // Reasoning rendered inside a chain-of-thought component is commentary wherever it sits.
+  expect(answerFor(
+    '<div data-streaming-response-status>s1</div>'
+    + '<div data-testid="cot-v5-block"><div class="markdown">THINKING</div></div>'
+    + '<div class="markdown">ANSWER</div>',
+  )).toBe("ANSWER");
+
+  // The regressions this rule exists for: a second tool call opening a status container below
+  // already-emitted answer text used to blank the visible text and drop answer chunks entirely.
+  expect(answerFor(
+    '<div data-streaming-response-status>s1</div>'
+    + '<div class="markdown">ANSWER</div>'
+    + '<div data-streaming-response-status>s2</div>',
+  )).toBe("ANSWER");
+  expect(answerFor(
+    '<div data-streaming-response-status>s1</div>'
+    + '<div class="markdown">PART ONE</div>'
+    + '<div data-streaming-response-status>s2</div>'
+    + '<div class="markdown">PART TWO</div>',
+  )).toBe("PART ONE | PART TWO");
+
+  // A turn with no status container at all is entirely answer.
+  expect(answerFor('<div class="markdown">ONLY ANSWER</div>')).toBe("ONLY ANSWER");
 });

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import type { Page } from "playwright-core";
-import { CHATGPT_BROWSER_OBSERVATION_PROBE_TIMEOUT_MS, CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_STOPPED_THINKING_GRACE_MS, ChatGptBrowserObservationTimeoutError, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_PAGE_REBINDS, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, assertChatGptWebMultipartInputWithinLimits, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptConnectorAttachmentMode, chatGptEffortSelectionRequired, chatGptNewTurnIdentity, chatGptReboundTurnIdentity, chatGptSubmissionEvidence, dismissChatGptTemporaryChatOnboarding, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, resolveChatGptWebMultipartStagingMode, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert, withChatGptBrowserObservationTimeout } from "../src/adapters/chatgpt-web/browser-worker";
+import { CHATGPT_BROWSER_OBSERVATION_PROBE_TIMEOUT_MS, CHATGPT_EXTERNAL_PROGRESS_SUPPRESSION_CEILING_MS, CHATGPT_RESPONSE_DOM_GRACE_MS, MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS, CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_STOPPED_THINKING_GRACE_MS, ChatGptBrowserObservationTimeoutError, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_PAGE_REBINDS, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, assertChatGptWebMultipartInputWithinLimits, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptConnectorAttachmentMode, chatGptEffortSelectionRequired, chatGptNewTurnIdentity, chatGptReboundTurnIdentity, chatGptSubmissionEvidence, dismissChatGptTemporaryChatOnboarding, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, resolveChatGptWebMultipartStagingMode, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert, withChatGptBrowserObservationTimeout } from "../src/adapters/chatgpt-web/browser-worker";
 import { chatGptStoppedThinkingError } from "../src/adapters/chatgpt-web/adapter-error";
 import { CHATGPT_WEB_MODEL_ID } from "../src/adapters/chatgpt-web/model";
 import { CHATGPT_CONNECTOR_NAME, DEV_CHATGPT_CONNECTOR_NAME, defaultChromeExecutable, legacyChatGptConnectorMigrationMessage } from "../src/config";
@@ -2253,4 +2253,23 @@ test("answer Markdown is not reclassified as commentary when a later tool call o
   expect(worker).not.toMatch(
     /streamingStatusContainers\.some\(status => \(\s*Boolean\(candidate\.compareDocumentPosition\(status\)/,
   );
+});
+
+test("an accepted turn survives internal observation faults instead of being torn down", () => {
+  const worker = readFileSync("src/adapters/chatgpt-web/browser-worker.ts", "utf8");
+
+  // A TypeError while reading the page is a defect in this worker, not evidence about ChatGPT.
+  // Failing the turn on one loses an accepted ChatGPT turn that is never resent.
+  expect(MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS).toBeGreaterThan(1);
+  expect(worker).toContain("if (!(error instanceof TypeError)) throw error;");
+  expect(worker).toContain("internalObservationFaults = 0;");
+  expect(worker).toMatch(/internalObservationFaults > MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS/);
+
+  // Liveness may postpone a verdict but never waive it, so a tool call that never returns cannot
+  // hold an undeadlined turn open forever.
+  expect(worker).toMatch(/Date\.now\(\) - sentAt < CHATGPT_EXTERNAL_PROGRESS_SUPPRESSION_CEILING_MS/);
+  expect(CHATGPT_EXTERNAL_PROGRESS_SUPPRESSION_CEILING_MS).toBeGreaterThan(CHATGPT_RESPONSE_DOM_GRACE_MS);
+
+  // Chain-of-thought containment is commentary regardless of document position.
+  expect(worker).toContain('candidate.closest(\'[data-testid^="cot-v5"]\') !== null');
 });

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -2180,11 +2180,9 @@ test("the launcher helper transport carries MCP progress into the out-of-process
 
 test("turn cancellation heuristics defer to proven MCP progress in both wait loops", () => {
   const worker = readFileSync("src/adapters/chatgpt-web/browser-worker.ts", "utf8");
-  const guarded = worker.match(/stoppedThinkingTracker\.update\([^)]*\)\s*&&\s*!externalProgressLive/g) ?? [];
-
   // A stale "Stopped thinking" label must not cancel a turn that is still driving tool calls, and
   // the multipart staging loop must not be the one place that skips the liveness guard.
-  expect(guarded.length).toBe(2);
+  expect((worker.match(/stoppedThinkingTracker\.clear\(\)/g) ?? []).length).toBe(2);
   expect((worker.match(/domHealthTracker\.clearMissingResponse\(\)/g) ?? []).length).toBe(2);
 });
 
@@ -2261,7 +2259,7 @@ test("an accepted turn survives internal observation faults instead of being tor
   // A TypeError while reading the page is a defect in this worker, not evidence about ChatGPT.
   // Failing the turn on one loses an accepted ChatGPT turn that is never resent.
   expect(MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS).toBeGreaterThan(1);
-  expect(worker).toContain("if (!(error instanceof TypeError)) throw error;");
+  expect(worker).toContain("if (!(error instanceof TypeError) || observedThisIteration) throw error;");
   expect(worker).toContain("internalObservationFaults = 0;");
   expect(worker).toMatch(/internalObservationFaults > MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS/);
 
@@ -2323,4 +2321,20 @@ test("the daemon prefers the browser helper that shipped beside its own entrypoi
 
   // A malformed liveness hint must not destroy an accepted turn that can never be resent.
   expect(helper).toContain("discarded an invalid MCP progress frame");
+});
+
+
+test("proven progress forgets a Stopped thinking window rather than merely ignoring it", () => {
+  const tracker = new ChatGptStoppedThinkingTracker(5_000);
+
+  // The label appears while a tool call is outstanding. Suppressing only the verdict let this
+  // window keep accruing, so the first observation after the tool result cancelled the turn.
+  expect(tracker.update(true, 1_000)).toBeFalse();
+  expect(tracker.update(true, 3_000)).toBeFalse();
+  tracker.clear();
+
+  // Progress has ended and the window starts again from here, not from the original sighting.
+  expect(tracker.update(true, 6_500)).toBeFalse();
+  expect(tracker.update(true, 11_499)).toBeFalse();
+  expect(tracker.update(true, 11_500)).toBeTrue();
 });

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -2186,3 +2186,57 @@ test("turn cancellation heuristics defer to proven MCP progress in both wait loo
   expect(guarded.length).toBe(2);
   expect((worker.match(/domHealthTracker\.clearMissingResponse\(\)/g) ?? []).length).toBe(2);
 });
+
+test("proven MCP progress vetoes every terminal DOM conclusion, not just a missing response", () => {
+  // Reproduces trace 970896e96e84: the response DOM is present and the renderer never exposes a
+  // completed-turn action, yet tool calls keep completing. "Stopped generating" is false there.
+  const stalled = new ChatGptTurnDomHealthTracker(1_000, 500, 750);
+  const answeredWithoutCompletionAction = {
+    responsePresent: true,
+    running: false,
+    currentText: "partial answer",
+    completionActionVisible: false,
+  };
+
+  expect(stalled.update({ ...answeredWithoutCompletionAction, externalProgressLive: true }, 1_000)).toBeUndefined();
+  expect(stalled.update({ ...answeredWithoutCompletionAction, externalProgressLive: true }, 10_000)).toBeUndefined();
+
+  // Once the model genuinely stops, the window starts fresh rather than charging the live stretch.
+  expect(stalled.update(answeredWithoutCompletionAction, 10_100)).toBeUndefined();
+  expect(stalled.update(answeredWithoutCompletionAction, 10_849)).toBeUndefined();
+  expect(stalled.update(answeredWithoutCompletionAction, 10_850)).toContain("did not expose its completed-turn action");
+
+  const empty = new ChatGptTurnDomHealthTracker(1_000, 500, 750);
+  const completedEmpty = {
+    responsePresent: true,
+    running: false,
+    currentText: "",
+    completionActionVisible: true,
+  };
+  expect(empty.update({ ...completedEmpty, externalProgressLive: true }, 1_000)).toBeUndefined();
+  expect(empty.update({ ...completedEmpty, externalProgressLive: true }, 9_000)).toBeUndefined();
+  expect(empty.update(completedEmpty, 9_100)).toBeUndefined();
+  expect(empty.update(completedEmpty, 9_600)).toContain("completed without a final answer");
+});
+
+test("live external progress still records that a response DOM was observed", () => {
+  const tracker = new ChatGptTurnDomHealthTracker(1_000, 500);
+  const absent = {
+    responsePresent: false,
+    running: true,
+    currentText: "",
+    completionActionVisible: false,
+  };
+
+  expect(tracker.update({
+    responsePresent: true,
+    running: true,
+    currentText: "",
+    completionActionVisible: false,
+    externalProgressLive: true,
+  }, 1_000)).toBeUndefined();
+
+  // The turn is reported as vanished rather than never created, so `sawResponse` survived.
+  expect(tracker.update(absent, 2_000)).toBeUndefined();
+  expect(tracker.update(absent, 3_000)).toContain("response DOM disappeared");
+});

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -2303,3 +2303,24 @@ test("stale MCP progress stops suppressing DOM health without penalising long ac
     1_000,
   )).toBeFalse();
 });
+
+test("the daemon prefers the browser helper that shipped beside its own entrypoint", () => {
+  const client = readFileSync("src/adapters/chatgpt-web/launcher-helper-client.ts", "utf8");
+  const helper = readFileSync("src/adapters/chatgpt-web/browser-helper-main.ts", "utf8");
+
+  // The launcher advertises the helper inside its signed application bundle while the daemon runs
+  // from a versioned runtime directory, so the two update independently. A daemon that spoke a
+  // newer protocol to an older helper had its frame routed to the run handler, which dereferenced
+  // a turn the frame never carried and destroyed the turn with an opaque TypeError.
+  expect(client).toContain("bundledHelperScript()");
+  expect(client).toMatch(/browserHelperScriptPath \?\? this\.bundledHelperScript\(\) \?\? descriptor\.helper\.script/);
+
+  // Belt and braces: negotiate the frame, and never treat an unrecognised frame as a run.
+  expect(client).toContain('this.helperFeatures.has("progress")');
+  expect(helper).toContain('features: ["progress"]');
+  expect(helper).toMatch(/message\.type === "run"/);
+  expect(helper).toContain("Browser helper received an unsupported message type");
+
+  // A malformed liveness hint must not destroy an accepted turn that can never be resent.
+  expect(helper).toContain("discarded an invalid MCP progress frame");
+});

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -2124,3 +2124,65 @@ test("visible reasoning keeps the browser turn healthy before final assistant ma
   expect(health.update(reasoning, 1_000)).toBeUndefined();
   expect(health.update(reasoning, 10_000)).toBeUndefined();
 });
+
+test("suspending DOM health for proven MCP progress restarts the missing-response window", () => {
+  const tracker = new ChatGptTurnDomHealthTracker(1_000, 500);
+  const absent = {
+    responsePresent: false,
+    running: true,
+    currentText: "",
+    completionActionVisible: false,
+  };
+
+  // The response DOM is unavailable from the first observation, so the window opens here.
+  expect(tracker.update(absent, 1_000)).toBeUndefined();
+
+  // Proven tool-call activity suspends the check. Charging that suspended stretch against the
+  // grace period is what let a live turn be cancelled the moment liveness lapsed.
+  tracker.clearMissingResponse();
+
+  expect(tracker.update(absent, 10_000)).toBeUndefined();
+  expect(tracker.update(absent, 10_999)).toBeUndefined();
+  expect(tracker.update(absent, 11_000)).toContain("did not create a response DOM");
+});
+
+test("clearing the missing-response window preserves whether a response was ever observed", () => {
+  const tracker = new ChatGptTurnDomHealthTracker(1_000, 500);
+  const present = {
+    responsePresent: true,
+    running: true,
+    currentText: "partial",
+    completionActionVisible: false,
+  };
+  const absent = { ...present, responsePresent: false, currentText: "" };
+
+  expect(tracker.update(present, 1_000)).toBeUndefined();
+  expect(tracker.update(absent, 1_500)).toBeUndefined();
+  tracker.clearMissingResponse();
+  expect(tracker.update(absent, 5_000)).toBeUndefined();
+  expect(tracker.update(absent, 6_000)).toContain("response DOM disappeared");
+});
+
+test("the launcher helper transport carries MCP progress into the out-of-process browser worker", () => {
+  const client = readFileSync("src/adapters/chatgpt-web/launcher-helper-client.ts", "utf8");
+  const helper = readFileSync("src/adapters/chatgpt-web/browser-helper-main.ts", "utf8");
+
+  // The browser worker runs in the helper process while the Codex MCP broker runs in the daemon.
+  // If progress stops crossing that boundary the worker silently observes "never live" and cancels
+  // turns whose tool calls are still completing, so both ends of the transport are asserted here.
+  expect(client).toContain("forwardProgress");
+  expect(client).toMatch(/type: "progress", id: turn\.traceId, snapshot/);
+  expect(helper).toMatch(/message\.type === "progress"/);
+  expect(helper).toContain("ChatGptMirroredTurnProgress");
+  expect(helper).toMatch(/externalProgress: progress/);
+});
+
+test("turn cancellation heuristics defer to proven MCP progress in both wait loops", () => {
+  const worker = readFileSync("src/adapters/chatgpt-web/browser-worker.ts", "utf8");
+  const guarded = worker.match(/stoppedThinkingTracker\.update\([^)]*\)\s*&&\s*!externalProgressLive/g) ?? [];
+
+  // A stale "Stopped thinking" label must not cancel a turn that is still driving tool calls, and
+  // the multipart staging loop must not be the one place that skips the liveness guard.
+  expect(guarded.length).toBe(2);
+  expect((worker.match(/domHealthTracker\.clearMissingResponse\(\)/g) ?? []).length).toBe(2);
+});

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import type { Page } from "playwright-core";
-import { CHATGPT_BROWSER_OBSERVATION_PROBE_TIMEOUT_MS, CHATGPT_EXTERNAL_PROGRESS_SUPPRESSION_CEILING_MS, CHATGPT_RESPONSE_DOM_GRACE_MS, MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS, CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_STOPPED_THINKING_GRACE_MS, ChatGptBrowserObservationTimeoutError, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_PAGE_REBINDS, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, assertChatGptWebMultipartInputWithinLimits, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptConnectorAttachmentMode, chatGptEffortSelectionRequired, chatGptNewTurnIdentity, chatGptReboundTurnIdentity, chatGptSubmissionEvidence, dismissChatGptTemporaryChatOnboarding, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, resolveChatGptWebMultipartStagingMode, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert, withChatGptBrowserObservationTimeout } from "../src/adapters/chatgpt-web/browser-worker";
+import { CHATGPT_BROWSER_OBSERVATION_PROBE_TIMEOUT_MS, CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS, chatGptExternalProgressSuppressesDomHealth, CHATGPT_RESPONSE_DOM_GRACE_MS, MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS, CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_STOPPED_THINKING_GRACE_MS, ChatGptBrowserObservationTimeoutError, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_PAGE_REBINDS, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, assertChatGptWebMultipartInputWithinLimits, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptConnectorAttachmentMode, chatGptEffortSelectionRequired, chatGptNewTurnIdentity, chatGptReboundTurnIdentity, chatGptSubmissionEvidence, dismissChatGptTemporaryChatOnboarding, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, resolveChatGptWebMultipartStagingMode, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert, withChatGptBrowserObservationTimeout } from "../src/adapters/chatgpt-web/browser-worker";
 import { chatGptStoppedThinkingError } from "../src/adapters/chatgpt-web/adapter-error";
 import { CHATGPT_WEB_MODEL_ID } from "../src/adapters/chatgpt-web/model";
 import { CHATGPT_CONNECTOR_NAME, DEV_CHATGPT_CONNECTOR_NAME, defaultChromeExecutable, legacyChatGptConnectorMigrationMessage } from "../src/config";
@@ -2267,9 +2267,39 @@ test("an accepted turn survives internal observation faults instead of being tor
 
   // Liveness may postpone a verdict but never waive it, so a tool call that never returns cannot
   // hold an undeadlined turn open forever.
-  expect(worker).toMatch(/Date\.now\(\) - sentAt < CHATGPT_EXTERNAL_PROGRESS_SUPPRESSION_CEILING_MS/);
-  expect(CHATGPT_EXTERNAL_PROGRESS_SUPPRESSION_CEILING_MS).toBeGreaterThan(CHATGPT_RESPONSE_DOM_GRACE_MS);
+  expect(CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS).toBeGreaterThan(CHATGPT_RESPONSE_DOM_GRACE_MS);
 
   // Chain-of-thought containment is commentary regardless of document position.
   expect(worker).toContain('candidate.closest(\'[data-testid^="cot-v5"]\') !== null');
+});
+
+test("stale MCP progress stops suppressing DOM health without penalising long active turns", () => {
+  const outstanding = { revision: 2, lastToolBatchRevision: 2, activeToolCalls: 1, lastProgressAt: 1_000 };
+
+  // An outstanding call reports liveness regardless of age, so age is bounded separately: a tool
+  // that never returns must not hold a turn open forever, since turns carry no deadline by default.
+  expect(chatGptExternalProgressSuppressesDomHealth(outstanding, 1_000)).toBeTrue();
+  expect(chatGptExternalProgressSuppressesDomHealth(
+    outstanding,
+    1_000 + CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS - 1,
+  )).toBeTrue();
+  expect(chatGptExternalProgressSuppressesDomHealth(
+    outstanding,
+    1_000 + CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS,
+  )).toBeFalse();
+
+  // A turn that keeps calling tools stays suppressed no matter how long it has been running, so
+  // the bound is silence since the last activity rather than total turn duration.
+  const hoursIn = 4 * 60 * 60_000;
+  expect(chatGptExternalProgressSuppressesDomHealth(
+    { ...outstanding, lastProgressAt: hoursIn },
+    hoursIn + 1_000,
+  )).toBeTrue();
+
+  // No recorded activity is never evidence.
+  expect(chatGptExternalProgressSuppressesDomHealth(undefined, 1_000)).toBeFalse();
+  expect(chatGptExternalProgressSuppressesDomHealth(
+    { revision: 0, lastToolBatchRevision: 0, activeToolCalls: 0 },
+    1_000,
+  )).toBeFalse();
 });

--- a/tests/chatgpt-web-harness.test.ts
+++ b/tests/chatgpt-web-harness.test.ts
@@ -2855,3 +2855,26 @@ test("mirrored turn progress wakes waiters exactly like the recording instance",
     lastProgressAt: 7_000,
   });
 });
+
+test("mirrored progress rejects frames that regress against the observed state", async () => {
+  const mirror = new ChatGptMirroredTurnProgress();
+  mirror.apply({ revision: 3, lastToolBatchRevision: 3, activeToolCalls: 1, lastProgressAt: 5_000 });
+
+  // Higher revision but contradicting what it already reported: a corrupt or forged frame, not an
+  // ordering artefact, and accepting it would desynchronise observed liveness.
+  expect(() => mirror.apply({
+    revision: 4, lastToolBatchRevision: 2, activeToolCalls: 1, lastProgressAt: 6_000,
+  })).toThrow("regressed against the observed state");
+  expect(() => mirror.apply({
+    revision: 4, lastToolBatchRevision: 3, activeToolCalls: 1, lastProgressAt: 4_000,
+  })).toThrow("regressed against the observed state");
+
+  // Recorded activity always stamps a timestamp, so a progress frame without one is malformed.
+  expect(() => mirror.apply({
+    revision: 5, lastToolBatchRevision: 3, activeToolCalls: 0,
+  })).toThrow("snapshot is invalid");
+
+  expect(mirror.snapshot()).toEqual({
+    revision: 3, lastToolBatchRevision: 3, activeToolCalls: 1, lastProgressAt: 5_000,
+  });
+});

--- a/tests/chatgpt-web-harness.test.ts
+++ b/tests/chatgpt-web-harness.test.ts
@@ -21,7 +21,7 @@ import { chatGptReadOnlyContextWarning, compileChatGptWebPrompt, withoutSupersed
 import { MAX_CHATGPT_WEB_TURN_RETRIES } from "../src/adapters/chatgpt-web/retry-policy";
 import { ChatGptTextFeed, ChatGptTraceFeed, ChatGptTurnSessions, chatGptCompactionSourceExecutionKey, chatGptThreadOwnershipKey, chatGptTurnExecutionKey, chatGptTurnSessions } from "../src/adapters/chatgpt-web/turn-execution";
 import { callTurnBroker, TurnBroker, type BrokerToolResult } from "../src/adapters/chatgpt-web/turn-broker";
-import { ChatGptExternalTurnProgress, chatGptExternalProgressIsLive } from "../src/adapters/chatgpt-web/turn-progress";
+import { ChatGptExternalTurnProgress, ChatGptMirroredTurnProgress, chatGptExternalProgressIsLive } from "../src/adapters/chatgpt-web/turn-progress";
 import { CHATGPT_WEB_MCP_INVOCATION_TIMEOUT_MS, chatGptMcpInvocationTimeout } from "../src/adapters/chatgpt-web/mcp-server";
 import { defaultBrokerEndpoint } from "../src/config";
 import { estimateChatGptWebUsage } from "../src/adapters/chatgpt-web/usage";
@@ -2798,4 +2798,60 @@ describe("ChatGPT outer-native harness v4", () => {
       await broker.close();
     }
   }, 10_000);
+});
+
+test("mirrored turn progress carries daemon MCP activity into the browser helper process", async () => {
+  const daemon = new ChatGptExternalTurnProgress();
+  const mirror = new ChatGptMirroredTurnProgress();
+
+  // A helper process with no mirrored progress reports "not live", which is exactly what let the
+  // DOM grace cancel turns whose tool calls were still completing.
+  expect(chatGptExternalProgressIsLive(mirror.snapshot(), 1_000, 60_000)).toBeFalse();
+
+  daemon.recordToolBatch(1, 1_000);
+  expect(mirror.apply(daemon.snapshot())).toBeTrue();
+  expect(chatGptExternalProgressIsLive(mirror.snapshot(), 30_000, 60_000)).toBeTrue();
+
+  daemon.recordToolResult(2_000);
+  expect(mirror.apply(daemon.snapshot())).toBeTrue();
+  expect(mirror.snapshot()).toEqual({
+    revision: 2,
+    lastToolBatchRevision: 1,
+    activeToolCalls: 0,
+    lastProgressAt: 2_000,
+  });
+
+  // Liveness still expires on the mirrored timestamp once the model genuinely stops working.
+  expect(chatGptExternalProgressIsLive(mirror.snapshot(), 61_999, 60_000)).toBeTrue();
+  expect(chatGptExternalProgressIsLive(mirror.snapshot(), 62_000, 60_000)).toBeFalse();
+});
+
+test("mirrored turn progress ignores replayed frames and rejects malformed ones", async () => {
+  const mirror = new ChatGptMirroredTurnProgress();
+  const first = { revision: 4, lastToolBatchRevision: 3, activeToolCalls: 1, lastProgressAt: 5_000 };
+
+  expect(mirror.apply(first)).toBeTrue();
+  expect(mirror.apply(first)).toBeFalse();
+  expect(mirror.apply({
+    revision: 2,
+    lastToolBatchRevision: 2,
+    activeToolCalls: 1,
+    lastProgressAt: 1_000,
+  })).toBeFalse();
+  expect(mirror.snapshot().lastProgressAt).toBe(5_000);
+
+  expect(() => mirror.apply({ ...first, revision: -1 })).toThrow("snapshot is invalid");
+  expect(() => mirror.apply({ ...first, revision: 5, lastToolBatchRevision: 9 })).toThrow("snapshot is invalid");
+});
+
+test("mirrored turn progress wakes waiters exactly like the recording instance", async () => {
+  const mirror = new ChatGptMirroredTurnProgress();
+  const changed = mirror.waitForChange(0);
+  mirror.apply({ revision: 1, lastToolBatchRevision: 1, activeToolCalls: 2, lastProgressAt: 7_000 });
+  expect(await changed).toEqual({
+    revision: 1,
+    lastToolBatchRevision: 1,
+    activeToolCalls: 2,
+    lastProgressAt: 7_000,
+  });
 });


### PR DESCRIPTION
Split of #222, part 1 of 2, per review. Based on current `main`.

This is the #221 path only: progress transport, liveness/completion vetoes, the answer-classifier correction, helper protocol pinning/negotiation, and the directly related regression tests. Part 2 is #233.

The automatic re-staging after "Stopped thinking" is **not** in either PR. As requested, that condition remains an explicit failure until the cause is established.

## Root cause

In launcher mode the ChatGPT browser worker runs in a separate helper process spawned by `launcher-helper-client.ts`, while the Codex MCP broker runs in the daemon. `BrowserTurn.externalProgress` was never forwarded across that boundary, so in the helper it was always `undefined` and `chatGptExternalProgressIsLive(undefined, …)` returned false on its first line. Every liveness guard was dead code in the mode most users run. The guard at `browser-worker.ts:3511` exists and is correct; it simply never fired.

That matches the reported timings: one turn failed 29.8s after its last recorded tool progress, well inside the 60s `CHATGPT_RESPONSE_DOM_GRACE_MS` window, and another completed a tool call one second after the harness declared the response DOM never existed.

## What this changes

**Transport.** Daemon progress is mirrored into the helper via a progress frame and `ChatGptMirroredTurnProgress`. `BrowserTurn.externalProgress` is now a read-only `ChatGptTurnProgressReader`, since the worker only observes. Mirrors reject replayed, regressing, and malformed frames.

**Liveness vetoes terminal verdicts.** All three `ChatGptTurnDomHealthTracker` branches assert that ChatGPT stopped producing this turn, which an in-flight tool call disproves. While live, every window is cleared and restarts fresh once liveness lapses, so a live stretch is never charged against the grace. `sawResponse` still records, preserving "disappeared" vs "never created". "Stopped thinking" defers to progress, and its window is cleared rather than merely ignored.

**Completion is vetoed too.** During a tool call the composer is idle because ChatGPT is waiting on the harness, so `ChatGptCompletionTracker` concluded the turn had finished. A live progress mirror now vetoes that as well; without it the DOM-health veto merely moves the failure one tracker over.

**Bounded by staleness, not duration.** An outstanding call reports liveness regardless of age, so a stuck call is bounded by silence since last activity (`CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS`). Nothing in this repo sets `turnTimeoutMs`, so bounding total duration instead would have cancelled legitimate multi-hour agent turns. The same rule now bounds the pre-response wait.

**Answer Markdown is no longer misclassified as commentary.** Commentary was any Markdown root with some status container after it, which holds only while a turn has one live status. Once a second tool call opened another status container below already-emitted answer text, that answer was reclassified. Verified in a real browser, old rule vs fix:

| layout | old | fixed |
| --- | --- | --- |
| Pro commentary, live status, answer | ANSWER | ANSWER |
| commentary nested inside status, answer | ANSWER | ANSWER |
| status, answer | ANSWER | ANSWER |
| status, answer, second tool status | `` (empty) | ANSWER |
| status, part one, second status, part two | PART TWO | PART ONE \| PART TWO |

The empty row reproduces the reported `textChars=0`. The interleaved row is worse and had not been noticed: answer content emitted between tool calls was silently dropped. Commentary now means Markdown preceding the first status container, plus chain-of-thought containment as a position-independent signal.

**An accepted turn survives internal faults.** A `TypeError` while reading the page is a defect in this worker, not evidence about ChatGPT, and failing on one destroys an accepted turn that is never resent. A bounded consecutive run is retried; faults raised after observation succeeded still fail immediately. Deliberate signals — adapter errors, aborts, closed tabs, DOM-health verdicts — are untouched.

**Protocol compatibility.** The launcher advertises the helper inside its signed application bundle while the daemon runs from a versioned runtime directory, so the two update independently. The daemon prefers the helper beside its own entrypoint; the helper advertises optional frames on ready and the daemon withholds anything unadvertised; unrecognised frames are answered with a protocol error instead of being routed to the run handler. That last path is how a newer daemon against an older helper produced `Cannot read properties of undefined (reading 'traceId')`, reported as "ChatGPT failed after accepting the Web prompt".

## Note on the cot-v5 locator hypothesis

#221 speculated that `cot-v5-*` rendering had broken the response locator. Instrumenting live turns shows that does not hold: during the cot-v5 phase there are zero `.markdown` roots, so `visibleText` of 0 is correct — the answer has not been written yet.

```
cot:2  mdRoots:0  statusContainers:1  visibleTextChars:0    stopBtn:1  copyBtn:0   <- thinking / tool phase
cot:0  mdRoots:1  statusContainers:0  visibleTextChars:139  stopBtn:1  copyBtn:0   <- answer streaming
cot:0  mdRoots:1  statusContainers:0  visibleTextChars:262  stopBtn:0  copyBtn:1   <- complete
```

`ui.response.textChars` counts the whole response element including CoT status text, a different measure from the tracker's `visibleText`. The reported `textChars=0` therefore has two causes: this correct-by-design reading, and the genuine misclassification above once a second tool call starts.

## Testing

`bun run typecheck` clean. `bun test`: 646 pass, 7 fail — the same seven that fail on `main` on macOS (six retained-compaction fixtures hitting the `sun_path` limit under `/var/folders`, plus one Linux-only AppImage test). Their fix is platform-test cleanup and is in part 2, per the requested split; this branch is therefore no worse than `main`.

Behavioural tests cover mirror apply/staleness/validation/waiters, staleness-bounded suppression, the terminal-branch veto, `sawResponse` preservation, the Stopped-thinking window reset, the completion veto, future-dated timestamps, and the fault budget. Wiring-contract tests cover both ends of the progress transport, helper pinning, capability negotiation, and unknown-frame handling. The commentary classifier test extracts the shipped source between two sentinels in `browser-worker.ts` and executes it against a real DOM built with `@mixmark-io/domino`, so the five layouts above are asserted on the code that actually runs. Every fix was mutation-tested: reverting it makes its test fail.

## Caveat

The CoT-containment signal assumes Pro commentary renders inside a `cot-v5` component — consistent with the testids in the reports on #221, but not confirmed against captured Pro markup. If Pro emits top-level commentary outside CoT between two status containers, it would be appended to the answer rather than dropped; that direction was chosen deliberately, since leaking commentary is visible and recoverable while losing answer text is not.
