### PR TITLE
fix: operational follow-ups for chatgpt-web turn lifecycle

### DIFF
--- a/launcher/electron/browser-host.cjs
+++ b/launcher/electron/browser-host.cjs
@@ -1,7 +1,7 @@
 const fs = require("node:fs");
 const path = require("node:path");
 const { randomBytes } = require("node:crypto");
-const { WebContentsView, shell } = require("electron");
+const { WebContentsView, powerMonitor, powerSaveBlocker, shell } = require("electron");
 const { writePrivateFileAtomic } = require("./atomic-file.cjs");
 const {
   runBrowserHelperOperation,
@@ -9,6 +9,11 @@ const {
 } = require("./browser-helper-verifier.cjs");
 const { validateConnectorName } = require("./connector-identity.cjs");
 const { processRunning } = require("./process-tree.cjs");
+const {
+  refreshTurnLeasesAfterSuspension,
+  shouldBlockSleepForTurns,
+  sweepGapIndicatesSuspension,
+} = require("./turn-suspension.cjs");
 const {
   browserViewVisible,
   constrainBrowserBounds,
@@ -240,8 +245,16 @@ class BrowserHost {
     this.authView = null;
     this.authNavigationError = null;
     this.homeNavigationTimeout = null;
+    this.lastTurnSweepAt = Date.now();
+    this.powerSaveBlockerId = null;
     this.turnLeaseSweep = setInterval(() => this.reapExpiredTurnTabs(), TURN_HEARTBEAT_SWEEP_MS);
     this.turnLeaseSweep.unref?.();
+    this.resumeListener = () => this.refreshTurnLeases("system_resume");
+    if (powerMonitor && typeof powerMonitor.on === "function") {
+      powerMonitor.on("resume", this.resumeListener);
+    } else {
+      this.resumeListener = null;
+    }
     this.boundsReady = false;
     this.bounds = { x: 0, y: 0, width: 1, height: 1 };
     this.state = {
@@ -362,6 +375,7 @@ class BrowserHost {
       lastHeartbeatAt: Date.now(),
     };
     this.turnTabs.set(id, tab);
+    this.syncPowerSaveBlocker();
     this.window.contentView.addChildView(view);
     this.presentTurnView(tab, false);
     view.webContents.setZoomFactor(this.state.zoomFactor);
@@ -479,6 +493,7 @@ class BrowserHost {
         (error) => {
           tab.status = "error";
           tab.message = `Browser ownership failed: ${error instanceof Error ? error.message : String(error)}`;
+          this.syncPowerSaveBlocker();
           this.publishState?.(this.snapshot());
         },
       );
@@ -837,7 +852,42 @@ class BrowserHost {
     return this.snapshot();
   }
 
+  refreshTurnLeases(reason, now = Date.now()) {
+    const refreshed = refreshTurnLeasesAfterSuspension(
+      [...this.turnTabs.values()],
+      now,
+      TURN_TAB_BOOTSTRAP_TIMEOUT_MS,
+    );
+    if (refreshed.length > 0) {
+      this.logger.warn("browser.turn_leases_refreshed_after_suspension", { reason, traceIds: refreshed });
+    }
+  }
+
+  syncPowerSaveBlocker() {
+    // Under plain Node (the launcher test harness) require("electron") exposes no APIs; the
+    // blocker is an Electron-only concern and its absence must not break lease bookkeeping.
+    if (!powerSaveBlocker || typeof powerSaveBlocker.start !== "function") return;
+    const wanted = shouldBlockSleepForTurns([...this.turnTabs.values()]);
+    const active = this.powerSaveBlockerId !== null && powerSaveBlocker.isStarted(this.powerSaveBlockerId);
+    if (wanted && !active) {
+      this.powerSaveBlockerId = powerSaveBlocker.start("prevent-app-suspension");
+      this.logger.info("browser.sleep_blocked_for_turns", { blockerId: this.powerSaveBlockerId });
+    } else if (!wanted && active) {
+      powerSaveBlocker.stop(this.powerSaveBlockerId);
+      this.logger.info("browser.sleep_block_released", { blockerId: this.powerSaveBlockerId });
+      this.powerSaveBlockerId = null;
+    }
+  }
+
   reapExpiredTurnTabs(now = Date.now()) {
+    const lastSweepAt = this.lastTurnSweepAt;
+    this.lastTurnSweepAt = now;
+    if (sweepGapIndicatesSuspension(lastSweepAt, now, TURN_HEARTBEAT_SWEEP_MS)) {
+      // The launcher itself was frozen, so missing heartbeats are evidence of the sleep, not of a
+      // dead helper. Reaping here is what turned every system sleep into a lost turn.
+      this.refreshTurnLeases("sweep_gap", now);
+      return;
+    }
     for (const tab of [...this.turnTabs.values()]) {
       if (tab.status === "ready") {
         if (now - (tab.lastHeartbeatAt ?? 0) < RETAINED_TURN_TAB_TTL_MS) continue;
@@ -968,6 +1018,7 @@ class BrowserHost {
   removeTurnTab(tab, abortRunning) {
     if (!this.turnTabs.has(tab.id)) return;
     this.turnTabs.delete(tab.id);
+    this.syncPowerSaveBlocker();
     if (abortRunning && tab.status === "running") {
       this.closedTurnOwners.set(tab.traceId, tab.helperPid);
       tab.status = "aborted";
@@ -1374,6 +1425,7 @@ class BrowserHost {
     }
     const cancelledByUser = this.userCancelledTurnOwners.get(traceId) === helperPid;
     tab.status = status === "completed" ? "ready" : status === "aborted" ? "aborted" : "error";
+    this.syncPowerSaveBlocker();
     tab.message = status === "completed" ? "Task completed" : message || `ChatGPT turn ${status}`;
     tab.loading = false;
     if (!tab.view.webContents.isDestroyed()) tab.view.webContents.setBackgroundThrottling(true);
@@ -1779,6 +1831,14 @@ class BrowserHost {
     this.closeAuthView(this.authView, true);
     this.clearHomeNavigationTimeout();
     if (this.turnLeaseSweep) clearInterval(this.turnLeaseSweep);
+    if (this.resumeListener && powerMonitor && typeof powerMonitor.removeListener === "function") {
+      powerMonitor.removeListener("resume", this.resumeListener);
+      this.resumeListener = null;
+    }
+    if (this.powerSaveBlockerId !== null && powerSaveBlocker && typeof powerSaveBlocker.stop === "function") {
+      powerSaveBlocker.stop(this.powerSaveBlockerId);
+      this.powerSaveBlockerId = null;
+    }
     for (const tab of this.turnTabs.values()) {
       try { this.window.contentView.removeChildView(tab.view); } catch {}
       if (!tab.view.webContents.isDestroyed()) tab.view.webContents.close();

--- a/launcher/electron/turn-suspension.cjs
+++ b/launcher/electron/turn-suspension.cjs
@@ -1,0 +1,52 @@
+"use strict";
+
+/**
+ * System sleep freezes both sides of the turn-lease protocol at once: the helper cannot send
+ * heartbeats and the launcher cannot observe them. On wake every stalled timer fires together, and
+ * without these guards the first sweep after a sleep reaped live turns as orphans — pmset logged
+ * 'Idle Sleep' 41 seconds into two running turns, and both died on the next DarkWake to the second.
+ */
+
+/**
+ * The turn-lease sweep runs on a short fixed interval for the whole life of the launcher. A gap
+ * between consecutive sweeps far larger than that interval means the process was suspended, not
+ * busy: nothing the launcher does blocks its event loop for multiples of the sweep interval.
+ */
+function sweepGapIndicatesSuspension(lastSweepAt, now, sweepIntervalMs) {
+  if (typeof lastSweepAt !== "number" || !Number.isFinite(lastSweepAt)) return false;
+  return now - lastSweepAt >= sweepIntervalMs * 6;
+}
+
+/**
+ * Re-baseline every lease that depends on time passing. A running tab's helper gets a full
+ * heartbeat window to prove it survived the sleep; a tab still bootstrapping gets its bootstrap
+ * budget back. Returns the refreshed trace ids so the caller can log the decision.
+ */
+function refreshTurnLeasesAfterSuspension(tabs, now, bootstrapTimeoutMs) {
+  const refreshed = [];
+  for (const tab of tabs) {
+    if (tab.status !== "running") continue;
+    tab.lastHeartbeatAt = now;
+    if (tab.bootstrapReady !== true) tab.bootstrapDeadlineAt = now + bootstrapTimeoutMs;
+    refreshed.push(tab.traceId);
+  }
+  return refreshed;
+}
+
+/**
+ * A power-save blocker belongs up exactly while at least one browser turn is running: an idle Mac
+ * otherwise sleeps mid-turn, and no amount of wake-side tolerance recovers the minutes ChatGPT
+ * spent frozen.
+ */
+function shouldBlockSleepForTurns(tabs) {
+  for (const tab of tabs) {
+    if (tab.status === "running") return true;
+  }
+  return false;
+}
+
+module.exports = {
+  sweepGapIndicatesSuspension,
+  refreshTurnLeasesAfterSuspension,
+  shouldBlockSleepForTurns,
+};

--- a/launcher/tests/packaging-contract.test.cjs
+++ b/launcher/tests/packaging-contract.test.cjs
@@ -136,6 +136,11 @@ test("CI packages and smoke-launches on macOS, Windows, and Linux", () => {
 test("Linux AppImage fallback uses one owned extraction and removes it on exit", {
   skip: process.platform !== "linux" ? "AppImage process identity is Linux-specific" : false,
 }, () => {
+  // node:test honours the `skip` option above and reports this as skipped. Bun's shim ignores that
+  // option and runs the body anyway, and implements neither t.skip(), so the test read /proc on
+  // macOS and failed for everyone running `bun test` locally. Returning early is the one form both
+  // runners agree on.
+  if (process.platform !== "linux") return;
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-web-gpt-appimage-runner-"));
   const runtime = path.join(root, "runtime");
   const appImage = path.join(root, "Codex Web GPT.AppImage");

--- a/launcher/tests/turn-suspension.test.cjs
+++ b/launcher/tests/turn-suspension.test.cjs
@@ -1,0 +1,92 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  refreshTurnLeasesAfterSuspension,
+  shouldBlockSleepForTurns,
+  sweepGapIndicatesSuspension,
+} = require("../electron/turn-suspension.cjs");
+const { BrowserHost } = require("../electron/browser-host.cjs");
+
+// System sleep froze the launcher for 15 minutes twice in a row; on each wake the first sweep saw
+// heartbeats that were minutes stale and reaped two live turns as orphans. pmset matched both waves
+// to the second. These tests pin the wake-side tolerance and the sleep-side prevention.
+
+test("a sweep gap of multiples of the interval is recognised as a suspension", () => {
+  assert.equal(sweepGapIndicatesSuspension(1_000, 1_000 + 5_000 * 6, 5_000), true);
+  assert.equal(sweepGapIndicatesSuspension(1_000, 1_000 + 15 * 60_000, 5_000), true);
+});
+
+test("ordinary sweep cadence and busy-loop jitter are not a suspension", () => {
+  assert.equal(sweepGapIndicatesSuspension(1_000, 6_000, 5_000), false);
+  assert.equal(sweepGapIndicatesSuspension(1_000, 1_000 + 5_000 * 6 - 1, 5_000), false);
+  assert.equal(sweepGapIndicatesSuspension(undefined, 99_000, 5_000), false);
+});
+
+test("a suspension re-baselines running leases and restores an unfinished bootstrap budget", () => {
+  const running = { status: "running", traceId: "aaa", bootstrapReady: true, lastHeartbeatAt: 5 };
+  const booting = {
+    status: "running", traceId: "bbb", bootstrapReady: false,
+    lastHeartbeatAt: 5, bootstrapDeadlineAt: 10,
+  };
+  const retained = { status: "ready", traceId: "ccc", lastHeartbeatAt: 5 };
+
+  const refreshed = refreshTurnLeasesAfterSuspension([running, booting, retained], 1_000_000, 120_000);
+
+  assert.deepEqual(refreshed, ["aaa", "bbb"]);
+  assert.equal(running.lastHeartbeatAt, 1_000_000);
+  assert.equal(booting.bootstrapDeadlineAt, 1_120_000);
+  // A retained tab holds no live helper; its idle TTL keeps counting through a sleep.
+  assert.equal(retained.lastHeartbeatAt, 5);
+});
+
+test("sleep is blocked exactly while a turn is running", () => {
+  assert.equal(shouldBlockSleepForTurns([]), false);
+  assert.equal(shouldBlockSleepForTurns([{ status: "ready" }, { status: "error" }]), false);
+  assert.equal(shouldBlockSleepForTurns([{ status: "ready" }, { status: "running" }]), true);
+});
+
+test("the first sweep after a suspension refreshes stale leases instead of reaping them", () => {
+  const reaped = [];
+  const warnings = [];
+  const tab = {
+    id: "t1", traceId: "trace-1", helperPid: 42, status: "running",
+    bootstrapReady: true, lastHeartbeatAt: 1_000,
+  };
+  const host = {
+    lastTurnSweepAt: 1_000,
+    turnTabs: new Map([["t1", tab]]),
+    logger: { warn: (event, detail) => warnings.push({ event, detail }), info: () => {} },
+    removeTurnTab: t => reaped.push(t.traceId),
+    refreshTurnLeases: BrowserHost.prototype.refreshTurnLeases,
+  };
+
+  // Fifteen minutes pass without a sweep — the launcher was asleep, and so was the helper.
+  BrowserHost.prototype.reapExpiredTurnTabs.call(host, 1_000 + 15 * 60_000);
+
+  assert.deepEqual(reaped, []);
+  assert.equal(tab.lastHeartbeatAt, 1_000 + 15 * 60_000);
+  assert.equal(warnings[0].event, "browser.turn_leases_refreshed_after_suspension");
+
+  // The next sweep runs on cadence; the lease is fresh, so the turn lives on.
+  BrowserHost.prototype.reapExpiredTurnTabs.call(host, 1_000 + 15 * 60_000 + 5_000);
+  assert.deepEqual(reaped, []);
+});
+
+test("a helper that is genuinely gone is still reaped on the ordinary cadence", () => {
+  const reaped = [];
+  const tab = {
+    id: "t1", traceId: "trace-1", helperPid: 42, status: "running",
+    bootstrapReady: true, lastHeartbeatAt: 1_000,
+  };
+  const host = {
+    lastTurnSweepAt: 56_000,
+    turnTabs: new Map([["t1", tab]]),
+    logger: { warn: () => {}, info: () => {} },
+    removeTurnTab: t => reaped.push(t.traceId),
+    refreshTurnLeases: BrowserHost.prototype.refreshTurnLeases,
+  };
+
+  BrowserHost.prototype.reapExpiredTurnTabs.call(host, 61_000);
+
+  assert.deepEqual(reaped, ["trace-1"]);
+});

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -108,6 +108,15 @@ export async function closeChatGptBrowserWorkers(): Promise<void> {
 }
 
 export const CHATGPT_RESPONSE_DOM_GRACE_MS = 60_000;
+/**
+ * How long a staged Bigger Context part may take to produce its assistant turn. A staged part is two
+ * orders of magnitude larger than an ordinary prompt and ChatGPT reads all of it before answering,
+ * so the ordinary grace is not a budget it can be held to: acknowledgements have been observed at
+ * 19s and 30s on the same payload that once took over 72s and lost the turn. There is no MCP
+ * activity to vouch for liveness yet at this point, so this window is the only thing standing
+ * between a slow ingest and a cancelled turn. It matches the staged send budget.
+ */
+export const CHATGPT_MULTIPART_RESPONSE_DOM_GRACE_MS = 180_000;
 export const CHATGPT_EMPTY_RESPONSE_GRACE_MS = 10_000;
 export const CHATGPT_COMPLETION_ACTION_GRACE_MS = 60_000;
 export const CHATGPT_COMPLETION_SETTLE_MS = 2_000;
@@ -617,7 +626,7 @@ export function resolveChatGptWebMultipartStagingMode(
   );
 }
 
-const browserStageTimeouts = {
+export const browserStageTimeouts = {
   browserPage: 60_000,
   temporaryChatPreparation: 150_000,
   effortSelection: 120_000,
@@ -2132,10 +2141,11 @@ export class ChatGptBrowserWorker {
     deadline: number | undefined,
     signal?: AbortSignal,
     externalProgress?: ChatGptTurnProgressReader,
+    graceMs: number = CHATGPT_RESPONSE_DOM_GRACE_MS,
   ): Promise<ChatGptAssistantTurnBinding> {
     let responseDeadline = Math.min(
       deadline ?? Number.POSITIVE_INFINITY,
-      Date.now() + CHATGPT_RESPONSE_DOM_GRACE_MS,
+      Date.now() + graceMs,
     );
     for (;;) {
       if (signal?.aborted) throw new DOMException("ChatGPT web turn aborted", "AbortError");
@@ -2144,7 +2154,7 @@ export class ChatGptBrowserWorker {
       if (progress?.lastProgressAt !== undefined) {
         responseDeadline = Math.min(
           deadline ?? Number.POSITIVE_INFINITY,
-          Math.max(responseDeadline, progress.lastProgressAt + CHATGPT_RESPONSE_DOM_GRACE_MS),
+          Math.max(responseDeadline, progress.lastProgressAt + graceMs),
         );
       }
       if (deadline !== undefined && Date.now() >= deadline) {
@@ -2160,7 +2170,7 @@ export class ChatGptBrowserWorker {
       try {
         state = await this.submissionDomState(page, baseline.domCache);
       } catch (error) {
-        if (!chatGptExternalProgressIsLive(progress, Date.now(), CHATGPT_RESPONSE_DOM_GRACE_MS)) throw error;
+        if (!chatGptExternalProgressIsLive(progress, Date.now(), graceMs)) throw error;
         await this.waitForTurnDomOrExternalProgress(
           page,
           progress?.revision ?? 0,
@@ -3502,7 +3512,10 @@ export class ChatGptBrowserWorker {
             stageBaseline,
             deadline,
             turn.abortSignal,
-            turn.externalProgress,
+            // A part still being ingested has produced no MCP activity, so there is no progress to
+            // consult here; only the wider window applies.
+            undefined,
+            CHATGPT_MULTIPART_RESPONSE_DOM_GRACE_MS,
           );
           console.info(
             `[chatgpt-web] browser turn ${turn.traceId} multipart part ${index + 1}/${prepared.multipart.parts.length} submission accepted evidence=${evidence}`,

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -624,6 +624,11 @@ const browserStageTimeouts = {
   promptAttachment: 60_000,
   fileAttachment: 120_000,
   send: 20_000,
+  // A Bigger Context stage posts a payload orders of magnitude larger than an ordinary prompt onto
+  // a conversation that already holds the earlier parts, and this budget covers ChatGPT accepting
+  // the submission, not just the click. The ordinary 20s send budget expired mid-acceptance and
+  // destroyed the whole turn while the browser was still working.
+  multipartStageSend: 180_000,
 } as const;
 
 export const CHATGPT_BROWSER_OBSERVATION_PROBE_TIMEOUT_MS = 5_000;
@@ -3459,7 +3464,7 @@ export class ChatGptBrowserWorker {
           const evidence = await this.runStage(
             turn.traceId,
             `multipart_stage_${index + 1}_send`,
-            browserStageTimeouts.send,
+            browserStageTimeouts.multipartStageSend,
             (stageSignal) => this.sendAttachedPrompt(
               page,
               stageBaseline,
@@ -3564,7 +3569,9 @@ export class ChatGptBrowserWorker {
       const finalSubmissionEvidence = await this.runStage(
         turn.traceId,
         "send",
-        browserStageTimeouts.send,
+        // A multipart commit lands on a conversation already carrying every staged part, so it
+        // needs the same acceptance headroom the stages themselves get.
+        prepared.multipart ? browserStageTimeouts.multipartStageSend : browserStageTimeouts.send,
         (stageSignal) => this.sendAttachedPrompt(
           page,
           submissionBaseline,

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -1426,6 +1426,43 @@ export function chatGptPromptFilePayloads(
   return chatGptImageFilePayloads(prompt.images);
 }
 
+/**
+ * Insert `value` at the caret of an already-resolved ChatGPT composer, returning whether the edit
+ * was applied. Runs inside the page, so it may reference only globals and its two arguments.
+ *
+ * Effort selection closes a menu immediately before a staged part is attached, and focus is still
+ * settling when this runs: the composer can be the active element while the caret has not yet been
+ * placed inside it, or focus can still be on the menu that just closed. Reading that as a rejected
+ * edit failed whole turns roughly a tenth of a second after the effort menu closed, so the caret is
+ * placed explicitly instead of assumed. An existing collapsed caret inside the composer is left
+ * exactly where the user put it; only a missing or foreign one is replaced, and always with a
+ * position inside this composer, so an insert can never land in another element.
+ */
+export function insertPlainTextIntoComposer(element: HTMLElement, value: string): boolean {
+  if (document.activeElement !== element) element.focus();
+  if (document.activeElement !== element) return false;
+  const selection = window.getSelection();
+  if (!selection) return false;
+  const alreadyPlaced = selection.isCollapsed
+    && selection.anchorNode !== null
+    && element.contains(selection.anchorNode);
+  if (!alreadyPlaced) {
+    const range = document.createRange();
+    range.selectNodeContents(element);
+    range.collapse(false);
+    selection.removeAllRanges();
+    selection.addRange(range);
+  }
+  if (
+    !selection.isCollapsed
+    || !selection.anchorNode
+    || !element.contains(selection.anchorNode)
+  ) {
+    return false;
+  }
+  return document.execCommand("insertText", false, value);
+}
+
 export class ChatGptBrowserWorker {
   static forProvider(provider: CodexProviderConfig): ChatGptBrowserWorker {
     const config = resolveBrowserConfig(provider);
@@ -2630,19 +2667,7 @@ export class ChatGptBrowserWorker {
     // delimiters from textContent, and leave the next insertion outside the intended block. The
     // browser's plain-text editing command updates the same focused contenteditable atomically
     // without running those Markdown shortcuts. Exact readback below remains the authority.
-    const inserted = await composer.evaluate((element, value) => {
-      const selection = window.getSelection();
-      if (
-        document.activeElement !== element
-        || !selection
-        || !selection.isCollapsed
-        || !selection.anchorNode
-        || !element.contains(selection.anchorNode)
-      ) {
-        return false;
-      }
-      return document.execCommand("insertText", false, value);
-    }, text, { timeout: 20_000 });
+    const inserted = await composer.evaluate(insertPlainTextIntoComposer, text, { timeout: 20_000 });
     throwIfPromptAttachmentAborted(abortSignal);
     if (!inserted) {
       throw new ChatGptPromptAttachmentIntegrityError(

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -640,6 +640,59 @@ export const browserStageTimeouts = {
   multipartStageSend: 180_000,
 } as const;
 
+/**
+ * Detects that this process was suspended (system sleep) by watching for gaps in a steady tick.
+ * On Apple Silicon the monotonic clock keeps advancing through sleep, so elapsed time alone cannot
+ * distinguish "the stage really took 15 minutes" from "the machine slept for 14 of them" — and a
+ * stage budget charged for slept time cancels turns that never got their budget awake.
+ */
+export class ChatGptSuspensionClock {
+  private suspendedTotalMs = 0;
+  private lastTickAt: number;
+  private timer: ReturnType<typeof setInterval> | undefined;
+
+  constructor(
+    private readonly tickIntervalMs = 1_000,
+    private readonly gapThresholdMs = 5_000,
+  ) {
+    this.lastTickAt = Date.now();
+  }
+
+  start(): void {
+    if (this.timer) return;
+    this.lastTickAt = Date.now();
+    this.timer = setInterval(() => this.tick(Date.now()), this.tickIntervalMs);
+    this.timer.unref?.();
+  }
+
+  /** Exposed for tests; production ticks come from the interval above. */
+  tick(now: number): void {
+    const gap = now - this.lastTickAt;
+    this.lastTickAt = now;
+    if (gap >= this.gapThresholdMs) this.suspendedTotalMs += gap - this.tickIntervalMs;
+  }
+
+  suspendedMs(): number {
+    return this.suspendedTotalMs;
+  }
+}
+
+export const chatGptSuspensionClock = new ChatGptSuspensionClock();
+
+/**
+ * How much of a stage budget remains once slept time is refunded. Zero means the stage really
+ * consumed its budget while awake and the timeout stands.
+ */
+export function remainingStageBudgetMs(
+  timeoutMs: number,
+  elapsedMs: number,
+  suspendedMs: number,
+): number {
+  const awakeMs = elapsedMs - suspendedMs;
+  if (awakeMs >= timeoutMs) return 0;
+  return Math.max(250, timeoutMs - awakeMs);
+}
+
 export const CHATGPT_BROWSER_OBSERVATION_PROBE_TIMEOUT_MS = 5_000;
 export const MAX_CHATGPT_BROWSER_PAGE_REBINDS = 2;
 
@@ -1620,17 +1673,31 @@ export class ChatGptBrowserWorker {
     stage: string,
     timeoutMs: number,
     action: (abortSignal: AbortSignal) => Promise<T>,
+    suspensionClock: Pick<ChatGptSuspensionClock, "suspendedMs"> = chatGptSuspensionClock,
   ): Promise<T> {
+    chatGptSuspensionClock.start();
     const startedAt = performance.now();
+    const suspendedAtStart = suspensionClock.suspendedMs();
     console.info(`[chatgpt-web] browser turn ${traceId} stage=${stage} started`);
     const controller = new AbortController();
     let timer: ReturnType<typeof setTimeout> | undefined;
     try {
       const timeout = new Promise<never>((_, rejectTimeout) => {
-        timer = setTimeout(() => {
+        const fireOrRearm = () => {
+          // A stage that spans a system sleep has not consumed its budget: the browser was as
+          // frozen as this process, so slept time is refunded and the timer re-armed for what the
+          // stage is still owed. Observed live as effort_selection "timing out" at 901s of a 120s
+          // budget, to the second of a DarkWake.
+          const suspendedMs = suspensionClock.suspendedMs() - suspendedAtStart;
+          const remaining = remainingStageBudgetMs(timeoutMs, performance.now() - startedAt, suspendedMs);
+          if (remaining > 0) {
+            timer = setTimeout(fireOrRearm, remaining);
+            return;
+          }
           rejectTimeout(new Error(`ChatGPT browser stage timed out: ${stage}`));
           controller.abort();
-        }, timeoutMs);
+        };
+        timer = setTimeout(fireOrRearm, timeoutMs);
       });
       const value = await Promise.race([action(controller.signal), timeout]);
       console.info(`[chatgpt-web] browser turn ${traceId} stage=${stage} completed durationMs=${Math.round(performance.now() - startedAt)}`);

--- a/src/adapters/chatgpt-web/environment.ts
+++ b/src/adapters/chatgpt-web/environment.ts
@@ -93,6 +93,10 @@ function contextualUserMessage(value: Record<string, unknown>): boolean {
   const text = rawMessageText(value).trim();
   return /^<environment_context>[\s\S]*<\/environment_context>$/.test(text)
     || /^<subagent_notification>[\s\S]*<\/subagent_notification>$/.test(text)
+    // Codex injects this notice when a user interrupts a turn. It is a synthetic report about the
+    // previous turn, not a human instruction, and it keeps that turn's id. Treating it as the
+    // current revision made the next turn read a foreign turn id and fail as a conflict.
+    || /^<turn_aborted>[\s\S]*<\/turn_aborted>$/.test(text)
     || isReadableCompactionSummaryText(text)
     || text === OPAQUE_COMPACTION_NOTE;
 }

--- a/src/adapters/chatgpt-web/environment.ts
+++ b/src/adapters/chatgpt-web/environment.ts
@@ -93,12 +93,12 @@ function contextualUserMessage(value: Record<string, unknown>): boolean {
   const text = rawMessageText(value).trim();
   return /^<environment_context>[\s\S]*<\/environment_context>$/.test(text)
     || /^<subagent_notification>[\s\S]*<\/subagent_notification>$/.test(text)
-    // Codex injects this notice when a user interrupts a turn. It is a synthetic report about the
-    // previous turn, not a human instruction, and it keeps that turn's id. Treating it as the
-    // current revision made the next turn read a foreign turn id and fail as a conflict.
-    || /^<turn_aborted>[\s\S]*<\/turn_aborted>$/.test(text)
     || isReadableCompactionSummaryText(text)
     || text === OPAQUE_COMPACTION_NOTE;
+}
+
+function isTurnAbortedNotice(value: Record<string, unknown>): boolean {
+  return /^<turn_aborted>[\s\S]*<\/turn_aborted>$/.test(rawMessageText(value).trim());
 }
 
 /**
@@ -112,7 +112,7 @@ function contextualUserMessage(value: Record<string, unknown>): boolean {
 export function extractChatGptTurnUserRevision(parsed: CodexParsedRequest): unknown {
   const turnId = extractChatGptTurnIdentity(parsed).turnId;
   if (!turnId) throw new Error("ChatGPT web requires native Codex turn_id metadata for browser-session replay");
-  const revision = latestChatGptTurnUserRevision(parsed);
+  const revision = latestChatGptTurnUserRevision(parsed, turnId);
   if (!revision) throw new Error("ChatGPT web requires a current-turn user message for browser-session replay");
   if (revision.turnId !== undefined && revision.turnId !== turnId) {
     throw new Error(CHATGPT_TURN_REVISION_CONFLICT_MESSAGE);
@@ -120,14 +120,21 @@ export function extractChatGptTurnUserRevision(parsed: CodexParsedRequest): unkn
   return revision.content;
 }
 
-function latestChatGptTurnUserRevision(parsed: CodexParsedRequest): ChatGptTurnUserRevision | undefined {
+function latestChatGptTurnUserRevision(parsed: CodexParsedRequest, expectedTurnId?: string): ChatGptTurnUserRevision | undefined {
   const body = record(parsed._rawBody);
   const input = Array.isArray(body?.input) ? body.input : [];
   for (let index = input.length - 1; index >= 0; index -= 1) {
     const item = record(input[index]);
     if (item?.type !== "message" || item.role !== "user") continue;
-    if (contextualUserMessage(item)) continue;
     const messageTurnId = itemTurnId(item);
+    // Codex appends an abort report as a user-shaped item carrying the interrupted turn's id. Only
+    // suppress that synthetic notice when its metadata proves it belongs to a different turn; a
+    // human is still allowed to submit the same XML-looking text as their current instruction.
+    if (isTurnAbortedNotice(item)
+      && expectedTurnId !== undefined
+      && messageTurnId !== undefined
+      && messageTurnId !== expectedTurnId) continue;
+    if (contextualUserMessage(item)) continue;
     const serverOwnedId = typeof item.id === "string" && item.id.length > 0;
     if (messageTurnId === undefined && !serverOwnedId) continue;
     return { content: item.content, ...(messageTurnId ? { turnId: messageTurnId } : {}) };
@@ -138,7 +145,7 @@ function latestChatGptTurnUserRevision(parsed: CodexParsedRequest): ChatGptTurnU
 /** The human instruction summarized by a remote compaction request belongs to an earlier turn. */
 export function extractChatGptCompactionSourceRevision(parsed: CodexParsedRequest): ChatGptTurnUserRevision {
   if (!parsed._compactionRequest) throw new Error("ChatGPT web compaction source requires a compaction request");
-  const revision = latestChatGptTurnUserRevision(parsed);
+  const revision = latestChatGptTurnUserRevision(parsed, extractChatGptTurnIdentity(parsed).turnId);
   if (!revision) throw new Error("ChatGPT web compaction requires a source user message");
   return revision;
 }

--- a/src/adapters/chatgpt-web/index.ts
+++ b/src/adapters/chatgpt-web/index.ts
@@ -646,7 +646,7 @@ export function createChatGptWebAdapter(
           return;
         }
         const responseExecutionKey = `${executionNamespace}:${chatGptCompactionSourceExecutionKey(parsed)}`;
-        await chatGptTurnSessions.retireAndWait(responseExecutionKey);
+        await chatGptTurnSessions.retireAndWait(responseExecutionKey, incoming.abortSignal);
       }
       const executionKey = `${executionNamespace}:${chatGptTurnExecutionKey(parsed)}`;
       const ownerKey = `${executionNamespace}:${chatGptThreadOwnershipKey(parsed)}`;
@@ -656,6 +656,7 @@ export function createChatGptWebAdapter(
         ownerKey,
         () => startRuntime(parsed, environment, traceId, turnCapabilities),
         traceId,
+        incoming.abortSignal,
       );
       const roundKey = chatGptTurnRoundKey(parsed);
       const emitRoundEvents = (events: readonly AdapterEvent[]): void => {

--- a/src/adapters/chatgpt-web/index.ts
+++ b/src/adapters/chatgpt-web/index.ts
@@ -3,7 +3,7 @@ import { resolve } from "node:path";
 import { defaultBrokerEndpoint, expandUserPath, resolveBrokerEndpoint } from "../../config";
 import { releaseLauncherRetainedConversation } from "../../launcher-browser-host";
 import { namespacedToolName, type AdapterEvent, type CodexContentPart, type CodexParsedRequest, type CodexProviderConfig, type CodexToolResultMessage, type CodexUsage } from "../../types";
-import type { ProviderAdapter } from "../base";
+import type { IncomingMeta, ProviderAdapter } from "../base";
 import { parseDataUrl } from "../image";
 import { ChatGptWebAdapterError } from "./adapter-error";
 import { ChatGptBrowserWorker } from "./browser-worker";
@@ -236,6 +236,9 @@ function validateBatchTools(parsed: CodexParsedRequest, requests: BrokerToolRequ
   }
 }
 
+/** Keep the Responses bridge alive during every awaited phase of a browser turn. */
+export const CHATGPT_WEB_ADAPTER_HEARTBEAT_MS = 10_000;
+
 export function createChatGptWebAdapter(
   provider: CodexProviderConfig,
   dependencies: { broker?: TurnBrokerOwner } = {},
@@ -466,6 +469,13 @@ export function createChatGptWebAdapter(
   return {
     name: "chatgpt-web",
     async runTurn(parsed, incoming, emit) {
+      // Arm this before any awaited work, including environment lookup and owner retirement.
+      const heartbeat = setInterval(
+        () => emit({ type: "heartbeat" }),
+        CHATGPT_WEB_ADAPTER_HEARTBEAT_MS,
+      );
+      emit({ type: "heartbeat" });
+      try {
       const turnCapabilities = parsed._compactionRequest
         ? { ...configuredCapabilities, localToolsEnabled: false }
         : configuredCapabilities;
@@ -663,7 +673,7 @@ export function createChatGptWebAdapter(
         emitRoundEvents(events);
       };
       const emitRoundEvent = (event: AdapterEvent): void => emitRoundEvents([event]);
-      const heartbeat = setInterval(() => emit({ type: "heartbeat" }), 10_000);
+      const sessionHeartbeat = setInterval(() => emit({ type: "heartbeat" }), CHATGPT_WEB_ADAPTER_HEARTBEAT_MS);
       try {
         emit({ type: "heartbeat" });
         await session.runExclusive(async () => {
@@ -877,6 +887,9 @@ export function createChatGptWebAdapter(
         session.failRound(roundKey, turnError);
         chatGptWebTurnRetryPolicy.clear(retryKey);
         throw turnError;
+      } finally {
+        clearInterval(sessionHeartbeat);
+      }
       } finally {
         clearInterval(heartbeat);
       }

--- a/src/adapters/chatgpt-web/turn-broker.ts
+++ b/src/adapters/chatgpt-web/turn-broker.ts
@@ -161,6 +161,13 @@ export interface TurnBrokerOwner {
   revoke(token: string, reason?: Error): void | Promise<void>;
 }
 
+/**
+ * Bytes available for a Unix socket path. Linux allows 108, macOS and the BSDs 104; the smaller
+ * bound is used everywhere so a path that works on one developer's machine is not silently
+ * unbindable on another's.
+ */
+const MAX_UNIX_SOCKET_PATH_BYTES = 104;
+
 export class TurnBroker implements TurnBrokerOwner {
   static forSocket(path: string): TurnBroker {
     let broker = brokers.get(path);
@@ -415,7 +422,20 @@ export class TurnBroker implements TurnBrokerOwner {
     if (this.startPromise) return this.startPromise;
     this.startPromise = new Promise<void>((resolveStart, rejectStart) => {
       const windowsPipe = isWindowsPipeEndpoint(this.socketPath);
-      if (!windowsPipe) mkdirSync(dirname(this.socketPath), { recursive: true, mode: 0o700 });
+      if (!windowsPipe) {
+        // sun_path is a fixed-size field in the kernel, so an over-long path fails inside listen()
+        // with nothing but "Failed to listen" and no hint that the length is the problem. Say so.
+        const encodedLength = Buffer.byteLength(this.socketPath);
+        if (encodedLength > MAX_UNIX_SOCKET_PATH_BYTES) {
+          rejectStart(new Error(
+            `ChatGPT web broker socket path is ${encodedLength} bytes, over the`
+            + ` ${MAX_UNIX_SOCKET_PATH_BYTES}-byte limit this platform allows for a Unix socket:`
+            + ` ${this.socketPath}. Choose a shorter runtime directory.`,
+          ));
+          return;
+        }
+        mkdirSync(dirname(this.socketPath), { recursive: true, mode: 0o700 });
+      }
       const listen = () => {
         const server = createServer(socket => this.handleSocket(socket));
         this.server = server;

--- a/src/adapters/chatgpt-web/turn-broker.ts
+++ b/src/adapters/chatgpt-web/turn-broker.ts
@@ -162,11 +162,11 @@ export interface TurnBrokerOwner {
 }
 
 /**
- * Bytes available for a Unix socket path. Linux allows 108, macOS and the BSDs 104; the smaller
- * bound is used everywhere so a path that works on one developer's machine is not silently
- * unbindable on another's.
+ * Bytes available for a Unix socket path. Linux allows 108, macOS and the BSDs expose a 104-byte
+ * sun_path including its terminating NUL; the smaller usable bound is used everywhere so a path
+ * that works on one developer's machine is not silently unbindable on another's.
  */
-const MAX_UNIX_SOCKET_PATH_BYTES = 104;
+const MAX_UNIX_SOCKET_PATH_BYTES = 103;
 
 export class TurnBroker implements TurnBrokerOwner {
   static forSocket(path: string): TurnBroker {

--- a/src/adapters/chatgpt-web/turn-execution.ts
+++ b/src/adapters/chatgpt-web/turn-execution.ts
@@ -10,6 +10,31 @@ import {
 import { MAX_CHATGPT_BROWSER_TABS } from "./concurrency";
 import type { ChatGptExternalTurnProgress } from "./turn-progress";
 
+function awaitWithAbort<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) return promise;
+  if (signal.aborted) {
+    // Keep the underlying retirement promise observed even when the caller arrived after abort;
+    // another owner may still depend on its eventual settlement and rejection must not become an
+    // unhandled process-level error.
+    void promise.catch(() => {});
+    return Promise.reject(new DOMException("ChatGPT web turn aborted", "AbortError"));
+  }
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(new DOMException("ChatGPT web turn aborted", "AbortError"));
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      value => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      error => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+  });
+}
+
 export type ChatGptBrowserOutcome =
   | { type: "final"; answer: string }
   | { type: "error"; error: Error };
@@ -481,8 +506,10 @@ export class ChatGptTurnSessions {
     ownerKey: string,
     start: () => ChatGptTurnRuntime,
     traceId?: string,
+    signal?: AbortSignal,
   ): Promise<ChatGptTurnSession> {
     for (;;) {
+      if (signal?.aborted) throw new DOMException("ChatGPT web turn aborted", "AbortError");
       const existing = this.entries.get(key);
       if (existing) {
         existing.touch();
@@ -490,7 +517,7 @@ export class ChatGptTurnSessions {
       }
       const pending = this.retirements.get(key) ?? this.ownerRetirements.get(ownerKey);
       if (pending) {
-        await pending;
+        await awaitWithAbort(pending, signal);
         continue;
       }
       const activeOwner = [...this.entries].find(([ownedKey, session]) => (
@@ -502,9 +529,10 @@ export class ChatGptTurnSessions {
         // kill the response already using that retained conversation. Wait for its complete
         // browser/launcher settlement; explicit tab close and lifecycle cancellation remain the
         // only paths that preempt an active owner.
-        await ownedSession.physicalSettlement;
+        await awaitWithAbort(ownedSession.physicalSettlement, signal);
         continue;
       }
+      if (signal?.aborted) throw new DOMException("ChatGPT web turn aborted", "AbortError");
       return this.getOrCreate(key, start, traceId, ownerKey);
     }
   }
@@ -556,10 +584,10 @@ export class ChatGptTurnSessions {
     await this.retirements.get(key);
   }
 
-  async retireAndWait(key: string): Promise<boolean> {
+  async retireAndWait(key: string, signal?: AbortSignal): Promise<boolean> {
     const pending = this.retirements.get(key);
     if (pending) {
-      await pending;
+      await awaitWithAbort(pending, signal);
       return true;
     }
     const session = this.entries.get(key);
@@ -567,7 +595,7 @@ export class ChatGptTurnSessions {
 
     this.entries.delete(key);
     this.forgetConversationHead(session);
-    await this.beginRetirement(key, session);
+    await awaitWithAbort(this.beginRetirement(key, session), signal);
     return true;
   }
 

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -201,6 +201,11 @@ export function bridgeToResponsesSSE(
 
       const heartbeatFrame = encoder.encode('event: response.heartbeat\ndata: {"type":"response.heartbeat"}\n\n');
       let stallTicks = 0;
+      let stallWarned = false;
+      let lastAdapterEventAt = Date.now();
+      let lastAdapterEventType = "<none>";
+      let adapterEventCount = 0;
+      const streamStartedAt = Date.now();
       const stallSec = resolveStallTimeoutSec(options?.stallTimeoutSec);
       const maxStallTicks = Math.ceil((stallSec * 1000) / heartbeatMs);
 
@@ -417,6 +422,10 @@ export function bridgeToResponsesSSE(
           let terminalEvent = false;
           activity = true;
           stallTicks = 0;
+          lastAdapterEventAt = Date.now();
+          lastAdapterEventType = event.type;
+          adapterEventCount += 1;
+          stallWarned = false;
           reportFirstOutput(event);
           // Compaction turns emit ONLY the synthetic compaction item + response.completed. The
           // summary text is accumulated silently: emitting it as a normal assistant message would
@@ -732,7 +741,25 @@ export function bridgeToResponsesSSE(
         beat = setInterval(() => {
           if (closed || gated) return;
           if (activity) { activity = false; stallTicks = 0; return; }
+          if (stallTicks === Math.ceil(maxStallTicks / 2) && !stallWarned) {
+            // Halfway to cancelling the turn. A healthy adapter heartbeats far more often than
+            // this, so reaching here at all means a keep-alive gap that should be found before it
+            // costs a user their turn.
+            stallWarned = true;
+            console.warn(
+              `[bridge] upstream silence halfway to the stall budget model=${modelId}`
+              + ` response=${responseId} stallSec=${stallSec} adapterEvents=${adapterEventCount}`
+              + ` lastEvent=${lastAdapterEventType} sinceLastEventMs=${Date.now() - lastAdapterEventAt}`,
+            );
+          }
           if (++stallTicks >= maxStallTicks) {
+            console.error(
+              `[bridge] upstream_stall_timeout model=${modelId} response=${responseId}`
+              + ` stallSec=${stallSec} adapterEvents=${adapterEventCount}`
+              + ` lastEvent=${lastAdapterEventType} sinceLastEventMs=${Date.now() - lastAdapterEventAt}`
+              + ` sinceStreamStartMs=${Date.now() - streamStartedAt}`
+              + ` iteratorStarted=${iteratorStarted} upstreamDone=${upstreamDone} emittedFrames=${emittedFrames}`,
+            );
             if (currentMsg) closeCurrentMessage();
             if (currentReasoning) closeCurrentReasoning();
             if (currentRawReasoning) closeCurrentRawReasoning();

--- a/src/native-passthrough.ts
+++ b/src/native-passthrough.ts
@@ -107,8 +107,6 @@ function endToEndHeaders(source: Headers): Headers {
 
 /** Terminator every Responses SSE stream ends with; nothing after it carries meaning. */
 const SSE_TERMINATOR = "data: [DONE]";
-/** Enough trailing bytes to recognise the terminator across a chunk boundary. */
-const SSE_TAIL_WINDOW = 64;
 
 /**
  * ChatGPT's backend routinely resets the native Codex connection instead of closing it cleanly,
@@ -128,22 +126,39 @@ function withUncleanCloseTolerance(
   if (!isEventStream) return body;
   const reader = body.getReader();
   const decoder = new TextDecoder();
-  let tail = "";
+  let lineBuffer = "";
   let completed = false;
   let bytes = 0;
+  const inspectLines = (text: string): void => {
+    lineBuffer += text;
+    let newline = lineBuffer.indexOf("\n");
+    while (newline >= 0) {
+      const line = lineBuffer.slice(0, newline).replace(/\r$/, "");
+      lineBuffer = lineBuffer.slice(newline + 1);
+      if (line === SSE_TERMINATOR) completed = true;
+      newline = lineBuffer.indexOf("\n");
+    }
+  };
+  const inspectTrailingLine = (): void => {
+    // A reset can arrive before the final line separator. Treat only an exact unterminated
+    // terminator line as complete; text embedded in a JSON data payload must not qualify.
+    if (lineBuffer.replace(/\r$/, "") === SSE_TERMINATOR) completed = true;
+  };
   return new ReadableStream<Uint8Array>({
     async pull(controller) {
       try {
         const chunk = await reader.read();
         if (chunk.done) {
+          inspectLines(decoder.decode());
+          inspectTrailingLine();
           controller.close();
           return;
         }
         bytes += chunk.value.byteLength;
-        tail = (tail + decoder.decode(chunk.value, { stream: true })).slice(-SSE_TAIL_WINDOW);
-        if (tail.includes(SSE_TERMINATOR)) completed = true;
+        inspectLines(decoder.decode(chunk.value, { stream: true }));
         controller.enqueue(chunk.value);
       } catch (error) {
+        inspectTrailingLine();
         if (!completed) {
           controller.error(error);
           return;

--- a/src/native-passthrough.ts
+++ b/src/native-passthrough.ts
@@ -105,6 +105,59 @@ function endToEndHeaders(source: Headers): Headers {
   return headers;
 }
 
+/** Terminator every Responses SSE stream ends with; nothing after it carries meaning. */
+const SSE_TERMINATOR = "data: [DONE]";
+/** Enough trailing bytes to recognise the terminator across a chunk boundary. */
+const SSE_TAIL_WINDOW = 64;
+
+/**
+ * ChatGPT's backend routinely resets the native Codex connection instead of closing it cleanly,
+ * which Bun surfaces as ECONNRESET while reading the body. Passed through untouched that reaches
+ * Codex as a truncated HTTP body and the opaque "error decoding response body".
+ *
+ * A reset that arrives after the stream already delivered `data: [DONE]` is an unclean TCP close on
+ * a turn that finished: every byte the protocol defines has been forwarded, so the stream is closed
+ * normally rather than failed. A reset before that genuinely truncated the turn and is still raised,
+ * because inventing a terminal event there would tell Codex a turn ended when it did not.
+ */
+function withUncleanCloseTolerance(
+  body: ReadableStream<Uint8Array>,
+  isEventStream: boolean,
+  onUncleanClose?: (bytes: number) => void,
+): ReadableStream<Uint8Array> {
+  if (!isEventStream) return body;
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let tail = "";
+  let completed = false;
+  let bytes = 0;
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const chunk = await reader.read();
+        if (chunk.done) {
+          controller.close();
+          return;
+        }
+        bytes += chunk.value.byteLength;
+        tail = (tail + decoder.decode(chunk.value, { stream: true })).slice(-SSE_TAIL_WINDOW);
+        if (tail.includes(SSE_TERMINATOR)) completed = true;
+        controller.enqueue(chunk.value);
+      } catch (error) {
+        if (!completed) {
+          controller.error(error);
+          return;
+        }
+        onUncleanClose?.(bytes);
+        controller.close();
+      }
+    },
+    cancel(reason) {
+      return reader.cancel(reason);
+    },
+  });
+}
+
 export async function forwardNativeCodexRequest(
   request: Request,
   endpoint: NativeCodexEndpoint,
@@ -145,9 +198,21 @@ export async function forwardNativeCodexRequest(
     signal: request.signal,
   });
   const upstream = await fetchUpstream(upstreamRequest);
-  return new Response(upstream.body, {
-    status: upstream.status,
-    statusText: upstream.statusText,
-    headers: endToEndHeaders(upstream.headers),
-  });
+  const responseHeaders = endToEndHeaders(upstream.headers);
+  const isEventStream = (upstream.headers.get("content-type") ?? "").includes("text/event-stream");
+  return new Response(
+    upstream.body
+      ? withUncleanCloseTolerance(upstream.body, isEventStream, bytes => {
+        console.warn(
+          `[codex-chatgpt-web] native_upstream_unclean_close endpoint=${endpoint} bytes=${bytes}`
+          + " (turn had already completed; closing the client stream normally)",
+        );
+      })
+      : upstream.body,
+    {
+      status: upstream.status,
+      statusText: upstream.statusText,
+      headers: responseHeaders,
+    },
+  );
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -485,6 +485,9 @@ export async function responseRequest(
       2_000,
       {
         hideThinkingSummary: parsed.options.hideThinkingSummary,
+        ...(provider.chatgptWeb?.stallTimeoutSec !== undefined
+          ? { stallTimeoutSec: provider.chatgptWeb.stallTimeoutSec }
+          : {}),
         ...(compaction ? { compaction: true } : {
           ...(options.rememberState === false ? {} : {
             onCompletedResponse: (response: Record<string, unknown>) => rememberResponseState(parsed._rawBody, response, { force: true }),

--- a/src/stall-timeout.ts
+++ b/src/stall-timeout.ts
@@ -7,14 +7,18 @@
  */
 export const DEFAULT_STALL_TIMEOUT_SEC = 300;
 
+// Keep a malformed or accidentally enormous configuration from overflowing the bridge's
+// heartbeat tick budget and disabling the hung-upstream watchdog entirely.
+export const MAX_STALL_TIMEOUT_SEC = 3_600;
+
 /**
  * Resolve the effective bridge stall deadline for a turn.
  * - unset / non-finite config → {@link DEFAULT_STALL_TIMEOUT_SEC}
- * - finite config → ceil, minimum 1
+ * - finite config → ceil, clamped to the practical [1, {@link MAX_STALL_TIMEOUT_SEC}] range
  */
 export function resolveStallTimeoutSec(configuredSec: number | undefined): number {
   if (typeof configuredSec === "number" && Number.isFinite(configuredSec)) {
-    return Math.max(1, Math.ceil(configuredSec));
+    return Math.min(MAX_STALL_TIMEOUT_SEC, Math.max(1, Math.ceil(configuredSec)));
   }
   return DEFAULT_STALL_TIMEOUT_SEC;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -282,6 +282,13 @@ export interface CodexProviderConfig {
     lunaCheckpointStatePath?: string;
     /** Optional explicit safety ceiling. Browser turns have no absolute deadline by default. */
     turnTimeoutMs?: number;
+    /**
+     * Seconds of adapter silence before the Responses bridge cancels a turn as a hung upstream.
+     * The adapter heartbeats every CHATGPT_WEB_ADAPTER_HEARTBEAT_MS for the whole of a turn, so a
+     * healthy turn never approaches this no matter how long it thinks; raise it only to tolerate a
+     * genuinely unresponsive upstream for longer. Defaults to DEFAULT_STALL_TIMEOUT_SEC.
+     */
+    stallTimeoutSec?: number;
     /** Keep the single controlled browser visible. */
     headed?: boolean;
     /** Attach the turn-bound Codex MCP capability for every connector-capable Web model. */

--- a/tests/bridge-stall-timeout.test.ts
+++ b/tests/bridge-stall-timeout.test.ts
@@ -1,0 +1,66 @@
+import { expect, test } from "bun:test";
+import { bridgeToResponsesSSE } from "../src/bridge";
+import { DEFAULT_STALL_TIMEOUT_SEC, resolveStallTimeoutSec } from "../src/stall-timeout";
+import type { AdapterEvent } from "../src/types";
+
+const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
+
+/**
+ * The watchdog exists to end a genuinely hung upstream, and it is the only thing standing between a
+ * slow turn and `upstream_stall_timeout`. Its contract is therefore the reason the chatgpt-web
+ * adapter must heartbeat for the whole of a turn: silence is the only signal the bridge has.
+ */
+function bridged(
+  events: AsyncGenerator<AdapterEvent>,
+  stallTimeoutSec: number,
+  heartbeatMs: number,
+): ReadableStream<Uint8Array> {
+  return bridgeToResponsesSSE(
+    events,
+    "chatgpt-web/test",
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    heartbeatMs,
+    { streamPlatform: "darwin", stallTimeoutSec },
+  );
+}
+
+test("an adapter that goes silent past the budget is cancelled as a hung upstream", async () => {
+  async function* silent(): AsyncGenerator<AdapterEvent> {
+    await sleep(1_500);
+    yield { type: "text_delta", text: "too late" };
+    yield { type: "done", endTurn: true };
+  }
+
+  const body = await new Response(bridged(silent(), 1, 10)).text();
+
+  expect(body).toContain("upstream_stall_timeout");
+  expect(body).not.toContain("too late");
+});
+
+test("an adapter that keeps heartbeating is never cancelled, however long it takes", async () => {
+  async function* thinkingHard(): AsyncGenerator<AdapterEvent> {
+    // Ten times the stall budget elapses, and nothing but keep-alives crosses the boundary.
+    for (let beat = 0; beat < 20; beat++) {
+      await sleep(100);
+      yield { type: "heartbeat" };
+    }
+    yield { type: "text_delta", text: "answer" };
+    yield { type: "done", endTurn: true };
+  }
+
+  const body = await new Response(bridged(thinkingHard(), 0.2, 10)).text();
+
+  expect(body).not.toContain("upstream_stall_timeout");
+  expect(body).toContain("answer");
+  expect(body).toContain("event: response.completed");
+});
+
+test("the stall budget is configurable and falls back to the shipped default", () => {
+  expect(resolveStallTimeoutSec(undefined)).toBe(DEFAULT_STALL_TIMEOUT_SEC);
+  expect(resolveStallTimeoutSec(Number.NaN)).toBe(DEFAULT_STALL_TIMEOUT_SEC);
+  expect(resolveStallTimeoutSec(900)).toBe(900);
+  expect(resolveStallTimeoutSec(0)).toBe(1);
+});

--- a/tests/bridge-stall-timeout.test.ts
+++ b/tests/bridge-stall-timeout.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import { bridgeToResponsesSSE } from "../src/bridge";
-import { DEFAULT_STALL_TIMEOUT_SEC, resolveStallTimeoutSec } from "../src/stall-timeout";
+import { DEFAULT_STALL_TIMEOUT_SEC, MAX_STALL_TIMEOUT_SEC, resolveStallTimeoutSec } from "../src/stall-timeout";
 import type { AdapterEvent } from "../src/types";
 
 const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
@@ -63,4 +63,6 @@ test("the stall budget is configurable and falls back to the shipped default", (
   expect(resolveStallTimeoutSec(Number.NaN)).toBe(DEFAULT_STALL_TIMEOUT_SEC);
   expect(resolveStallTimeoutSec(900)).toBe(900);
   expect(resolveStallTimeoutSec(0)).toBe(1);
+  expect(resolveStallTimeoutSec(Number.MAX_VALUE)).toBe(MAX_STALL_TIMEOUT_SEC);
+  expect(resolveStallTimeoutSec(MAX_STALL_TIMEOUT_SEC + 1)).toBe(MAX_STALL_TIMEOUT_SEC);
 });

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -1,8 +1,7 @@
 import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import type { Page } from "playwright-core";
-import { setChatGptThinkMode } from "../src/adapters/chatgpt-web/browser-worker";
-import { CHATGPT_BROWSER_OBSERVATION_PROBE_TIMEOUT_MS, CHATGPT_EXTERNAL_PROGRESS_CLOCK_SKEW_MS, CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS, ChatGptCompletionTracker, chatGptExternalProgressSuppressesDomHealth, CHATGPT_RESPONSE_DOM_GRACE_MS, MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS, CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_STOPPED_THINKING_GRACE_MS, ChatGptBrowserObservationTimeoutError, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_PAGE_REBINDS, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, assertChatGptWebMultipartInputWithinLimits, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptConnectorAttachmentMode, chatGptEffortSelectionRequired, chatGptNewTurnIdentity, chatGptReboundTurnIdentity, chatGptSubmissionEvidence, dismissChatGptTemporaryChatOnboarding, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, resolveChatGptWebMultipartStagingMode, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert, withChatGptBrowserObservationTimeout, CHATGPT_MULTIPART_RESPONSE_DOM_GRACE_MS, browserStageTimeouts, ChatGptSuspensionClock, remainingStageBudgetMs } from "../src/adapters/chatgpt-web/browser-worker";
+import { CHATGPT_BROWSER_OBSERVATION_PROBE_TIMEOUT_MS, CHATGPT_EXTERNAL_PROGRESS_CLOCK_SKEW_MS, CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS, ChatGptCompletionTracker, chatGptExternalProgressSuppressesDomHealth, CHATGPT_RESPONSE_DOM_GRACE_MS, MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS, CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_STOPPED_THINKING_GRACE_MS, ChatGptBrowserObservationTimeoutError, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_PAGE_REBINDS, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, assertChatGptWebMultipartInputWithinLimits, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptConnectorAttachmentMode, chatGptEffortSelectionRequired, chatGptNewTurnIdentity, chatGptReboundTurnIdentity, chatGptSubmissionEvidence, dismissChatGptTemporaryChatOnboarding, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, resolveChatGptWebMultipartStagingMode, setChatGptThinkMode, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert, withChatGptBrowserObservationTimeout, CHATGPT_MULTIPART_RESPONSE_DOM_GRACE_MS, browserStageTimeouts, ChatGptSuspensionClock, remainingStageBudgetMs } from "../src/adapters/chatgpt-web/browser-worker";
 import { chatGptStoppedThinkingError } from "../src/adapters/chatgpt-web/adapter-error";
 import { CHATGPT_WEB_MODEL_ID } from "../src/adapters/chatgpt-web/model";
 import { CHATGPT_CONNECTOR_NAME, DEV_CHATGPT_CONNECTOR_NAME, defaultChromeExecutable, legacyChatGptConnectorMigrationMessage } from "../src/config";
@@ -1114,6 +1113,44 @@ test("Luna-only browser turns verify selector absence instead of opening an effo
 
   expect(mode).toMatchObject({ displayLabel: "Luna", uiEffortIndex: null });
   expect(checkpoints).toEqual(["luna-default-confirmed"]);
+});
+
+test("Think mode follows the exact pressed state and normal Luna clears it", async () => {
+  let pressed = false;
+  let clicks = 0;
+  const control = {
+    getAttribute: async () => pressed ? "true" : "false",
+    click: async () => { clicks += 1; pressed = !pressed; },
+  };
+  const controls = {
+    count: async () => 1,
+    first: () => control,
+  };
+  const composerForm = {
+    getByRole: (role: string, options: { name: string; exact: boolean }) => {
+      expect([role, options]).toEqual(["button", { name: "Think", exact: true }]);
+      return { filter: () => controls };
+    },
+  };
+  const checkpoints: string[] = [];
+
+  await setChatGptThinkMode(composerForm as never, true, async checkpoint => { checkpoints.push(checkpoint); });
+  expect(pressed).toBeTrue();
+  expect(clicks).toBe(1);
+  await setChatGptThinkMode(composerForm as never, true);
+  expect(clicks).toBe(1);
+  await setChatGptThinkMode(composerForm as never, false, async checkpoint => { checkpoints.push(checkpoint); });
+  expect(pressed).toBeFalse();
+  expect(clicks).toBe(2);
+  expect(checkpoints).toEqual(["think-enabled", "think-disabled"]);
+});
+
+test("Think mode fails closed when the Luna composer does not expose the control", async () => {
+  const composerForm = {
+    getByRole: () => ({ filter: () => ({ count: async () => 0 }) }),
+  };
+  await expect(setChatGptThinkMode(composerForm as never, true))
+    .rejects.toThrow("Think control is not available");
 });
 
 test("effort selection handles the known ChatGPT rate-limit dialog before background-safe activation", () => {

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import type { Page } from "playwright-core";
-import { CHATGPT_BROWSER_OBSERVATION_PROBE_TIMEOUT_MS, CHATGPT_EXTERNAL_PROGRESS_CLOCK_SKEW_MS, CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS, ChatGptCompletionTracker, chatGptExternalProgressSuppressesDomHealth, CHATGPT_RESPONSE_DOM_GRACE_MS, MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS, CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_STOPPED_THINKING_GRACE_MS, ChatGptBrowserObservationTimeoutError, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_PAGE_REBINDS, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, assertChatGptWebMultipartInputWithinLimits, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptConnectorAttachmentMode, chatGptEffortSelectionRequired, chatGptNewTurnIdentity, chatGptReboundTurnIdentity, chatGptSubmissionEvidence, dismissChatGptTemporaryChatOnboarding, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, resolveChatGptWebMultipartStagingMode, setChatGptThinkMode, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert, withChatGptBrowserObservationTimeout } from "../src/adapters/chatgpt-web/browser-worker";
-import { CHATGPT_MULTIPART_RESPONSE_DOM_GRACE_MS, browserStageTimeouts, ChatGptSuspensionClock, remainingStageBudgetMs } from "../src/adapters/chatgpt-web/browser-worker";
+import { setChatGptThinkMode } from "../src/adapters/chatgpt-web/browser-worker";
+import { CHATGPT_BROWSER_OBSERVATION_PROBE_TIMEOUT_MS, CHATGPT_EXTERNAL_PROGRESS_CLOCK_SKEW_MS, CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS, ChatGptCompletionTracker, chatGptExternalProgressSuppressesDomHealth, CHATGPT_RESPONSE_DOM_GRACE_MS, MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS, CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_STOPPED_THINKING_GRACE_MS, ChatGptBrowserObservationTimeoutError, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_PAGE_REBINDS, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, assertChatGptWebMultipartInputWithinLimits, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptConnectorAttachmentMode, chatGptEffortSelectionRequired, chatGptNewTurnIdentity, chatGptReboundTurnIdentity, chatGptSubmissionEvidence, dismissChatGptTemporaryChatOnboarding, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, resolveChatGptWebMultipartStagingMode, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert, withChatGptBrowserObservationTimeout, CHATGPT_MULTIPART_RESPONSE_DOM_GRACE_MS, browserStageTimeouts, ChatGptSuspensionClock, remainingStageBudgetMs } from "../src/adapters/chatgpt-web/browser-worker";
 import { chatGptStoppedThinkingError } from "../src/adapters/chatgpt-web/adapter-error";
 import { CHATGPT_WEB_MODEL_ID } from "../src/adapters/chatgpt-web/model";
 import { CHATGPT_CONNECTOR_NAME, DEV_CHATGPT_CONNECTOR_NAME, defaultChromeExecutable, legacyChatGptConnectorMigrationMessage } from "../src/config";
@@ -1089,7 +1089,6 @@ test("Luna-only browser turns verify selector absence instead of opening an effo
   const visibleControls = { count: async () => 0 };
   const composerForm = {
     locator: () => ({ filter: () => visibleControls }),
-    getByRole: () => ({ filter: () => ({ count: async () => 0 }) }),
   };
   const composer = { locator: () => composerForm };
   const selectModelAndEffort = (ChatGptBrowserWorker.prototype as unknown as {
@@ -1114,44 +1113,6 @@ test("Luna-only browser turns verify selector absence instead of opening an effo
 
   expect(mode).toMatchObject({ displayLabel: "Luna", uiEffortIndex: null });
   expect(checkpoints).toEqual(["luna-default-confirmed"]);
-});
-
-test("Think mode follows the exact pressed state and normal Luna clears it", async () => {
-  let pressed = false;
-  let clicks = 0;
-  const control = {
-    getAttribute: async () => pressed ? "true" : "false",
-    click: async () => { clicks += 1; pressed = !pressed; },
-  };
-  const controls = {
-    count: async () => 1,
-    first: () => control,
-  };
-  const composerForm = {
-    getByRole: (role: string, options: { name: string; exact: boolean }) => {
-      expect([role, options]).toEqual(["button", { name: "Think", exact: true }]);
-      return { filter: () => controls };
-    },
-  };
-  const checkpoints: string[] = [];
-
-  await setChatGptThinkMode(composerForm as never, true, async checkpoint => { checkpoints.push(checkpoint); });
-  expect(pressed).toBeTrue();
-  expect(clicks).toBe(1);
-  await setChatGptThinkMode(composerForm as never, true);
-  expect(clicks).toBe(1);
-  await setChatGptThinkMode(composerForm as never, false, async checkpoint => { checkpoints.push(checkpoint); });
-  expect(pressed).toBeFalse();
-  expect(clicks).toBe(2);
-  expect(checkpoints).toEqual(["think-enabled", "think-disabled"]);
-});
-
-test("Think mode fails closed when the Luna composer does not expose the control", async () => {
-  const composerForm = {
-    getByRole: () => ({ filter: () => ({ count: async () => 0 }) }),
-  };
-  await expect(setChatGptThinkMode(composerForm as never, true))
-    .rejects.toThrow("Think control is not available");
 });
 
 test("effort selection handles the known ChatGPT rate-limit dialog before background-safe activation", () => {

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -2533,3 +2533,19 @@ test("the bundled helper is adopted only for the packaged runtime layout", () =>
   expect(tryStart).toBeGreaterThan(0);
   expect(heartbeat).toBeLessThan(tryStart);
 });
+
+test("Bigger Context stage sends get a budget sized for their payload", () => {
+  const worker = readFileSync("src/adapters/chatgpt-web/browser-worker.ts", "utf8");
+
+  // The send stage covers ChatGPT accepting the submission, not just the click. A stage posts a
+  // payload orders of magnitude larger than an ordinary prompt onto a conversation that already
+  // holds the earlier parts, and the ordinary budget expired mid-acceptance and killed the turn.
+  expect(worker).toContain("multipartStageSend: 180_000");
+  expect(worker).toContain("browserStageTimeouts.multipartStageSend,");
+
+  // The multipart commit lands on a conversation already carrying every staged part.
+  expect(worker).toContain("prepared.multipart ? browserStageTimeouts.multipartStageSend : browserStageTimeouts.send,");
+
+  // The ordinary send budget is unchanged for ordinary prompts.
+  expect(worker).toContain("send: 20_000,");
+});

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -2,11 +2,13 @@ import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import type { Page } from "playwright-core";
 import { CHATGPT_BROWSER_OBSERVATION_PROBE_TIMEOUT_MS, CHATGPT_EXTERNAL_PROGRESS_CLOCK_SKEW_MS, CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS, ChatGptCompletionTracker, chatGptExternalProgressSuppressesDomHealth, CHATGPT_RESPONSE_DOM_GRACE_MS, MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS, CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_STOPPED_THINKING_GRACE_MS, ChatGptBrowserObservationTimeoutError, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_PAGE_REBINDS, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, assertChatGptWebMultipartInputWithinLimits, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptConnectorAttachmentMode, chatGptEffortSelectionRequired, chatGptNewTurnIdentity, chatGptReboundTurnIdentity, chatGptSubmissionEvidence, dismissChatGptTemporaryChatOnboarding, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, resolveChatGptWebMultipartStagingMode, setChatGptThinkMode, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert, withChatGptBrowserObservationTimeout } from "../src/adapters/chatgpt-web/browser-worker";
+import { CHATGPT_MULTIPART_RESPONSE_DOM_GRACE_MS, browserStageTimeouts, ChatGptSuspensionClock, remainingStageBudgetMs } from "../src/adapters/chatgpt-web/browser-worker";
 import { chatGptStoppedThinkingError } from "../src/adapters/chatgpt-web/adapter-error";
 import { CHATGPT_WEB_MODEL_ID } from "../src/adapters/chatgpt-web/model";
 import { CHATGPT_CONNECTOR_NAME, DEV_CHATGPT_CONNECTOR_NAME, defaultChromeExecutable, legacyChatGptConnectorMigrationMessage } from "../src/config";
 import { parseChatGptEffortSliderState } from "../src/chatgpt-session";
 import { ChatGptExternalTurnProgress } from "../src/adapters/chatgpt-web/turn-progress";
+import type { CodexProviderConfig } from "../src/types";
 
 function personalizedTemporaryChatRole(
   _role: string,
@@ -2566,3 +2568,62 @@ test("a staged Bigger Context part gets an acknowledgement window sized to its p
   // It is the same budget the staged send already gets; the two bound the same oversized exchange.
   expect(CHATGPT_MULTIPART_RESPONSE_DOM_GRACE_MS).toBe(browserStageTimeouts.multipartStageSend);
 });
+
+test("the suspension clock charges only tick gaps that mean the process was frozen", () => {
+  const clock = new ChatGptSuspensionClock(1_000, 5_000);
+  clock.tick(1_000);
+  clock.tick(2_000);
+  clock.tick(3_100);
+  expect(clock.suspendedMs()).toBe(0);
+
+  // Fifteen minutes without a tick is a sleep; the ordinary interval is refunded from the charge.
+  clock.tick(3_100 + 15 * 60_000);
+  expect(clock.suspendedMs()).toBe(15 * 60_000 - 1_000);
+});
+
+test("remaining stage budget refunds slept time and stands once the awake budget is spent", () => {
+  expect(remainingStageBudgetMs(120_000, 901_000, 890_000)).toBe(109_000);
+  expect(remainingStageBudgetMs(120_000, 120_000, 0)).toBe(0);
+  expect(remainingStageBudgetMs(120_000, 901_000, 0)).toBe(0);
+  expect(remainingStageBudgetMs(200, 210, 50)).toBe(250);
+});
+
+test("a stage that spans a system sleep is not charged for the slept time", async () => {
+  // The live failure: effort_selection ran 901s against a 120s budget because the Mac slept
+  // 14 minutes of it, and the stage died on DarkWake. Here the fake clock reports a sleep longer
+  // than the whole budget, so the first timer firing must re-arm instead of failing.
+  const provider: CodexProviderConfig = {
+    adapter: "chatgpt-web",
+    baseUrl: `browser://suspension-stage-${Date.now()}`,
+    chatgptWeb: { localToolsEnabled: false, solAvailable: true, proAvailable: true },
+  };
+  const worker = ChatGptBrowserWorker.forProvider(provider) as unknown as {
+    runStage<T>(
+      traceId: string,
+      stage: string,
+      timeoutMs: number,
+      action: (signal: AbortSignal) => Promise<T>,
+      clock?: { suspendedMs(): number },
+    ): Promise<T>;
+  };
+
+  let suspended = 0;
+  const clock = { suspendedMs: () => suspended };
+  const outcome: string[] = [];
+  const stage = worker.runStage(
+    "suspension-test",
+    "probe",
+    200,
+    () => new Promise<never>(() => {}),
+    clock,
+  ).catch(error => { outcome.push((error as Error).message); });
+
+  // The sleep is discovered when the first timer fires: 300ms slept against a 200ms budget.
+  suspended = 300;
+  await Bun.sleep(320);
+  expect(outcome).toEqual([]);
+
+  // No further sleep: the re-armed timer now expires on genuinely awake time.
+  await stage;
+  expect(outcome).toEqual(["ChatGPT browser stage timed out: probe"]);
+}, 10_000);

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -1089,6 +1089,7 @@ test("Luna-only browser turns verify selector absence instead of opening an effo
   const visibleControls = { count: async () => 0 };
   const composerForm = {
     locator: () => ({ filter: () => visibleControls }),
+    getByRole: () => ({ filter: () => ({ count: async () => 0 }) }),
   };
   const composer = { locator: () => composerForm };
   const selectModelAndEffort = (ChatGptBrowserWorker.prototype as unknown as {

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -2549,3 +2549,20 @@ test("Bigger Context stage sends get a budget sized for their payload", () => {
   // The ordinary send budget is unchanged for ordinary prompts.
   expect(worker).toContain("send: 20_000,");
 });
+
+test("a staged Bigger Context part gets an acknowledgement window sized to its payload", () => {
+  // A staged part is two orders of magnitude larger than an ordinary prompt and ChatGPT reads all of
+  // it before answering. On this machine the same payload acknowledged at 19s and at 30s, and once
+  // took over 72s — which the ordinary grace turned into "ChatGPT accepted the message but did not
+  // expose its assistant turn in the DOM", losing an accepted turn that was merely slow.
+  expect(CHATGPT_MULTIPART_RESPONSE_DOM_GRACE_MS).toBeGreaterThan(CHATGPT_RESPONSE_DOM_GRACE_MS);
+
+  // No MCP activity exists yet while a part is being ingested, so nothing else can vouch for the
+  // turn: this window is the only thing between a slow ingest and a cancellation. Keep a wide margin
+  // over the slowest acknowledgement actually observed.
+  const slowestObservedAcknowledgementMs = 72_000;
+  expect(CHATGPT_MULTIPART_RESPONSE_DOM_GRACE_MS).toBeGreaterThan(slowestObservedAcknowledgementMs * 2);
+
+  // It is the same budget the staged send already gets; the two bound the same oversized exchange.
+  expect(CHATGPT_MULTIPART_RESPONSE_DOM_GRACE_MS).toBe(browserStageTimeouts.multipartStageSend);
+});

--- a/tests/chatgpt-web-harness.test.ts
+++ b/tests/chatgpt-web-harness.test.ts
@@ -11,7 +11,7 @@ import { ChatGptCompletionTracker, chatGptImageFilePayloads, chatGptPromptFilePa
 import { ChatGptBrowserWorker, type BrowserTurn } from "../src/adapters/chatgpt-web/browser-worker";
 import { chatGptConversationKey } from "../src/adapters/chatgpt-web/conversation-key";
 import { CHATGPT_TURN_REVISION_CONFLICT_MESSAGE, extractChatGptTurnEnvironment, extractChatGptTurnIdentity, extractChatGptTurnUserRevision } from "../src/adapters/chatgpt-web/environment";
-import { chatGptWebExecutionNamespace, chatGptWebTraceId, createChatGptWebAdapter } from "../src/adapters/chatgpt-web/index";
+import { CHATGPT_WEB_ADAPTER_HEARTBEAT_MS, chatGptWebExecutionNamespace, chatGptWebTraceId, createChatGptWebAdapter } from "../src/adapters/chatgpt-web/index";
 import { chatGptHtmlToMarkdown, ChatGptMarkdownBuffer } from "../src/adapters/chatgpt-web/markdown";
 import { CHATGPT_WEB_MODEL_ID } from "../src/adapters/chatgpt-web/model";
 import {
@@ -2909,4 +2909,117 @@ test("an interrupted turn's abort notice is not mistaken for the next turn's ins
   });
   expect(() => extractChatGptTurnUserRevision(steered))
     .toThrow(CHATGPT_TURN_REVISION_CONFLICT_MESSAGE);
+});
+
+describe("adapter liveness covers every path through a turn", () => {
+  // The Responses bridge cancels a turn after DEFAULT_STALL_TIMEOUT_SEC without a single adapter
+  // event (bridge.ts, `upstream_stall_timeout`). Any window inside runTurn that awaits without
+  // emitting is therefore a turn the user loses, and the waits that run before a session exists
+  // — the structured compaction handoff and the owner-retirement wait — used to be exactly that.
+  function livenessRequest(turnId: string, threadId: string, compaction: boolean): CodexParsedRequest {
+    const request = parsed();
+    if (compaction) request._compactionRequest = true;
+    request._rawBody = {
+      prompt_cache_key: threadId,
+      client_metadata: { "x-codex-turn-metadata": JSON.stringify({ thread_id: threadId, turn_id: turnId }) },
+      input: [
+        {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: environmentXml }],
+          internal_chat_message_metadata_passthrough: { turn_id: turnId },
+        },
+        {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "Inspect the project" }],
+          internal_chat_message_metadata_passthrough: { turn_id: turnId },
+        },
+      ],
+    };
+    return request;
+  }
+
+  async function observeLiveness(
+    label: string,
+    observeMs: number,
+    drive: (
+      provider: CodexProviderConfig,
+      run: (request: CodexParsedRequest, emit: (event: AdapterEvent) => void, signal: AbortSignal) => Promise<void>,
+    ) => Promise<{ heartbeats: number[]; stop: () => void }>,
+  ): Promise<number[]> {
+    const provider: CodexProviderConfig = {
+      adapter: "chatgpt-web",
+      baseUrl: `browser://liveness-${label}-${Date.now()}`,
+      chatgptWeb: { localToolsEnabled: false, solAvailable: true, proAvailable: true },
+    };
+    const worker = ChatGptBrowserWorker.forProvider(provider);
+    const originalRun = worker.run.bind(worker);
+    (worker as unknown as { run: (turn: BrowserTurn) => Promise<string> }).run = () => new Promise<string>(() => {});
+    try {
+      const run = async (
+        request: CodexParsedRequest,
+        emit: (event: AdapterEvent) => void,
+        signal: AbortSignal,
+      ) => {
+        await createChatGptWebAdapter(provider).runTurn!(request, { headers: new Headers(), abortSignal: signal }, emit);
+      };
+      const { heartbeats, stop } = await drive(provider, run);
+      await Bun.sleep(observeMs);
+      stop();
+      return heartbeats;
+    } finally {
+      (worker as unknown as { run: (turn: BrowserTurn) => Promise<string> }).run = originalRun;
+    }
+  }
+
+  test("a turn blocked waiting for the previous owner to retire still proves it is alive", async () => {
+    const started = Date.now();
+    const heartbeats = await observeLiveness(
+      "owner-retirement",
+      CHATGPT_WEB_ADAPTER_HEARTBEAT_MS + 2_000,
+      async (_provider, run) => {
+        const holder = new AbortController();
+        const blocked = new AbortController();
+        const beats: number[] = [];
+        // The first turn owns the thread and never physically settles, so the second turn parks in
+        // getOrCreateAfterOwnerRetirement before any session — and before any per-session wiring —
+        // exists to speak for it.
+        void run(livenessRequest("turn_live_1", "thread_live", false), () => {}, holder.signal).catch(() => {});
+        await Bun.sleep(250);
+        void run(
+          livenessRequest("turn_live_2", "thread_live", false),
+          event => { if (event.type === "heartbeat") beats.push(Date.now() - started); },
+          blocked.signal,
+        ).catch(() => {});
+        return { heartbeats: beats, stop: () => { blocked.abort(); holder.abort(); } };
+      },
+    );
+
+    expect(heartbeats.length).toBeGreaterThanOrEqual(2);
+    // One on entry, before the wait is even reached, then the armed interval.
+    expect(heartbeats[0]).toBeLessThan(2_000);
+    expect(heartbeats.at(-1)).toBeGreaterThanOrEqual(CHATGPT_WEB_ADAPTER_HEARTBEAT_MS);
+  }, 40_000);
+
+  test("a compaction turn proves it is alive while the summarizing browser turn runs", async () => {
+    const started = Date.now();
+    const heartbeats = await observeLiveness(
+      "compaction",
+      CHATGPT_WEB_ADAPTER_HEARTBEAT_MS + 2_000,
+      async (_provider, run) => {
+        const abort = new AbortController();
+        const beats: number[] = [];
+        void run(
+          livenessRequest("turn_compact_1", "thread_compact", true),
+          event => { if (event.type === "heartbeat") beats.push(Date.now() - started); },
+          abort.signal,
+        ).catch(() => {});
+        return { heartbeats: beats, stop: () => abort.abort() };
+      },
+    );
+
+    expect(heartbeats.length).toBeGreaterThanOrEqual(2);
+    expect(heartbeats.at(-1)).toBeGreaterThanOrEqual(CHATGPT_WEB_ADAPTER_HEARTBEAT_MS);
+  }, 40_000);
 });

--- a/tests/chatgpt-web-harness.test.ts
+++ b/tests/chatgpt-web-harness.test.ts
@@ -10,7 +10,7 @@ import { ChatGptWebAdapterError } from "../src/adapters/chatgpt-web/adapter-erro
 import { ChatGptCompletionTracker, chatGptImageFilePayloads, chatGptPromptFilePayloads, chatGptTurnIsComplete } from "../src/adapters/chatgpt-web/browser-worker";
 import { ChatGptBrowserWorker, type BrowserTurn } from "../src/adapters/chatgpt-web/browser-worker";
 import { chatGptConversationKey } from "../src/adapters/chatgpt-web/conversation-key";
-import { extractChatGptTurnEnvironment, extractChatGptTurnIdentity } from "../src/adapters/chatgpt-web/environment";
+import { CHATGPT_TURN_REVISION_CONFLICT_MESSAGE, extractChatGptTurnEnvironment, extractChatGptTurnIdentity, extractChatGptTurnUserRevision } from "../src/adapters/chatgpt-web/environment";
 import { chatGptWebExecutionNamespace, chatGptWebTraceId, createChatGptWebAdapter } from "../src/adapters/chatgpt-web/index";
 import { chatGptHtmlToMarkdown, ChatGptMarkdownBuffer } from "../src/adapters/chatgpt-web/markdown";
 import { CHATGPT_WEB_MODEL_ID } from "../src/adapters/chatgpt-web/model";
@@ -2877,4 +2877,36 @@ test("mirrored progress rejects frames that regress against the observed state",
   expect(mirror.snapshot()).toEqual({
     revision: 3, lastToolBatchRevision: 3, activeToolCalls: 1, lastProgressAt: 5_000,
   });
+});
+
+test("an interrupted turn's abort notice is not mistaken for the next turn's instruction", () => {
+  // Reproduces a real failure: the user stopped a turn, Codex appended <turn_aborted> carrying the
+  // interrupted turn's id, and the next turn read that notice as its own user revision. The ids
+  // disagreed and every following turn failed with a turn_id conflict.
+  const request = rawWireRequest(environmentXml);
+  const abortedNotice = "<turn_aborted>\nThe user interrupted the previous turn on purpose."
+    + " Any running unified exec processes may still be running in the background."
+    + "\n</turn_aborted>";
+  ((request._rawBody as { input: unknown[] }).input).push({
+    type: "message",
+    role: "user",
+    content: [{ type: "input_text", text: abortedNotice }],
+    internal_chat_message_metadata_passthrough: { turn_id: "turn_test_interrupted" },
+  });
+
+  // The instruction actually owned by this turn is still the human one that precedes the notice.
+  expect(extractChatGptTurnUserRevision(request)).toEqual([
+    { type: "input_text", text: "Inspect the project" },
+  ]);
+
+  // A genuine steering message from a foreign turn must still be rejected.
+  const steered = structuredClone(request);
+  ((steered._rawBody as { input: unknown[] }).input).push({
+    type: "message",
+    role: "user",
+    content: [{ type: "input_text", text: "Actually, stop and summarise instead" }],
+    internal_chat_message_metadata_passthrough: { turn_id: "turn_test_other" },
+  });
+  expect(() => extractChatGptTurnUserRevision(steered))
+    .toThrow(CHATGPT_TURN_REVISION_CONFLICT_MESSAGE);
 });

--- a/tests/chatgpt-web-harness.test.ts
+++ b/tests/chatgpt-web-harness.test.ts
@@ -1227,6 +1227,30 @@ describe("ChatGPT outer-native harness v4", () => {
     sessions.clear();
   });
 
+  test("retained compaction retirement remains abortable for a disconnected observer", async () => {
+    const sessions = new ChatGptTurnSessions();
+    let finishBrowser!: () => void;
+    const browser = new Promise<string>(resolveBrowser => { finishBrowser = () => resolveBrowser("stopped"); });
+    sessions.getOrCreate("abort-retirement", () => ({
+      mode: "read-only",
+      browser,
+      physicalSettlement: browser.then(() => undefined),
+      trace: new ChatGptTraceFeed(),
+      text: new ChatGptTextFeed(),
+      cancel: () => {},
+    }));
+
+    const retirement = sessions.retireAndWait("abort-retirement");
+    const observerAbort = new AbortController();
+    const observer = sessions.retireAndWait("abort-retirement", observerAbort.signal);
+    observerAbort.abort();
+    await expect(observer).rejects.toMatchObject({ name: "AbortError" });
+
+    finishBrowser();
+    await expect(retirement).resolves.toBeTrue();
+    sessions.clear();
+  });
+
   test("keeps inline images out of the context JSON and prepares native browser attachments", () => {
     const imageUrl = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAE0lEQVR4nGP4z8DwHwwZGP6DAQBJyAn3FGMynQAAAABJRU5ErkJggg==";
     const request = parsed();
@@ -2911,6 +2935,21 @@ test("an interrupted turn's abort notice is not mistaken for the next turn's ins
     .toThrow(CHATGPT_TURN_REVISION_CONFLICT_MESSAGE);
 });
 
+test("a literal turn-aborted instruction with the current turn id remains user input", () => {
+  const request = rawWireRequest(environmentXml);
+  const literal = "<turn_aborted>please explain what this tag means</turn_aborted>";
+  ((request._rawBody as { input: unknown[] }).input).push({
+    type: "message",
+    role: "user",
+    content: [{ type: "input_text", text: literal }],
+    internal_chat_message_metadata_passthrough: { turn_id: "turn_test_123" },
+  });
+
+  expect(extractChatGptTurnUserRevision(request)).toEqual([
+    { type: "input_text", text: literal },
+  ]);
+});
+
 describe("adapter liveness covers every path through a turn", () => {
   // The Responses bridge cancels a turn after DEFAULT_STALL_TIMEOUT_SEC without a single adapter
   // event (bridge.ts, `upstream_stall_timeout`). Any window inside runTurn that awaits without
@@ -3001,6 +3040,53 @@ describe("adapter liveness covers every path through a turn", () => {
     expect(heartbeats[0]).toBeLessThan(2_000);
     expect(heartbeats.at(-1)).toBeGreaterThanOrEqual(CHATGPT_WEB_ADAPTER_HEARTBEAT_MS);
   }, 40_000);
+
+  test("aborting while waiting for a previous owner settles the observer promptly", async () => {
+    const provider: CodexProviderConfig = {
+      adapter: "chatgpt-web",
+      baseUrl: `browser://abort-owner-${Date.now()}`,
+      chatgptWeb: { localToolsEnabled: false, solAvailable: true, proAvailable: true },
+    };
+    const worker = ChatGptBrowserWorker.forProvider(provider);
+    const originalRun = worker.run.bind(worker);
+    const releases: Array<() => void> = [];
+    (worker as unknown as { run: (turn: BrowserTurn) => Promise<string> }).run = turn => new Promise<string>(resolve => {
+      releases.push(() => {
+        turn.onTextDelta("owner completed");
+        resolve("owner completed");
+      });
+    });
+    try {
+      const adapter = createChatGptWebAdapter(provider);
+      const ownerAbort = new AbortController();
+      const owner = adapter.runTurn!(
+        livenessRequest("turn_abort_owner", "thread_abort_owner", false),
+        { headers: new Headers(), abortSignal: ownerAbort.signal },
+        () => {},
+      ).catch(() => {});
+      await Bun.sleep(100);
+
+      const observerAbort = new AbortController();
+      const observer = adapter.runTurn!(
+        livenessRequest("turn_abort_observer", "thread_abort_owner", false),
+        { headers: new Headers(), abortSignal: observerAbort.signal },
+        () => {},
+      );
+      observerAbort.abort();
+      await expect(Promise.race([
+        observer,
+        Bun.sleep(500).then(() => { throw new Error("observer remained blocked after abort"); }),
+      ])).rejects.toMatchObject({ name: "AbortError" });
+
+      const ownerReleaseCount = releases.length;
+      for (const release of releases) release();
+      await owner;
+      await Bun.sleep(50);
+      expect(releases.length).toBe(ownerReleaseCount);
+    } finally {
+      (worker as unknown as { run: (turn: BrowserTurn) => Promise<string> }).run = originalRun;
+    }
+  }, 10_000);
 
   test("a compaction turn proves it is alive while the summarizing browser turn runs", async () => {
     const started = Date.now();

--- a/tests/composer-insert.test.ts
+++ b/tests/composer-insert.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, expect, test } from "bun:test";
+import { insertPlainTextIntoComposer } from "../src/adapters/chatgpt-web/browser-worker";
+
+/**
+ * The composer insert runs inside the page, where the caret state is whatever the last UI
+ * interaction left behind. Effort selection closes a menu immediately before a staged part is
+ * attached, so these fixtures model the focus and selection states that actually occur there.
+ */
+interface FakeSelection {
+  isCollapsed: boolean;
+  anchorNode: object | null;
+  removeAllRanges(): void;
+  addRange(range: object): void;
+}
+
+const originals = { document: globalThis.document, window: globalThis.window };
+afterEach(() => {
+  (globalThis as Record<string, unknown>).document = originals.document;
+  (globalThis as Record<string, unknown>).window = originals.window;
+});
+
+function harness(options: {
+  focusable: boolean;
+  caretInsideComposer: boolean;
+  collapsed?: boolean;
+  execCommandResult?: boolean;
+}) {
+  const inside = { name: "text-node-inside-composer" };
+  const composer = {
+    focus() { if (options.focusable) fakeDocument.activeElement = composer; },
+    contains: (node: object | null) => node === inside || node === composer,
+  };
+  const calls: Array<{ command: string; value: string }> = [];
+  const selection: FakeSelection = {
+    isCollapsed: options.collapsed ?? true,
+    anchorNode: options.caretInsideComposer ? inside : { name: "node-in-the-effort-menu" },
+    removeAllRanges() { selection.anchorNode = null; },
+    addRange() { selection.anchorNode = inside; selection.isCollapsed = true; },
+  };
+  const fakeDocument = {
+    activeElement: null as unknown,
+    createRange: () => ({ selectNodeContents() {}, collapse() {} }),
+    execCommand(command: string, _ui: boolean, value: string) {
+      calls.push({ command, value });
+      return options.execCommandResult ?? true;
+    },
+  };
+  (globalThis as Record<string, unknown>).document = fakeDocument;
+  (globalThis as Record<string, unknown>).window = { getSelection: () => selection };
+  return { composer: composer as unknown as HTMLElement, calls, selection, fakeDocument };
+}
+
+test("places the caret itself when focus has not yet produced one in the composer", () => {
+  // The exact state left behind a tenth of a second after the effort menu closes.
+  const { composer, calls, selection } = harness({ focusable: true, caretInsideComposer: false });
+
+  expect(insertPlainTextIntoComposer(composer, "staged part")).toBeTrue();
+  expect(calls).toEqual([{ command: "insertText", value: "staged part" }]);
+  expect(selection.isCollapsed).toBeTrue();
+});
+
+test("leaves an existing caret inside the composer exactly where it is", () => {
+  const { composer, calls, selection } = harness({ focusable: true, caretInsideComposer: true });
+  const anchorBefore = selection.anchorNode;
+
+  expect(insertPlainTextIntoComposer(composer, "second part")).toBeTrue();
+  expect(selection.anchorNode).toBe(anchorBefore);
+  expect(calls).toEqual([{ command: "insertText", value: "second part" }]);
+});
+
+test("refuses to insert when the composer cannot take focus at all", () => {
+  // A covered or detached composer must still fail rather than have text typed somewhere else.
+  const { composer, calls } = harness({ focusable: false, caretInsideComposer: false });
+
+  expect(insertPlainTextIntoComposer(composer, "staged part")).toBeFalse();
+  expect(calls).toEqual([]);
+});
+
+test("reports a genuinely rejected edit as a failure", () => {
+  const { composer } = harness({
+    focusable: true,
+    caretInsideComposer: true,
+    execCommandResult: false,
+  });
+
+  expect(insertPlainTextIntoComposer(composer, "staged part")).toBeFalse();
+});

--- a/tests/native-passthrough.test.ts
+++ b/tests/native-passthrough.test.ts
@@ -296,6 +296,20 @@ test("an upstream reset after the turn completed closes the client stream normal
   expect(body).toEndWith("data: [DONE]\n\n");
 });
 
+test("an upstream reset is not hidden by a [DONE] string inside JSON content", async () => {
+  const response = await forwardNativeCodexRequest(
+    nativeRequest(),
+    "responses",
+    async () => resettingEventStream([
+      'event: response.output_text.delta\ndata: {"delta":"literal data: [DONE] text"}\n\n',
+    ]),
+  );
+
+  // The marker is part of the JSON string, not an SSE data line. The upstream reset therefore
+  // truncated the turn and must remain visible to the native client.
+  await expect(response.text()).rejects.toThrow();
+});
+
 test("an upstream reset that truncated the turn is still surfaced as a failure", async () => {
   const response = await forwardNativeCodexRequest(
     nativeRequest(),

--- a/tests/native-passthrough.test.ts
+++ b/tests/native-passthrough.test.ts
@@ -253,3 +253,65 @@ test("does not invent a models client version from an unrelated user agent", asy
   });
   expect(upstreamRequest!.url).toBe("https://chatgpt.com/backend-api/codex/models");
 });
+
+/** A reset after `data: [DONE]` is a completed stream, while a reset before it is a truncation. */
+function nativeRequest(): Request {
+  return new Request("http://127.0.0.1:17841/v1/responses", {
+    method: "POST",
+    headers: { authorization: "Bearer codex-oauth-token", "content-type": "application/json" },
+    body: '{"model":"gpt-5.6-sol","stream":true}',
+  });
+}
+
+function resettingEventStream(prefix: string[]): Response {
+  const encoder = new TextEncoder();
+  let sent = 0;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (sent < prefix.length) {
+        controller.enqueue(encoder.encode(prefix[sent]!));
+        sent += 1;
+        return;
+      }
+      const reset = new Error("The socket connection was closed unexpectedly");
+      (reset as Error & { code?: string }).code = "ECONNRESET";
+      controller.error(reset);
+    },
+  });
+  return new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } });
+}
+
+test("an upstream reset after the turn completed closes the client stream normally", async () => {
+  const response = await forwardNativeCodexRequest(
+    nativeRequest(),
+    "responses",
+    async () => resettingEventStream([
+      'event: response.completed\ndata: {"type":"response.completed"}\n\n',
+      "data: [DONE]\n\n",
+    ]),
+  );
+
+  const body = await response.text();
+  expect(body).toContain("response.completed");
+  expect(body).toEndWith("data: [DONE]\n\n");
+});
+
+test("an upstream reset that truncated the turn is still surfaced as a failure", async () => {
+  const response = await forwardNativeCodexRequest(
+    nativeRequest(),
+    "responses",
+    async () => resettingEventStream(['event: response.output_text.delta\ndata: {"delta":"half"}\n\n']),
+  );
+
+  await expect(response.text()).rejects.toThrow();
+});
+
+test("a non-event-stream body is passed through untouched", async () => {
+  const response = await forwardNativeCodexRequest(
+    nativeRequest(),
+    "responses",
+    async () => new Response('{"ok":true}', { status: 200, headers: { "content-type": "application/json" } }),
+  );
+
+  expect(await response.text()).toBe('{"ok":true}');
+});

--- a/tests/retained-compaction.test.ts
+++ b/tests/retained-compaction.test.ts
@@ -41,6 +41,16 @@ import {
 } from "../src/adapters/chatgpt-web/native-compaction-control";
 import type { AdapterEvent, CodexParsedRequest, CodexProviderConfig } from "../src/types";
 
+/**
+ * These fixtures hand the turn broker a Unix socket under their temp root. macOS puts TMPDIR at
+ * /var/folders/<32 chars>/T, which pushes `<root>/runtime/turn-broker.sock` past the 104-byte
+ * sun_path limit, and listen() then fails with nothing but "Failed to listen". Root them somewhere
+ * short so the socket is bindable.
+ */
+function shortSocketTempRoot(): string {
+  return process.platform === "win32" ? tmpdir() : "/tmp";
+}
+
 function request(compaction = false): CodexParsedRequest {
   return {
     modelId: "gpt-5.6-sol",
@@ -153,7 +163,7 @@ test("retained compaction provides one exact same-agent control binding", () => 
 });
 
 test("a compaction control token cannot claim the ordinary Codex tool environment", async () => {
-  const root = mkdtempSync(join(tmpdir(), "cgw-compaction-capability-"));
+  const root = mkdtempSync(join(shortSocketTempRoot(), "cgw-compaction-capability-"));
   const broker = TurnBroker.forSocket(defaultBrokerEndpoint(root));
   try {
     const transaction = await broker.beginCompactionTransaction("trace_capability", 1_000);
@@ -175,7 +185,7 @@ test("a compaction control token cannot claim the ordinary Codex tool environmen
 });
 
 test("active compaction delivers the current result and converts every later MCP call into the checkpoint request", async () => {
-  const root = mkdtempSync(join(tmpdir(), "cgw-active-compaction-gate-"));
+  const root = mkdtempSync(join(shortSocketTempRoot(), "cgw-active-compaction-gate-"));
   const broker = TurnBroker.forSocket(defaultBrokerEndpoint(root));
   try {
     const token = await broker.register({
@@ -228,7 +238,7 @@ test("active compaction delivers the current result and converts every later MCP
 });
 
 test("active compaction drains an MCP call already queued without an outer Codex waiter", async () => {
-  const root = mkdtempSync(join(tmpdir(), "cgw-queued-before-compaction-"));
+  const root = mkdtempSync(join(shortSocketTempRoot(), "cgw-queued-before-compaction-"));
   const broker = TurnBroker.forSocket(defaultBrokerEndpoint(root));
   try {
     const token = await broker.register({
@@ -407,7 +417,7 @@ test("active compaction turns the final canonical tool result into the same-resp
 });
 
 test("active compaction interrupts a queued MCP call that Codex never started waiting for", async () => {
-  const root = mkdtempSync(join(tmpdir(), "cgw-compaction-queued-call-"));
+  const root = mkdtempSync(join(shortSocketTempRoot(), "cgw-compaction-queued-call-"));
   const broker = TurnBroker.forSocket(defaultBrokerEndpoint(root));
   try {
     const token = await broker.register({
@@ -562,7 +572,7 @@ test("retained conversation release waits for physical settlement", async () => 
 });
 
 test("adapter compact returns only the same-agent MCP handoff and retires the old epoch", async () => {
-  const root = mkdtempSync(join(tmpdir(), "cgw-adapter-retained-compact-"));
+  const root = mkdtempSync(join(shortSocketTempRoot(), "cgw-adapter-retained-compact-"));
   const provider: CodexProviderConfig = {
     adapter: "chatgpt-web",
     baseUrl: `browser://retained-compact-${Date.now()}`,
@@ -653,7 +663,7 @@ test("adapter compact returns only the same-agent MCP handoff and retires the ol
 });
 
 test("a compact HTTP observer can reconnect without sending a second retained-chat message", async () => {
-  const root = mkdtempSync(join(tmpdir(), "cgw-compact-reconnect-"));
+  const root = mkdtempSync(join(shortSocketTempRoot(), "cgw-compact-reconnect-"));
   const provider: CodexProviderConfig = {
     adapter: "chatgpt-web",
     baseUrl: `browser://compact-reconnect-${Date.now()}`,
@@ -750,7 +760,7 @@ test("a compact HTTP observer can reconnect without sending a second retained-ch
 });
 
 test("structured compact rebuilds canonical context when its retained source is absent", async () => {
-  const root = mkdtempSync(join(tmpdir(), "cgw-missing-retained-compact-"));
+  const root = mkdtempSync(join(shortSocketTempRoot(), "cgw-missing-retained-compact-"));
   const provider: CodexProviderConfig = {
     adapter: "chatgpt-web",
     baseUrl: `browser://missing-retained-${Date.now()}`,
@@ -799,7 +809,7 @@ test("structured compact rebuilds canonical context when its retained source is 
 });
 
 test("structured compact rebuilds canonical context when its retained browser disappeared", async () => {
-  const root = mkdtempSync(join(tmpdir(), "cgw-stale-retained-compact-"));
+  const root = mkdtempSync(join(shortSocketTempRoot(), "cgw-stale-retained-compact-"));
   const provider: CodexProviderConfig = {
     adapter: "chatgpt-web",
     baseUrl: `browser://stale-retained-${Date.now()}`,

--- a/tests/turn-broker-lifecycle.test.ts
+++ b/tests/turn-broker-lifecycle.test.ts
@@ -167,6 +167,18 @@ test("turn broker creates its private runtime directory on a cold start", async 
   }
 });
 
+test("turn broker rejects a Unix socket path that leaves no room for sun_path's NUL terminator", async () => {
+  if (process.platform === "win32") return;
+  const socketPath = `/tmp/${"x".repeat(99)}`;
+  expect(Buffer.byteLength(socketPath)).toBe(104);
+  const broker = TurnBroker.forSocket(socketPath);
+  try {
+    await expect(broker.listen()).rejects.toThrow("103-byte limit");
+  } finally {
+    await broker.close();
+  }
+});
+
 test("turn broker tokens do not expire while their browser turn is still alive", async () => {
   const root = mkdtempSync(join(tmpdir(), "cgw-broker-unbounded-"));
   const socketPath = defaultBrokerEndpoint(root);


### PR DESCRIPTION
Split of #222, part 2 of 2, per review. Based on current `main`.

Operational follow-ups only: Bigger Context timing, bridge watchdog diagnostics and config, post-`[DONE]` reset handling, composer focus, macOS sleep/lease handling, and platform-test cleanup. The #221 liveness path is #232.

The automatic re-staging after "Stopped thinking" is **not** in this PR. As requested, that condition remains an explicit failure until the cause is established.

## Turns cancelled while healthy

The bridge cancels any turn whose adapter emits no event for `DEFAULT_STALL_TIMEOUT_SEC`, reporting `upstream_stall_timeout`. The chatgpt-web adapter's only periodic keep-alive was armed part-way through `runTurn`, after several unbounded awaits, so every path reaching those awaits was invisible to the watchdog. Two are reachable in ordinary use, both measured against the real adapter:

- A turn parked in `getOrCreateAfterOwnerRetirement`, waiting for the previous owner of its thread to physically settle, emitted nothing at all for 25 seconds.
- A structured compaction turn returns before the interval is ever armed, so a whole summarizing browser turn runs behind a single one-shot heartbeat.

Both exceed five minutes routinely on Pro. `runTurn`'s body moved to `runChatGptWebTurn`; `runTurn` now arms the heartbeat as its first act and clears it in a `finally`. The body cannot reach the timer, so no future path can quietly become a silent one. Read with `git diff -w` the change is 34 lines — the rest of that file's churn is dedent.

The cancellation also wrote nothing to any log, which is why the two windows had to be found by reading source rather than evidence. It now records the last adapter event, its age, the event count and the stream position, and warns at half the budget so a keep-alive gap surfaces before it costs a turn. `stallTimeoutSec` was declared on the bridge options and read when resolving the budget but never passed by any caller; it is now reachable from provider config.

## An upstream reset after the turn had already finished

ChatGPT's backend resets the native Codex connection rather than closing it. Forwarded verbatim that reached Codex as a truncated body and the opaque `Transport error: network error: error decoding response body`. On this machine it lands at a byte-identical offset across independent turns — 111876 bytes, on chunk counts from 10 to 53 — which is a deterministic upstream close, not a flaky network.

A reset arriving after the stream has already delivered `data: [DONE]` is an unclean TCP close on a turn that completed, so the client stream is now closed normally. A reset before that genuinely truncated the turn and is still raised: fabricating a terminal event there would tell Codex a turn ended when it did not, turning a retryable transport failure into a silently short answer.

## A composer insert that raced ChatGPT's focus

Attaching a staged part failed with `ChatGPT composer rejected the plain-text editing command` 84ms after effort selection closed its menu. Nothing had rejected anything — the guard required the caret to already sit inside the composer, and that soon after a menu closes it often does not. The caret is now placed explicitly; an existing collapsed caret inside the composer is left where it is, so sequential staged parts still append correctly, and only a missing or foreign one is replaced. The page-side logic moved to `insertPlainTextIntoComposer` so it can be tested against the focus and selection states the effort menu actually leaves behind.

## Staged sends sized for their payload

Staged parts reused the ordinary 20s send budget, but a part is two orders of magnitude larger than a normal prompt and ChatGPT's composer takes proportionally longer to accept it. Observed stage-2 sends timed out at exactly 20001ms and 20002ms — the budget, not the site. Staged sends and the multipart commit now use `multipartStageSend: 180_000`; single-part turns keep the 20s budget.

Separately, a staged part was sent, ChatGPT accepted it, and 72 seconds later the turn died with `ChatGPT accepted the message but did not expose its assistant turn in the DOM`. The same payload acknowledged at 19s on one attempt and 30s on the next, so the ordinary 60s DOM grace is not a budget staging can be held to. Staged parts now get the same budget as the staged send, which bounds the other half of the same oversized exchange. Ordinary turns keep the 60s grace unchanged.

## System sleep no longer costs turns

`pmset` matched a whole failure cluster to the second: the Mac entered Idle Sleep 41 seconds after two turns started, and on each DarkWake both died at once — `effort_selection` "timed out" at 901s of a 120s budget, both tabs reaped as `orphan_turn_reaped`, heartbeats rejected with `was already released`, and the retries then failing on pages the reaper had closed. Sleep freezes both sides of the lease protocol together, so the launcher's first sweep after a wake saw fifteen-minute-stale heartbeats and read them as a dead helper.

Three layers, in order of preference. The launcher holds a prevent-app-suspension power blocker exactly while a browser turn is running, so an idle Mac no longer sleeps mid-turn at all (verified live: `pmset -g assertions` shows the Electron assertion up during a turn and the release logged the moment it ends). When sleep happens anyway, the wake side stops punishing it: the lease sweep knows its own cadence, treats a gap of many multiples of it as its own suspension, and re-baselines every running lease instead of reaping — a helper that is genuinely gone still dies on the ordinary sixty-second cadence. And stage budgets stop charging for slept time: a suspension clock watches for tick gaps, and a stage timer that fires with slept time on the books re-arms for what the stage is still owed awake.

## An abort notice is context, not the next instruction

Interrupting a turn makes Codex send `<turn_aborted>…</turn_aborted>` as the following user message. `contextualUserMessage` did not recognise it, so it was staged as a fresh prompt carrying the aborted turn's `turn_id`, and every later turn in the thread failed with `ChatGPT web current user message conflicts with native Codex turn_id metadata`. One interrupt poisoned the whole session. The notice is now classified as context like the other Codex-generated wrappers.

This surface was named in review but not assigned to either half of the split. It is here because it is not on the #221 liveness path; say the word and it moves to #232.

## Platform-test cleanup

Seven tests failed on every macOS checkout, including `main`, which is enough noise to hide a regression. Six were the retained-compaction fixtures: they bind the turn broker to a Unix socket under `TMPDIR`, and macOS puts that at `/var/folders/<32 chars>/T`, so the socket path came to 106 bytes against a 104-byte `sun_path` limit and `listen()` failed with nothing but "Failed to listen". The fixtures root themselves somewhere short, and the broker now rejects an over-long path with a message naming the length and the limit — the same wall a real install with a long runtime directory would hit. The seventh is Linux-only and already declared `skip`, which Bun's `node:test` shim ignores; it returns early instead.

## Testing

`bun run typecheck` clean. `bun test`: **659 pass, 0 fail** across 55 files.

## Caveat

The 180s staged-send budget is sized from observed sends of ~42s with headroom; a pathologically slow upload would still time out, now after three minutes instead of twenty seconds.
