### PR TITLE
perf: deduplicate retained system prompts safely

### DIFF
--- a/launcher/electron/browser-host.cjs
+++ b/launcher/electron/browser-host.cjs
@@ -345,6 +345,8 @@ class BrowserHost {
       conversationKey,
       connectorIdentity,
       connectorBound: false,
+      retainedUrl: null,
+      retainedNavigationInvalidated: false,
       helperPid,
       view,
       status: "running",
@@ -388,6 +390,15 @@ class BrowserHost {
     return true;
   }
 
+  retainedConversationIsCurrent(tab) {
+    const contents = tab.view?.webContents;
+    if (!contents || contents.isDestroyed()) return false;
+    return tab.status === "ready"
+      && tab.retainedNavigationInvalidated !== true
+      && typeof tab.retainedUrl === "string"
+      && contents.getURL() === tab.retainedUrl;
+  }
+
   zoomShell(action) {
     const contents = this.window.webContents;
     if (!contents || contents.isDestroyed()) throw new Error("Launcher shell is unavailable for zoom");
@@ -423,6 +434,15 @@ class BrowserHost {
 
   bindTurnContents(tab) {
     const contents = tab.view.webContents;
+    const invalidateRetainedConversation = (evidence) => {
+      if (tab.status !== "ready" || tab.retainedNavigationInvalidated === true) return;
+      tab.retainedNavigationInvalidated = true;
+      this.logger.info("browser.retained_conversation_invalidated", {
+        tabId: tab.id,
+        traceId: tab.traceId,
+        evidence,
+      });
+    };
     contents.setWindowOpenHandler(({ url }) => {
       if (allowedAuthUrl(url)) {
         this.logger.warn("browser.turn_authentication_blocked", { tabId: tab.id, traceId: tab.traceId });
@@ -444,6 +464,7 @@ class BrowserHost {
     contents.on("will-redirect", blockAuthenticationNavigation);
     contents.on("did-start-navigation", (_event, url, inPlace, mainFrame) => {
       if (!mainFrame) return;
+      invalidateRetainedConversation("main-frame navigation");
       tab.url = url;
       tab.loading = true;
       if (!inPlace) {
@@ -488,7 +509,10 @@ class BrowserHost {
       this.publishState?.(this.snapshot());
     });
     contents.on("did-navigate-in-page", (_event, url, mainFrame) => {
-      if (mainFrame) tab.url = url;
+      if (mainFrame) {
+        invalidateRetainedConversation("in-page navigation");
+        tab.url = url;
+      }
       this.publishState?.(this.snapshot());
     });
     contents.on("did-fail-load", (_event, errorCode, errorDescription, url, mainFrame) => {
@@ -1281,7 +1305,7 @@ class BrowserHost {
       throw new Error(`ChatGPT browser turn ${traceId} conversation metadata does not match its owned tab`);
     }
     const retainedMatches = conversationKey ? [...this.turnTabs.values()].filter((tab) => (
-      tab.status === "ready"
+      this.retainedConversationIsCurrent(tab)
       && tab.conversationKey === conversationKey
       && tab.connectorIdentity === connectorIdentity
       && (!connectorIdentity || tab.connectorBound === true)
@@ -1383,8 +1407,11 @@ class BrowserHost {
     if (status === "completed"
       && retain
       && tab.conversationKey
-      && (!tab.connectorIdentity || connectorBound)) {
+      && (!tab.connectorIdentity || connectorBound)
+      && !tab.view.webContents.isDestroyed()) {
       tab.connectorBound = connectorBound === true;
+      tab.retainedUrl = tab.view.webContents.getURL();
+      tab.retainedNavigationInvalidated = false;
       tab.lastHeartbeatAt = Date.now();
       if (hideAfterTurn && !this.activeTraceId) this.hide();
       this.logger.info("browser.tab_retained", { tabId: tab.id, traceId });

--- a/launcher/tests/browser-host.test.cjs
+++ b/launcher/tests/browser-host.test.cjs
@@ -1442,6 +1442,8 @@ test("a later provider round reuses only its exact connector-bound conversation"
     conversationKey,
     connectorIdentity: "Codex Native2",
     connectorBound: true,
+    retainedUrl: "https://chatgpt.com/c/original",
+    retainedNavigationInvalidated: false,
     helperPid: 111,
     status: "ready",
     loading: false,
@@ -1450,6 +1452,7 @@ test("a later provider round reuses only its exact connector-bound conversation"
     view: {
       webContents: {
         isDestroyed: () => false,
+        getURL: () => "https://chatgpt.com/c/original",
         setBackgroundThrottling: (enabled) => throttling.push(enabled),
       },
     },
@@ -1491,6 +1494,72 @@ test("a later provider round reuses only its exact connector-bound conversation"
   assert.equal(fixture.selectedTabId, tab.id);
   assert.deepEqual(throttling, [false]);
   assert.deepEqual(events, ["visible", "published", "descriptor", "browser.tab_reused"]);
+});
+
+test("navigating a retained task tab forces a fresh full-context turn", () => {
+  let currentUrl = "https://chatgpt.com/c/original";
+  const webContents = Object.assign(new EventEmitter(), {
+    setWindowOpenHandler() {},
+    isDestroyed: () => false,
+    getURL: () => currentUrl,
+  });
+  const conversationKey = "9".repeat(64);
+  const retained = {
+    id: "tab-navigated",
+    surfaceId: "surface-navigated",
+    traceId: "trace_previous",
+    conversationKey,
+    connectorIdentity: "Codex Native2",
+    connectorBound: true,
+    retainedUrl: currentUrl,
+    retainedNavigationInvalidated: false,
+    status: "ready",
+    view: { webContents },
+  };
+  const created = { id: "tab-fresh", surfaceId: "surface-fresh" };
+  const events = [];
+  const fixture = Object.assign(Object.create(BrowserHost.prototype), {
+    manualOperation: null,
+    turnTabs: new Map([[retained.id, retained]]),
+    userCancelledTurnOwners: new Map(),
+    selectedTabId: retained.id,
+    createTurnTab: (...args) => {
+      assert.deepEqual(args, ["trace_next", 222, conversationKey, "Codex Native2"]);
+      return created;
+    },
+    syncViewVisibility() {},
+    snapshot: () => ({ tabs: [] }),
+    publishState() {},
+    logger: {
+      info: (event) => events.push(event),
+      warn() {},
+      error() {},
+    },
+  });
+  BrowserHost.prototype.bindTurnContents.call(fixture, retained);
+
+  currentUrl = "https://chatgpt.com/";
+  webContents.emit("did-navigate-in-page", {}, currentUrl, true);
+
+  assert.equal(retained.retainedNavigationInvalidated, true);
+  assert.deepEqual(
+    BrowserHost.prototype.beginTurn.call(
+      fixture,
+      "trace_next",
+      false,
+      222,
+      conversationKey,
+      "Codex Native2",
+    ),
+    {
+      surfaceId: "surface-fresh",
+      tabId: "tab-fresh",
+      reused: false,
+      connectorBound: false,
+    },
+  );
+  assert.equal(retained.status, "ready");
+  assert.deepEqual(events, ["browser.retained_conversation_invalidated", "browser.tab_created"]);
 });
 
 test("a retained conversation is not reused for a different connector identity", () => {
@@ -1709,6 +1778,7 @@ test("a completed keyed turn is retained for thirty minutes and preserves its ac
     loading: true,
     view: { webContents: {
       isDestroyed: () => false,
+      getURL: () => "https://chatgpt.com/c/retained",
       setBackgroundThrottling: (enabled) => throttling.push(enabled),
     } },
   };
@@ -1740,6 +1810,8 @@ test("a completed keyed turn is retained for thirty minutes and preserves its ac
   assert.equal(fixture.turnTabs.get(tab.id), tab);
   assert.equal(tab.status, "ready");
   assert.equal(tab.connectorBound, true);
+  assert.equal(tab.retainedUrl, "https://chatgpt.com/c/retained");
+  assert.equal(tab.retainedNavigationInvalidated, false);
   assert.equal(Number.isFinite(tab.lastHeartbeatAt), true);
   assert.deepEqual(throttling, [true]);
 

--- a/src/adapters/chatgpt-web/conversation-key.ts
+++ b/src/adapters/chatgpt-web/conversation-key.ts
@@ -38,11 +38,16 @@ export function chatGptConversationKey(
     threadId: identity.threadId,
     modelId: parsed.modelId,
     reasoning: parsed.options.reasoning,
+    systemPrompt: parsed.context.systemPrompt ?? [],
     compaction: compactionEpoch(raw?.input),
   })).digest("hex");
 }
 
-/** Full history remains canonical; a retained epoch receives only the suffix after its last assistant reply. */
+/**
+ * Full history remains canonical. A retained epoch already holds its static system instructions,
+ * so follow-up turns send only the canonical suffix after the last assistant reply. The system
+ * prompt is part of the conversation key above; if it changes, the caller rotates to a fresh chat.
+ */
 export function retainedConversationResumeRequest(
   parsed: CodexParsedRequest,
 ): CodexParsedRequest | undefined {
@@ -52,6 +57,7 @@ export function retainedConversationResumeRequest(
     ...parsed,
     context: {
       ...parsed.context,
+      systemPrompt: undefined,
       messages: parsed.context.messages.slice(lastAssistant + 1),
     },
   };

--- a/tests/chatgpt-web-harness.test.ts
+++ b/tests/chatgpt-web-harness.test.ts
@@ -334,7 +334,9 @@ describe("ChatGPT outer-native harness v4", () => {
     };
 
     const first = rawWireRequest(environmentXml);
+    first.context.systemPrompt = ["stable retained system contract"];
     const second = parsed();
+    second.context.systemPrompt = ["stable retained system contract"];
     second.context.messages = [
       { role: "user", content: "Inspect the project", timestamp: 2 },
       { role: "assistant", content: [{ type: "text", text: "First retained answer" }], timestamp: 3 },
@@ -375,9 +377,11 @@ describe("ChatGPT outer-native harness v4", () => {
       expect(conversationKeys[1]).toBe(conversationKeys[0]);
       expect(tokens[1]).not.toBe(tokens[0]);
       expect(preparedPrompts[0]).toContain("Inspect the project");
+      expect(preparedPrompts[0]).toContain("stable retained system contract");
       expect(preparedPrompts[1]).toContain("Continue in the same repository");
       expect(preparedPrompts[1]).not.toContain("First retained answer");
       expect(preparedPrompts[1]).not.toContain(environmentXml);
+      expect(preparedPrompts[1]).not.toContain("stable retained system contract");
     } finally {
       (worker as unknown as { run: (turn: BrowserTurn) => Promise<string> }).run = originalRun;
       chatGptTurnSessions.clear();

--- a/tests/retained-compaction.test.ts
+++ b/tests/retained-compaction.test.ts
@@ -80,6 +80,7 @@ function controlBinding(instruction: string): { token: string; handoffId: string
 
 test("one browser conversation spans native turns and rotates only at compaction", () => {
   const before = request(false);
+  before.context.systemPrompt = ["stable system contract"];
   const sameTurn = structuredClone(before);
   (sameTurn._rawBody as { input: unknown[] }).input.push({
     type: "message",
@@ -116,7 +117,12 @@ test("one browser conversation spans native turns and rotates only at compaction
     }),
   };
   expect(chatGptConversationKey(otherThread, "provider")).not.toBe(chatGptConversationKey(before, "provider"));
-  expect(retainedConversationResumeRequest(before)?.context.messages).toEqual([
+  const changedSystem = structuredClone(before);
+  changedSystem.context.systemPrompt = ["updated system contract"];
+  expect(chatGptConversationKey(changedSystem, "provider")).not.toBe(chatGptConversationKey(before, "provider"));
+  const resume = retainedConversationResumeRequest(before);
+  expect(resume?.context.systemPrompt).toBeUndefined();
+  expect(resume?.context.messages).toEqual([
     { role: "user", content: "Continue with the next step", timestamp: 3 },
   ]);
 


### PR DESCRIPTION
## Summary

- include the canonical system prompt in the retained conversation key
- omit that unchanged system prompt from retained follow-up payloads
- invalidate retained reuse after a main-frame or in-page navigation so the next turn falls back to a fresh full-context tab
- cover stable prompt reuse, prompt changes, and manually navigated retained tabs

## Safety

The full Codex request remains canonical. A system prompt change rotates the conversation key, while any navigation after retention prevents the launcher from returning `reused: true`. Fresh tabs therefore continue through the existing full `prepare()` path.

## Validation

- focused retained conversation tests: pass
- `bun run typecheck`: pass
- `bun run launcher:typecheck`: pass
- `bun run launcher:test`: 215 pass, 2 skipped, 0 fail
- launcher build, runtime bundle, third-party notices, and relocatable runtime smoke: pass
- `bun run verify`: reaches the root test suite with 460 pass / 1 unrelated existing Windows failure in `installed launcher discovery has explicit platform candidates` (`C:\Users\tester` expected, current user path received)