### PR TITLE
Relay native realtime voice WebSocket through the local bridge

### DIFF
--- a/src/native-realtime-passthrough.ts
+++ b/src/native-realtime-passthrough.ts
@@ -1,0 +1,100 @@
+const NATIVE_REALTIME_URL = "wss://api.openai.com/v1/live";
+const NATIVE_REALTIME_HANDSHAKE_TIMEOUT_MS = 35_000;
+
+const HANDSHAKE_HEADERS = new Set([
+  "connection",
+  "content-length",
+  "host",
+  "sec-websocket-extensions",
+  "sec-websocket-key",
+  "sec-websocket-protocol",
+  "sec-websocket-version",
+  "upgrade",
+]);
+
+export type NativeRealtimeSocketFactory = (
+  url: string,
+  options: Bun.WebSocketOptions,
+) => WebSocket;
+
+const BunWebSocket = WebSocket as unknown as {
+  new (url: string | URL, options?: Bun.WebSocketOptions): WebSocket;
+};
+
+export interface NativeRealtimeUpstreamOptions {
+  url?: string;
+  handshakeTimeoutMs?: number;
+  createSocket?: NativeRealtimeSocketFactory;
+}
+
+export function nativeRealtimeHeaders(request: Request): Record<string, string> {
+  const authorization = request.headers.get("authorization") ?? "";
+  if (!authorization.startsWith("Bearer ") || authorization.length <= "Bearer ".length) {
+    throw new Error("Native Codex realtime passthrough requires the incoming Bearer authorization");
+  }
+
+  return Object.fromEntries(
+    [...request.headers]
+      .filter(([name]) => !HANDSHAKE_HEADERS.has(name.toLowerCase())),
+  );
+}
+
+export function nativeRealtimeProtocols(request: Request): string[] {
+  return (request.headers.get("sec-websocket-protocol") ?? "")
+    .split(",")
+    .map(protocol => protocol.trim())
+    .filter(Boolean);
+}
+
+export function nativeRealtimeTarget(request: Request, upstreamUrl = NATIVE_REALTIME_URL): string {
+  const incoming = new URL(request.url);
+  const target = new URL(upstreamUrl);
+  target.search = incoming.search;
+  return target.toString();
+}
+
+export async function openNativeRealtimeUpstream(
+  request: Request,
+  options: NativeRealtimeUpstreamOptions = {},
+): Promise<WebSocket> {
+  const createSocket = options.createSocket ?? ((url, socketOptions) => new BunWebSocket(url, socketOptions));
+  const protocols = nativeRealtimeProtocols(request);
+  const upstream = createSocket(nativeRealtimeTarget(request, options.url), {
+    headers: nativeRealtimeHeaders(request),
+    ...(protocols.length > 0 ? { protocols } : {}),
+    perMessageDeflate: true,
+  });
+  upstream.binaryType = "arraybuffer";
+
+  return await new Promise<WebSocket>((resolve, reject) => {
+    let settled = false;
+    const finish = (error?: Error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      request.signal.removeEventListener("abort", onAbort);
+      upstream.removeEventListener("open", onOpen);
+      upstream.removeEventListener("error", onError);
+      upstream.removeEventListener("close", onClose);
+      if (error) {
+        try { upstream.close(); } catch {}
+        reject(error);
+      } else {
+        resolve(upstream);
+      }
+    };
+    const onOpen = () => finish();
+    const onError = () => finish(new Error("Native Codex realtime upstream handshake failed"));
+    const onClose = () => finish(new Error("Native Codex realtime upstream closed during handshake"));
+    const onAbort = () => finish(new Error("Native Codex realtime client disconnected during handshake"));
+    const timer = setTimeout(
+      () => finish(new Error("Native Codex realtime upstream handshake timed out")),
+      options.handshakeTimeoutMs ?? NATIVE_REALTIME_HANDSHAKE_TIMEOUT_MS,
+    );
+
+    upstream.addEventListener("open", onOpen, { once: true });
+    upstream.addEventListener("error", onError, { once: true });
+    upstream.addEventListener("close", onClose, { once: true });
+    request.signal.addEventListener("abort", onAbort, { once: true });
+  });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -26,6 +26,10 @@ import {
 } from "./chatgpt-web-models";
 import { forwardNativeCodexRequest, type NativeFetch } from "./native-passthrough";
 import {
+  openNativeRealtimeUpstream,
+  type NativeRealtimeUpstreamOptions,
+} from "./native-realtime-passthrough";
+import {
   buildCompactV1Output,
   COMPACT_PROMPT,
   decodeCompactionSummary,
@@ -39,6 +43,54 @@ import type { ProviderAdapter } from "./adapters/base";
 import { VERSION } from "./version";
 
 type HttpTrackedEndpoint = "models" | "responses" | "compact" | "search" | "unspecified";
+
+interface NativeRealtimeRelay {
+  upstream: WebSocket;
+  downstream?: Bun.ServerWebSocket<NativeRealtimeRelay>;
+  pending: Array<string | ArrayBuffer>;
+  closed: boolean;
+  release: () => void;
+}
+
+function wireSafeWebSocketCloseCode(code: number): number {
+  return code >= 1000
+    && code <= 4999
+    && code !== 1004
+    && code !== 1005
+    && code !== 1006
+    && code !== 1015
+    ? code
+    : 1011;
+}
+
+function closeNativeRealtimeRelay(
+  relay: NativeRealtimeRelay,
+  code = 1000,
+  reason = "native realtime relay closed",
+): void {
+  if (relay.closed) return;
+  relay.closed = true;
+  relay.release();
+  if (relay.upstream.readyState === WebSocket.OPEN || relay.upstream.readyState === WebSocket.CONNECTING) {
+    try { relay.upstream.close(code, reason); } catch {}
+  }
+}
+
+function sendNativeRealtimeDownstream(relay: NativeRealtimeRelay, data: unknown): void {
+  const normalized = typeof data === "string"
+    ? data
+    : data instanceof ArrayBuffer
+      ? data
+      : ArrayBuffer.isView(data)
+        ? new Uint8Array(data.buffer, data.byteOffset, data.byteLength).slice().buffer
+        : null;
+  if (normalized === null) return;
+  if (!relay.downstream) {
+    relay.pending.push(normalized);
+    return;
+  }
+  relay.downstream.send(normalized);
+}
 
 export interface HttpStreamFailureEvidence {
   httpTurnId: number;
@@ -630,7 +682,10 @@ export async function compactRequest(
 
 export function startServer(
   config: AppConfig,
-  dependencies: { fetchUpstream?: NativeFetch } = {},
+  dependencies: {
+    fetchUpstream?: NativeFetch;
+    nativeRealtime?: NativeRealtimeUpstreamOptions;
+  } = {},
 ): ReturnType<typeof Bun.serve> {
   if (config.purpose === "dev-harness") {
     throw new Error("DEV harness configuration cannot start a Responses listener");
@@ -649,9 +704,11 @@ export function startServer(
   let successfulModelCatalogRequests = 0;
   let lastSuccessfulModelCatalogRequestAt: string | null = null;
   const httpTurns = new HttpTurnCounter();
+  const nativeRealtimeRelays = new Set<NativeRealtimeRelay>();
   const activity = () => ({
     active_http_turns: httpTurns.count(),
     active_browser_turns: chatGptTurnSessions.activeCount() + (turnBroker?.externalOwnerActiveCount() ?? 0),
+    active_realtime_turns: nativeRealtimeRelays.size,
   });
   const controlAuthorized = (req: Request): boolean => {
     const header = req.headers.get("authorization") ?? "";
@@ -659,11 +716,11 @@ export function startServer(
     const actual = Buffer.from(header);
     return actual.length === expected.length && timingSafeEqual(actual, expected);
   };
-  const server = Bun.serve({
+  const server = Bun.serve<NativeRealtimeRelay>({
     hostname: config.host,
     port: config.port,
     idleTimeout: 0,
-    async fetch(req) {
+    async fetch(req, bunServer) {
       const url = new URL(req.url);
       if (req.method === "GET" && url.pathname === "/healthz") {
         return Response.json({
@@ -714,17 +771,26 @@ export function startServer(
         if (!controlAuthorized(req)) return new Response("Unauthorized", { status: 401 });
         const cancelledBrowserTurns = chatGptTurnSessions.clear() + (turnBroker?.revokeExternalOwners() ?? 0);
         const cancelledHttpTurns = await httpTurns.cancelAll(new Error("Active turn cancelled by launcher"));
+        const cancelledRealtimeTurns = nativeRealtimeRelays.size;
+        for (const relay of [...nativeRealtimeRelays]) {
+          relay.downstream?.close(1012, "Active turn cancelled by launcher");
+          closeNativeRealtimeRelay(relay, 1012, "Active turn cancelled by launcher");
+        }
         return Response.json({
           status: "ok",
           cancelled_http_turns: cancelledHttpTurns,
           cancelled_browser_turns: cancelledBrowserTurns,
+          cancelled_realtime_turns: cancelledRealtimeTurns,
           ...activity(),
         });
       }
       if (req.method === "POST" && url.pathname === "/admin/shutdown") {
         if (!controlAuthorized(req)) return new Response("Unauthorized", { status: 401 });
         const current = activity();
-        if (!draining || current.active_http_turns > 0 || current.active_browser_turns > 0) {
+        if (!draining
+          || current.active_http_turns > 0
+          || current.active_browser_turns > 0
+          || current.active_realtime_turns > 0) {
           return Response.json(
             {
               status: "refused",
@@ -778,6 +844,58 @@ export function startServer(
           headers: { "content-type": "text/plain; charset=utf-8" },
         });
       }
+      if (url.pathname === "/v1/live") {
+        if (draining) {
+          return formatErrorResponse(
+            503,
+            "server_error",
+            "codex-chatgpt-web is draining for a requested service operation",
+          );
+        }
+        if (req.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+          return new Response("Native realtime requires a WebSocket upgrade", {
+            status: 426,
+            headers: { upgrade: "websocket" },
+          });
+        }
+        let upstream: WebSocket;
+        try {
+          upstream = await openNativeRealtimeUpstream(req, dependencies.nativeRealtime);
+        } catch (error) {
+          return formatErrorResponse(
+            error instanceof Error && error.message.includes("Bearer") ? 401 : 502,
+            "upstream_error",
+            error instanceof Error ? error.message : String(error),
+          );
+        }
+        let relay!: NativeRealtimeRelay;
+        relay = {
+          upstream,
+          pending: [],
+          closed: false,
+          release: () => nativeRealtimeRelays.delete(relay),
+        };
+        nativeRealtimeRelays.add(relay);
+        upstream.addEventListener("message", event => sendNativeRealtimeDownstream(relay, event.data));
+        upstream.addEventListener("close", event => {
+          const code = wireSafeWebSocketCloseCode(event.code || 1000);
+          relay.downstream?.close(code, event.reason || "native realtime upstream closed");
+          closeNativeRealtimeRelay(relay, code, event.reason || "native realtime upstream closed");
+        });
+        upstream.addEventListener("error", () => {
+          relay.downstream?.close(1011, "native realtime upstream failed");
+          closeNativeRealtimeRelay(relay, 1011, "native realtime upstream failed");
+        });
+        const upgraded = bunServer.upgrade(req, {
+          data: relay,
+          ...(upstream.protocol ? { headers: { "sec-websocket-protocol": upstream.protocol } } : {}),
+        });
+        if (!upgraded) {
+          closeNativeRealtimeRelay(relay, 1011, "native realtime downstream upgrade failed");
+          return formatErrorResponse(400, "invalid_request_error", "Native realtime WebSocket upgrade failed");
+        }
+        return;
+      }
       if (req.method === "POST" && url.pathname === "/v1/responses") {
         if (draining) return formatErrorResponse(503, "server_error", "codex-chatgpt-web is draining for a requested service operation");
         return httpTurns.track(
@@ -807,11 +925,31 @@ export function startServer(
       }
       return new Response("Not found", { status: 404 });
     },
+    websocket: {
+      open(ws) {
+        const relay = ws.data;
+        relay.downstream = ws;
+        for (const message of relay.pending.splice(0)) ws.send(message);
+      },
+      message(ws, message) {
+        const relay = ws.data;
+        if (relay.upstream.readyState === WebSocket.OPEN) relay.upstream.send(message);
+      },
+      close(ws, code, reason) {
+        closeNativeRealtimeRelay(ws.data, code || 1000, reason || "native realtime downstream closed");
+      },
+      maxPayloadLength: 16 * 1024 * 1024,
+      perMessageDeflate: true,
+    },
   });
   function shutdown(): void {
     if (shutdownPromise) return;
     draining = true;
     chatGptTurnSessions.clear();
+    for (const relay of [...nativeRealtimeRelays]) {
+      relay.downstream?.close(1012, "bridge shutting down");
+      closeNativeRealtimeRelay(relay, 1012, "bridge shutting down");
+    }
     flushResponseState();
     shutdownPromise = (async () => {
       const results = await Promise.allSettled([

--- a/tests/native-realtime-passthrough.test.ts
+++ b/tests/native-realtime-passthrough.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test";
+import {
+  nativeRealtimeHeaders,
+  nativeRealtimeTarget,
+} from "../src/native-realtime-passthrough";
+
+test("builds the native realtime target and preserves authenticated end-to-end headers", () => {
+  const request = new Request("http://127.0.0.1:17841/v1/live?session_id=rtc_test", {
+    headers: {
+      authorization: "Bearer codex-oauth-token",
+      connection: "Upgrade",
+      upgrade: "websocket",
+      "sec-websocket-key": "downstream-key",
+      "sec-websocket-protocol": "realtime",
+      "x-oai-attestation": "attestation-token",
+    },
+  });
+
+  expect(nativeRealtimeTarget(request)).toBe("wss://api.openai.com/v1/live?session_id=rtc_test");
+  expect(nativeRealtimeHeaders(request)).toEqual({
+    authorization: "Bearer codex-oauth-token",
+    "x-oai-attestation": "attestation-token",
+  });
+});
+
+test("native realtime passthrough fails closed without Codex bearer authentication", () => {
+  const request = new Request("http://127.0.0.1:17841/v1/live", {
+    headers: { upgrade: "websocket" },
+  });
+  expect(() => nativeRealtimeHeaders(request)).toThrow(
+    "Native Codex realtime passthrough requires the incoming Bearer authorization",
+  );
+});

--- a/tests/server-lifecycle.test.ts
+++ b/tests/server-lifecycle.test.ts
@@ -654,6 +654,91 @@ test("server exposes authenticated standalone Web Search on the routed v1 base U
   }
 });
 
+test("server relays authenticated native realtime WebSocket traffic without rerouting Responses", async () => {
+  const upstreamRequests: Array<{ path: string; authorization: string | null; attestation: string | null }> = [];
+  const upstream = Bun.serve<{ path: string }>({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch(req, server) {
+      const url = new URL(req.url);
+      upstreamRequests.push({
+        path: `${url.pathname}${url.search}`,
+        authorization: req.headers.get("authorization"),
+        attestation: req.headers.get("x-oai-attestation"),
+      });
+      if (server.upgrade(req, { data: { path: url.pathname } })) return;
+      return new Response("upgrade required", { status: 426 });
+    },
+    websocket: {
+      open(ws) { ws.send("upstream-ready"); },
+      message(ws, message) { ws.send(message); },
+    },
+  });
+  const config = { ...defaultConfig("browser-only"), port: 0 };
+  const server = startServer(config, {
+    nativeRealtime: { url: `ws://127.0.0.1:${upstream.port}/v1/live` },
+  });
+  const endpoint = `ws://127.0.0.1:${server.port}`;
+  const messages: string[] = [];
+  const BunWebSocket = WebSocket as unknown as {
+    new (url: string | URL, options?: Bun.WebSocketOptions): WebSocket;
+  };
+  const client = new BunWebSocket(`${endpoint}/v1/live?session_id=rtc_test`, {
+    headers: {
+      authorization: "Bearer test-codex-session",
+      "x-oai-attestation": "test-attestation",
+    },
+  });
+  client.addEventListener("message", event => messages.push(String(event.data)));
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      client.addEventListener("open", () => resolve(), { once: true });
+      client.addEventListener("error", () => reject(new Error("downstream realtime connection failed")), { once: true });
+    });
+    const readyDeadline = Date.now() + 1_000;
+    while (!messages.includes("upstream-ready") && Date.now() < readyDeadline) await Bun.sleep(5);
+    expect(messages).toContain("upstream-ready");
+
+    client.send("client-event");
+    const echoDeadline = Date.now() + 1_000;
+    while (!messages.includes("client-event") && Date.now() < echoDeadline) await Bun.sleep(5);
+    expect(messages).toContain("client-event");
+    expect(upstreamRequests).toEqual([{
+      path: "/v1/live?session_id=rtc_test",
+      authorization: "Bearer test-codex-session",
+      attestation: "test-attestation",
+    }]);
+    expect(await (await fetch(`http://127.0.0.1:${server.port}/healthz`)).json()).toMatchObject({
+      active_realtime_turns: 1,
+    });
+  } finally {
+    client.close();
+    const deadline = Date.now() + 1_000;
+    while (Date.now() < deadline) {
+      const health = await (await fetch(`http://127.0.0.1:${server.port}/healthz`)).json() as {
+        active_realtime_turns: number;
+      };
+      if (health.active_realtime_turns === 0) break;
+      await Bun.sleep(5);
+    }
+    await server.stop(true);
+    await upstream.stop(true);
+  }
+});
+
+test("server rejects non-WebSocket native realtime requests before upstream access", async () => {
+  const config = { ...defaultConfig("browser-only"), port: 0 };
+  const server = startServer(config);
+  try {
+    const response = await fetch(`http://127.0.0.1:${server.port}/v1/live`);
+    expect(response.status).toBe(426);
+    expect(response.headers.get("upgrade")).toBe("websocket");
+  } finally {
+    await server.stop(true);
+  }
+});
+
 test("authenticated shutdown requires a verified idle drain", async () => {
   const config = { ...defaultConfig("browser-only"), port: 0 };
   const server = startServer(config);


### PR DESCRIPTION
## Summary

- add an authenticated `/v1/live` WebSocket relay to the native OpenAI realtime endpoint
- preserve the incoming bearer token, attestation headers, query string, and negotiated subprotocol while stripping hop-by-hop handshake headers
- include realtime relays in health, cancellation, drain, shutdown, and active-turn accounting
- leave the existing `/v1/responses` routing behavior unchanged

## Why

When Codex Desktop uses this bridge as its configured OpenAI base URL, realtime voice starts an app-server sideband WebSocket at `/v1/live`. The bridge currently returns `404 Not Found`, so the voice session fails after the WebRTC setup has already started.

## Validation

- `bun run typecheck`
- `bun test tests/native-realtime-passthrough.test.ts tests/server-lifecycle.test.ts` (26 passed)
- packaged local canary reached `realtime_session_started` and received a realtime session ID without another `/v1/live` 404

## Boundaries

This change does not alter model selection, Responses routing, browser automation, or credential storage. The relay fails closed when the incoming Codex bearer credential is absent.
