### PR TITLE
Run managed runtime upgrades from the packaged runtime

### DIFF
--- a/launcher/electron/runtime.cjs
+++ b/launcher/electron/runtime.cjs
@@ -902,6 +902,7 @@ class RuntimeHost {
       message: `Upgrading launcher runtime from ${existing.config.releaseVersion} to ${currentVersion}`,
       successMessage: `Launcher runtime upgraded to ${currentVersion}`,
       timeoutMs: existing.mode === "full" ? MCP_SETUP_TIMEOUT_MS : CORE_SETUP_TIMEOUT_MS,
+      embedded: true,
     });
     return {
       updated: true,

--- a/launcher/tests/runtime-host.test.cjs
+++ b/launcher/tests/runtime-host.test.cjs
@@ -23,11 +23,13 @@ function hostFor(existingConfig) {
     },
   });
   let invocation;
-  host.runSetup = async (name, args) => {
+  let runOptions;
+  host.runSetup = async (name, args, options) => {
     invocation = { name, args };
+    runOptions = options;
     return { code: 0, stdout: "", stderr: "" };
   };
-  return { host, invocation: () => invocation };
+  return { host, invocation: () => invocation, runOptions: () => runOptions };
 }
 
 function devHostFor(existingConfig) {
@@ -287,6 +289,7 @@ test("launcher update transaction upgrades its owned full runtime with saved con
     "--app-name",
     "Codex Native2",
   ]);
+  assert.equal(fixture.runOptions().embedded, true);
   assert.deepEqual(result, {
     updated: true,
     mode: "full",


### PR DESCRIPTION
## Summary

- execute `upgradeManagedRuntime()` with the new launcher's embedded runtime
- add regression coverage that asserts the upgrade transaction selects the embedded invocation

## Why

The launcher detects that its managed runtime belongs to an older release, but the upgrade setup command currently runs through the configured old runtime. That old runtime writes its own version and command back into `config.json`, so the launcher appears upgraded while the running daemon remains on the predecessor release.

Using the packaged runtime makes the upgrade monotonic: the newly installed launcher writes its own exact runtime identity into the managed configuration.

## Validation

`node --test launcher/tests/runtime-host.test.cjs launcher/tests/runtime-install.test.cjs launcher/tests/update.test.cjs` (44 passed)

## Boundaries

This does not change update discovery, version comparison, external-runtime ownership, or rollback behavior. It only selects the already packaged runtime for the existing managed upgrade transaction.
