### PR TITLE
fix: keep Codex Voice call creation on the ChatGPT backend

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -140,10 +140,12 @@ launcher runtime from a stale or external process. Legacy macOS launchd services
 removed during an explicit launcher migration; launchd remains only for the advanced terminal-only
 mode.
 
-Setup keeps Codex's built-in `openai` provider; its only managed provider-routing assignment is
-`openai_base_url`. The daemon
-forwards the authenticated official model catalog and appends only the routed models owned by the
-`chatgpt-web/` namespace; no static catalog is installed. Subagent protocol selection is explicit,
+Setup keeps Codex's built-in `openai` provider. It manages `openai_base_url` for Responses traffic
+and `experimental_realtime_webrtc_call_base_url` for Codex Voice call creation; the latter remains
+on the ChatGPT backend instead of the Responses-only local daemon. Both route overrides are journaled
+and restored exactly on disconnect or uninstall. The daemon forwards the authenticated official
+model catalog and appends only the routed models owned by the `chatgpt-web/` namespace; no static
+catalog is installed. Subagent protocol selection is explicit,
 and new installations default to Compatibility V1 because it is the only surface portable across
 native and routed Web backends:
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -62,7 +62,7 @@ Setup options:
   --app-name NAME              ChatGPT connector name (default: ${CHATGPT_CONNECTOR_NAME})
   --tunnel-id ID               Existing OpenAI tunnel id (full mode)
   --runtime-key-file PATH      File containing a Tunnels Read+Use runtime key
-  --replace-codex-route        Reversibly replace an existing openai_base_url
+  --replace-codex-route        Reversibly replace existing Codex route overrides
   --subagent-protocol MODE     compatibility-v1 (default) or native (advanced)
   --restart-service            Explicitly restart this project's daemon after an update
   --login                      Refresh the stored ChatGPT login even if one exists

--- a/src/codex-integration-document.ts
+++ b/src/codex-integration-document.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { stripUtf8Bom } from "./config";
 import {
   MANAGED_COMMENT,
+  MANAGED_ROUTE_COMMENT,
   MANAGED_MULTI_AGENT_LINE,
   MANAGED_MULTI_AGENT_V2_LINE,
   MANAGED_MULTI_AGENT_V2_TABLE_LINE,
@@ -193,7 +194,9 @@ export function removeDocumentLine(document: CodexConfigDocument, index: number)
 
 export function removeManagedComment(document: CodexConfigDocument): void {
   for (let index = document.lines.length - 1; index >= 0; index -= 1) {
-    if (document.lines[index] === MANAGED_COMMENT) removeDocumentLine(document, index);
+    if (document.lines[index] === MANAGED_COMMENT || document.lines[index] === MANAGED_ROUTE_COMMENT) {
+      removeDocumentLine(document, index);
+    }
   }
 }
 

--- a/src/codex-integration-journal.ts
+++ b/src/codex-integration-journal.ts
@@ -17,12 +17,31 @@ import type {
   LegacyCodexIntegrationJournalV5,
   LegacyCodexIntegrationJournalV6,
   LegacyCodexIntegrationJournalV7,
+  LegacyCodexIntegrationJournalV8,
 } from "./codex-integration-shared";
 import { verifyManagedJournalState } from "./codex-integration-route";
 
 function parseJournal(path: string): AnyCodexIntegrationJournal {
   const value = JSON.parse(stripUtf8Bom(readFileSync(path, "utf8"))) as Record<string, unknown>;
   const installed = value.installed as Record<string, unknown> | undefined;
+  const previousRealtime = value.previousRealtimeWebrtcCallBaseUrl as Record<string, unknown> | undefined;
+  if (value.version === 9
+    && typeof value.active === "boolean"
+    && installed
+    && typeof installed.experimental_realtime_webrtc_call_base_url === "string"
+    && (installed.subagent_protocol === "compatibility-v1" || installed.subagent_protocol === "native")
+    && (installed.subagent_protocol !== "compatibility-v1"
+      || (value.previousMultiAgent && value.previousMultiAgentV2
+        && value.previousAgentMaxDepth
+        && typeof installed.agent_max_depth === "number"
+        && Number.isSafeInteger(installed.agent_max_depth)
+        && installed.agent_max_depth >= 2))
+    && value.previous
+    && previousRealtime
+    && typeof previousRealtime.present === "boolean"
+    && typeof value.configPath === "string") {
+    return value as unknown as CodexIntegrationJournal;
+  }
   if (value.version === 8
     && typeof value.active === "boolean"
     && installed
@@ -35,7 +54,7 @@ function parseJournal(path: string): AnyCodexIntegrationJournal {
         && installed.agent_max_depth >= 2))
     && value.previous
     && typeof value.configPath === "string") {
-    return value as unknown as CodexIntegrationJournal;
+    return value as unknown as LegacyCodexIntegrationJournalV8;
   }
   if (value.version === 7
     && typeof value.active === "boolean"

--- a/src/codex-integration-route.ts
+++ b/src/codex-integration-route.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import {
   MANAGED_COMMENT,
+  MANAGED_ROUTE_COMMENT,
   MANAGED_MULTI_AGENT_LINE,
   MANAGED_MULTI_AGENT_V2_LINE,
   MANAGED_MULTI_AGENT_V2_TABLE_LINE,
@@ -15,6 +16,7 @@ import type {
   LegacyCodexIntegrationJournalV5,
   LegacyCodexIntegrationJournalV6,
   LegacyCodexIntegrationJournalV7,
+  LegacyCodexIntegrationJournalV8,
   ManagedAssignmentKey,
   ManagedRouteJournal,
   PreviousAssignment,
@@ -43,7 +45,7 @@ import {
   verifyCompatibilityV1Features,
 } from "./codex-integration-document";
 
-function compatibilityV1Evidence(journal: CodexIntegrationJournal): {
+function compatibilityV1Evidence(journal: CodexIntegrationJournal | LegacyCodexIntegrationJournalV8): {
   previousMultiAgent: PreviousFeatureAssignment;
   previousMultiAgentV2: PreviousFeatureAssignment;
   previousAgentMaxDepth: PreviousAgentAssignment;
@@ -64,7 +66,7 @@ function compatibilityV1Evidence(journal: CodexIntegrationJournal): {
 
 function restoreOwnedManagedFeatures(text: string, journal: ManagedRouteJournal): string {
   let restored = text;
-  if (journal.version === 8) {
+  if (journal.version === 8 || journal.version === 9) {
     const evidence = compatibilityV1Evidence(journal);
     if (evidence) {
       const depth = findAgentMaxDepthAssignment(splitLines(restored));
@@ -172,19 +174,35 @@ export function replacementBaseline(
   if (!configExists) return "";
   if (!managedJournalIsActive(journal)) return currentText;
 
-  if (journal.version === 7 || journal.version === 8) {
+  if (journal.version === 7 || journal.version === 8 || journal.version === 9) {
     const baseline = restoreOwnedManagedFeatures(currentText, journal);
     const document = parseDocument(baseline);
     removeManagedComment(document);
-    const current = findTopLevelAssignment(document.lines, "openai_base_url");
-    if (current.value === journal.installed.openai_base_url && current.index !== undefined) {
-      const previous = journal.previous.openai_base_url;
+    const restoreIfStillManaged = (
+      key: string,
+      installed: string,
+      previous: PreviousAssignment,
+    ): void => {
+      const current = findTopLevelAssignment(document.lines, key);
+      if (current.value !== installed || current.index === undefined) return;
       if (previous.present) {
-        if (!previous.rawLine) throw new Error("Codex integration journal is missing the prior openai_base_url line");
+        if (!previous.rawLine) throw new Error(`Codex integration journal is missing the prior ${key} line`);
         document.lines[current.index] = previous.rawLine;
       } else {
         removeDocumentLine(document, current.index);
       }
+    };
+    restoreIfStillManaged(
+      "openai_base_url",
+      journal.installed.openai_base_url,
+      journal.previous.openai_base_url,
+    );
+    if (journal.version === 9) {
+      restoreIfStillManaged(
+        "experimental_realtime_webrtc_call_base_url",
+        journal.installed.experimental_realtime_webrtc_call_base_url,
+        journal.previousRealtimeWebrtcCallBaseUrl,
+      );
     }
     return renderDocument(document);
   }
@@ -194,13 +212,40 @@ export function replacementBaseline(
   return baseline;
 }
 
+export function assertRealtimeRouteCanBeReplaced(
+  text: string,
+  installedRealtimeUrl: string,
+  replaceExistingRoute: boolean,
+): void {
+  const current = findTopLevelAssignment(
+    parseDocument(text).lines,
+    "experimental_realtime_webrtc_call_base_url",
+  );
+  if (current.present && current.value !== installedRealtimeUrl && !replaceExistingRoute) {
+    throw new Error(
+      "Codex already configures realtime call routing "
+      + `(experimental_realtime_webrtc_call_base_url=${JSON.stringify(current.value)}). `
+      + "Rerun with --replace-codex-route to replace it reversibly.",
+    );
+  }
+}
+
 export function installRoute(
   text: string,
   installedUrl: string,
+  installedRealtimeUrl: string,
   replaceExistingRoute: boolean,
-): { text: string; previous: CodexIntegrationJournal["previous"] } {
+): {
+  text: string;
+  previous: CodexIntegrationJournal["previous"];
+  previousRealtimeWebrtcCallBaseUrl: PreviousAssignment;
+} {
   const document = parseDocument(text);
   const previous = assignments(document.lines);
+  const previousRealtimeWebrtcCallBaseUrl = findTopLevelAssignment(
+    document.lines,
+    "experimental_realtime_webrtc_call_base_url",
+  );
   if (previous.openai_base_url.present && !replaceExistingRoute) {
     throw new Error(
       `Codex already configures model routing (openai_base_url=${JSON.stringify(previous.openai_base_url.value)}). `
@@ -208,17 +253,37 @@ export function installRoute(
       + "Check whether another Codex extension or wrapper (for example, OpenCodex or Headroom) is replacing the bridge port.",
     );
   }
+  assertRealtimeRouteCanBeReplaced(text, installedRealtimeUrl, replaceExistingRoute);
 
+  removeManagedComment(document);
   const currentBaseUrl = findTopLevelAssignment(document.lines, "openai_base_url");
   if (currentBaseUrl.index !== undefined) {
     document.lines[currentBaseUrl.index] = `openai_base_url = ${JSON.stringify(installedUrl)}`;
   } else {
     insertDocumentLine(document, firstTableIndex(document.lines), `openai_base_url = ${JSON.stringify(installedUrl)}`);
   }
-  removeManagedComment(document);
   const installedBaseUrl = findTopLevelAssignment(document.lines, "openai_base_url");
-  insertDocumentLine(document, installedBaseUrl.index!, MANAGED_COMMENT);
-  return { text: renderDocument(document), previous };
+  const currentRealtimeUrl = findTopLevelAssignment(
+    document.lines,
+    "experimental_realtime_webrtc_call_base_url",
+  );
+  if (currentRealtimeUrl.index !== undefined) {
+    document.lines[currentRealtimeUrl.index] =
+      `experimental_realtime_webrtc_call_base_url = ${JSON.stringify(installedRealtimeUrl)}`;
+  } else {
+    insertDocumentLine(
+      document,
+      installedBaseUrl.index! + 1,
+      `experimental_realtime_webrtc_call_base_url = ${JSON.stringify(installedRealtimeUrl)}`,
+    );
+  }
+  const installedRealtimeBaseUrl = findTopLevelAssignment(
+    document.lines,
+    "experimental_realtime_webrtc_call_base_url",
+  );
+  const managedIndex = Math.min(installedBaseUrl.index!, installedRealtimeBaseUrl.index!);
+  insertDocumentLine(document, managedIndex, MANAGED_ROUTE_COMMENT);
+  return { text: renderDocument(document), previous, previousRealtimeWebrtcCallBaseUrl };
 }
 
 export function verifyInstalledRoute(text: string, journal: ManagedRouteJournal): void {
@@ -227,10 +292,21 @@ export function verifyInstalledRoute(text: string, journal: ManagedRouteJournal)
   if (current.openai_base_url.value !== journal.installed.openai_base_url) {
     throw new Error("Codex openai_base_url changed after setup; refusing to overwrite the user's newer value");
   }
-  if (!lines.includes(MANAGED_COMMENT)) {
+  if (journal.version === 9) {
+    const realtime = findTopLevelAssignment(lines, "experimental_realtime_webrtc_call_base_url");
+    if (realtime.value !== journal.installed.experimental_realtime_webrtc_call_base_url) {
+      throw new Error(
+        "Codex experimental_realtime_webrtc_call_base_url changed after setup; "
+        + "refusing to overwrite the user's newer value",
+      );
+    }
+  }
+  const expectedMarker = journal.version === 9 ? MANAGED_ROUTE_COMMENT : MANAGED_COMMENT;
+  if (!lines.includes(expectedMarker)
+    || (journal.version === 9 && lines.includes(MANAGED_COMMENT))) {
     throw new Error("Managed Codex route marker changed after setup; refusing to overwrite it");
   }
-  if (journal.version === 8) {
+  if (journal.version === 8 || journal.version === 9) {
     const evidence = compatibilityV1Evidence(journal);
     if (evidence) {
       verifyCompatibilityV1Features(
@@ -240,7 +316,7 @@ export function verifyInstalledRoute(text: string, journal: ManagedRouteJournal)
       );
     }
   }
-  if (journal.version !== 7 && journal.version !== 8) {
+  if (journal.version !== 7 && journal.version !== 8 && journal.version !== 9) {
     if (current.model_provider.present || current.model_catalog_json.present) {
       throw new Error("Codex model_provider or model_catalog_json changed after setup; refusing to overwrite the user's newer value");
     }
@@ -255,11 +331,11 @@ function previousAssignmentMatches(current: PreviousAssignment, previous: Previo
 
 export function verifyRestoredRoute(
   text: string,
-  journal: CodexIntegrationJournal | LegacyCodexIntegrationJournalV7 | LegacyCodexIntegrationJournalV6 | LegacyCodexIntegrationJournalV5 | LegacyCodexIntegrationJournalV4,
+  journal: CodexIntegrationJournal | LegacyCodexIntegrationJournalV8 | LegacyCodexIntegrationJournalV7 | LegacyCodexIntegrationJournalV6 | LegacyCodexIntegrationJournalV5 | LegacyCodexIntegrationJournalV4,
 ): void {
   const lines = splitLines(text);
   const current = assignments(lines);
-  const keys = journal.version === 7 || journal.version === 8
+  const keys = journal.version === 7 || journal.version === 8 || journal.version === 9
     ? (["openai_base_url"] as const)
     : (["openai_base_url", "model_provider", "model_catalog_json"] as const);
   for (const key of keys) {
@@ -267,7 +343,19 @@ export function verifyRestoredRoute(
       throw new Error(`Codex ${key} changed while the bridge was disconnected; refusing to overwrite the user's newer value`);
     }
   }
-  if (lines.includes(MANAGED_COMMENT)) {
+  if (journal.version === 9) {
+    const currentRealtime = findTopLevelAssignment(
+      lines,
+      "experimental_realtime_webrtc_call_base_url",
+    );
+    if (!previousAssignmentMatches(currentRealtime, journal.previousRealtimeWebrtcCallBaseUrl)) {
+      throw new Error(
+        "Codex experimental_realtime_webrtc_call_base_url changed while the bridge was disconnected; "
+        + "refusing to overwrite the user's newer value",
+      );
+    }
+  }
+  if (lines.includes(MANAGED_COMMENT) || lines.includes(MANAGED_ROUTE_COMMENT)) {
     throw new Error("Managed Codex route marker is present while the bridge is disconnected");
   }
   if (journal.version === 5 || journal.version === 6) {
@@ -292,7 +380,7 @@ export function verifyRestoredRoute(
       }
     }
   }
-  if (journal.version === 8) {
+  if (journal.version === 8 || journal.version === 9) {
     const evidence = compatibilityV1Evidence(journal);
     if (evidence) {
       for (const [key, previous] of [
@@ -329,9 +417,18 @@ export function verifyRestoredRoute(
 export function assertPreservedPreviousAssignments(
   actual: CodexIntegrationJournal["previous"],
   expected: CodexIntegrationJournal["previous"],
+  actualRealtime?: PreviousAssignment,
+  expectedRealtime?: PreviousAssignment,
 ): void {
   if (!previousAssignmentMatches(actual.openai_base_url, expected.openai_base_url)) {
     throw new Error("Codex openai_base_url changed while the bridge was disconnected; refusing to replace it");
+  }
+  if (expectedRealtime && (!actualRealtime
+    || !previousAssignmentMatches(actualRealtime, expectedRealtime))) {
+    throw new Error(
+      "Codex experimental_realtime_webrtc_call_base_url changed while the bridge was disconnected; "
+      + "refusing to replace it",
+    );
   }
 }
 
@@ -348,7 +445,27 @@ export function restoreManagedRoute(text: string, journal: ManagedRouteJournal):
   } else {
     removeDocumentLine(document, currentBaseUrl.index);
   }
-  if (journal.version !== 7 && journal.version !== 8) {
+  if (journal.version === 9) {
+    const currentRealtime = findTopLevelAssignment(
+      document.lines,
+      "experimental_realtime_webrtc_call_base_url",
+    );
+    if (currentRealtime.index === undefined) {
+      throw new Error("Managed Codex experimental_realtime_webrtc_call_base_url is missing");
+    }
+    const previousRealtime = journal.previousRealtimeWebrtcCallBaseUrl;
+    if (previousRealtime.present) {
+      if (!previousRealtime.rawLine) {
+        throw new Error(
+          "Codex integration journal is missing the prior experimental_realtime_webrtc_call_base_url line",
+        );
+      }
+      document.lines[currentRealtime.index] = previousRealtime.rawLine;
+    } else {
+      removeDocumentLine(document, currentRealtime.index);
+    }
+  }
+  if (journal.version !== 7 && journal.version !== 8 && journal.version !== 9) {
     const removedAssignments = (["model_provider", "model_catalog_json"] as const)
       .map(key => ({ key, previous: journal.previous[key] }))
       .filter(item => item.previous.present)
@@ -360,7 +477,7 @@ export function restoreManagedRoute(text: string, journal: ManagedRouteJournal):
     }
   }
   const restoredRoute = renderDocument(document);
-  if (journal.version === 8) {
+  if (journal.version === 8 || journal.version === 9) {
     const evidence = compatibilityV1Evidence(journal);
     return evidence
       ? restoreCompatibilityV1Features(

--- a/src/codex-integration-shared.ts
+++ b/src/codex-integration-shared.ts
@@ -6,6 +6,9 @@ import type { AppConfig, SubagentProtocol } from "./config";
 import { atomicWriteFile, expandUserPath, getConfigDir } from "./config";
 
 export const MANAGED_COMMENT = "# Managed by codex-chatgpt-web; `codex-chatgpt-web uninstall` restores prior values.";
+export const MANAGED_ROUTE_COMMENT =
+  "# Managed by codex-chatgpt-web; `codex-chatgpt-web uninstall` restores prior routing values.";
+export const CODEX_REALTIME_WEBRTC_CALL_BASE_URL = "https://chatgpt.com/backend-api/codex";
 export const MANAGED_REMOTE_COMPACTION_LINE =
   "remote_compaction_v2 = false # Managed by codex-chatgpt-web: bounds retained Web image history.";
 export const MANAGED_MULTI_AGENT_LINE =
@@ -38,6 +41,27 @@ export interface PreviousAgentAssignment extends PreviousAssignment {
 }
 
 export interface CodexIntegrationJournal {
+  version: 9;
+  active: boolean;
+  configPath: string;
+  installed: {
+    openai_base_url: string;
+    experimental_realtime_webrtc_call_base_url: string;
+    subagent_protocol: SubagentProtocol;
+    agent_max_depth?: number;
+  };
+  previous: Record<ManagedAssignmentKey, PreviousAssignment>;
+  previousRealtimeWebrtcCallBaseUrl: PreviousAssignment;
+  previousMultiAgent?: PreviousFeatureAssignment;
+  previousMultiAgentV2?: PreviousFeatureAssignment;
+  previousAgentMaxDepth?: PreviousAgentAssignment;
+  format?: {
+    lineEnding: "\n" | "\r\n";
+    trailingNewline: boolean;
+  };
+}
+
+export interface LegacyCodexIntegrationJournalV8 {
   version: 8;
   active: boolean;
   configPath: string;
@@ -153,6 +177,7 @@ export interface LegacyCodexIntegrationJournal {
 
 export type ManagedRouteJournal =
   | CodexIntegrationJournal
+  | LegacyCodexIntegrationJournalV8
   | LegacyCodexIntegrationJournalV7
   | LegacyCodexIntegrationJournalV6
   | LegacyCodexIntegrationJournalV5

--- a/src/codex-integration.ts
+++ b/src/codex-integration.ts
@@ -3,6 +3,7 @@ import { dirname } from "node:path";
 import type { AppConfig } from "./config";
 import { atomicWriteFile, getConfigPath, saveConfig } from "./config";
 import {
+  CODEX_REALTIME_WEBRTC_CALL_BASE_URL,
   getCodexConfigPath,
   getCodexJournalPath,
   getCodexJournalRecoveryPath,
@@ -21,6 +22,7 @@ import type {
   LegacyCodexIntegrationJournalV5,
   LegacyCodexIntegrationJournalV6,
   LegacyCodexIntegrationJournalV7,
+  LegacyCodexIntegrationJournalV8,
   SetCodexIntegrationActiveResult,
   UninstallCodexIntegrationResult,
 } from "./codex-integration-shared";
@@ -33,6 +35,7 @@ import {
 } from "./codex-integration-document";
 import {
   assertPreservedPreviousAssignments,
+  assertRealtimeRouteCanBeReplaced,
   installRoute,
   managedJournalIsActive,
   replacementBaseline,
@@ -51,17 +54,24 @@ function installConfiguredRoute(
 ): {
   text: string;
   previous: CodexIntegrationJournal["previous"];
+  previousRealtimeWebrtcCallBaseUrl: CodexIntegrationJournal["previousRealtimeWebrtcCallBaseUrl"];
   previousMultiAgent?: CodexIntegrationJournal["previousMultiAgent"];
   previousMultiAgentV2?: CodexIntegrationJournal["previousMultiAgentV2"];
   previousAgentMaxDepth?: CodexIntegrationJournal["previousAgentMaxDepth"];
   installedAgentMaxDepth?: number;
 } {
-  const route = installRoute(baseline, installedUrl, replaceExistingRoute);
+  const route = installRoute(
+    baseline,
+    installedUrl,
+    CODEX_REALTIME_WEBRTC_CALL_BASE_URL,
+    replaceExistingRoute,
+  );
   if (config.subagentProtocol !== "compatibility-v1") return route;
   const features = installCompatibilityV1Features(route.text);
   return {
     text: features.text,
     previous: route.previous,
+    previousRealtimeWebrtcCallBaseUrl: route.previousRealtimeWebrtcCallBaseUrl,
     previousMultiAgent: features.previousMultiAgent,
     previousMultiAgentV2: features.previousMultiAgentV2,
     previousAgentMaxDepth: features.previousAgentMaxDepth,
@@ -70,7 +80,7 @@ function installConfiguredRoute(
 }
 
 function journalProtocol(journal: Exclude<AnyCodexIntegrationJournal, { version: 2 }>): AppConfig["subagentProtocol"] {
-  return journal.version === 8 ? journal.installed.subagent_protocol : "native";
+  return journal.version === 8 || journal.version === 9 ? journal.installed.subagent_protocol : "native";
 }
 
 export {
@@ -93,7 +103,7 @@ export function readCodexSubagentProtocol(
   fallback: AppConfig["subagentProtocol"] = "compatibility-v1",
 ): AppConfig["subagentProtocol"] {
   const journal = readJournal();
-  return journal?.version === 8 ? journal.installed.subagent_protocol : fallback;
+  return journal?.version === 8 || journal?.version === 9 ? journal.installed.subagent_protocol : fallback;
 }
 
 export function setCodexSubagentProtocol(
@@ -148,7 +158,14 @@ export function preflightCodexIntegration(
   const existing = readJournal();
   const installedUrl = routeUrl(config);
   if (existing) assertJournalTargetsConfig(existing, configPath);
-  if (existing?.version === 3 || existing?.version === 4 || existing?.version === 5 || existing?.version === 6 || existing?.version === 7 || existing?.version === 8) {
+  if (existing?.version === 3 || existing?.version === 4 || existing?.version === 5 || existing?.version === 6 || existing?.version === 7 || existing?.version === 8 || existing?.version === 9) {
+    if (existing.version !== 9) {
+      assertRealtimeRouteCanBeReplaced(
+        currentText,
+        CODEX_REALTIME_WEBRTC_CALL_BASE_URL,
+        options.replaceExistingRoute === true,
+      );
+    }
     if (!configExists) {
       if (options.replaceExistingRoute !== true) {
         throw new Error(`Codex config is missing: ${configPath}`);
@@ -195,7 +212,15 @@ export function installCodexIntegration(
     || existing?.version === 5
     || existing?.version === 6
     || existing?.version === 7
-    || existing?.version === 8;
+    || existing?.version === 8
+    || existing?.version === 9;
+  if (hasManagedJournal && existing.version !== 9) {
+    assertRealtimeRouteCanBeReplaced(
+      currentText,
+      CODEX_REALTIME_WEBRTC_CALL_BASE_URL,
+      options.replaceExistingRoute === true,
+    );
+  }
   if (hasManagedJournal && !configExists && options.replaceExistingRoute !== true) {
     throw new Error(`Codex config is missing: ${configPath}`);
   }
@@ -215,20 +240,29 @@ export function installCodexIntegration(
     }
     const patched = installConfiguredRoute(baseline, installedUrl, config, true);
     if (preservePrevious) {
-      assertPreservedPreviousAssignments(patched.previous, existing.previous);
+      assertPreservedPreviousAssignments(
+        patched.previous,
+        existing.previous,
+        patched.previousRealtimeWebrtcCallBaseUrl,
+        existing.version === 9 ? existing.previousRealtimeWebrtcCallBaseUrl : undefined,
+      );
     }
     const updated: CodexIntegrationJournal = {
-      version: 8,
+      version: 9,
       active: true,
       configPath,
       installed: {
         openai_base_url: installedUrl,
+        experimental_realtime_webrtc_call_base_url: CODEX_REALTIME_WEBRTC_CALL_BASE_URL,
         subagent_protocol: config.subagentProtocol,
         ...(config.subagentProtocol === "compatibility-v1" ? {
           agent_max_depth: patched.installedAgentMaxDepth,
         } : {}),
       },
       previous: preservePrevious ? existing.previous : patched.previous,
+      previousRealtimeWebrtcCallBaseUrl: preservePrevious && existing.version === 9
+        ? existing.previousRealtimeWebrtcCallBaseUrl
+        : patched.previousRealtimeWebrtcCallBaseUrl,
       ...(config.subagentProtocol === "compatibility-v1" ? {
         previousMultiAgent: patched.previousMultiAgent,
         previousMultiAgentV2: patched.previousMultiAgentV2,
@@ -249,17 +283,19 @@ export function installCodexIntegration(
   }
   const patched = installConfiguredRoute(baseline, installedUrl, config, options.replaceExistingRoute === true);
   const journal: CodexIntegrationJournal = {
-    version: 8,
+    version: 9,
     active: true,
     configPath,
     installed: {
       openai_base_url: installedUrl,
+      experimental_realtime_webrtc_call_base_url: CODEX_REALTIME_WEBRTC_CALL_BASE_URL,
       subagent_protocol: config.subagentProtocol,
       ...(config.subagentProtocol === "compatibility-v1" ? {
         agent_max_depth: patched.installedAgentMaxDepth,
       } : {}),
     },
     previous: patched.previous,
+    previousRealtimeWebrtcCallBaseUrl: patched.previousRealtimeWebrtcCallBaseUrl,
     ...(config.subagentProtocol === "compatibility-v1" ? {
       previousMultiAgent: patched.previousMultiAgent,
       previousMultiAgentV2: patched.previousMultiAgentV2,
@@ -281,18 +317,19 @@ export function deactivateCodexIntegration(): SetCodexIntegrationActiveResult {
   assertJournalTargetsConfig(existing, getCodexConfigPath());
   if (!existsSync(existing.configPath)) throw new Error(`Codex config is missing: ${existing.configPath}`);
   const current = readFileSync(existing.configPath, "utf8");
-  if ((existing.version === 4 || existing.version === 5 || existing.version === 6 || existing.version === 7 || existing.version === 8) && !existing.active) {
+  if ((existing.version === 4 || existing.version === 5 || existing.version === 6 || existing.version === 7 || existing.version === 8 || existing.version === 9) && !existing.active) {
     verifyRestoredRoute(current, existing);
     return { changed: false, active: false };
   }
   const restored = restoreManagedRoute(current, existing);
   const disconnected:
     | CodexIntegrationJournal
+    | LegacyCodexIntegrationJournalV8
     | LegacyCodexIntegrationJournalV6
     | LegacyCodexIntegrationJournalV7
     | LegacyCodexIntegrationJournalV5
     | LegacyCodexIntegrationJournalV4 = existing.version === 6 || existing.version === 5
-      || existing.version === 7 || existing.version === 8
+      || existing.version === 7 || existing.version === 8 || existing.version === 9
       ? { ...existing, active: false }
       : { ...existing, version: 4, active: false };
   writeIntegrationState(disconnected, { path: existing.configPath, data: restored }, [getCodexModelsCachePath()]);
@@ -308,12 +345,15 @@ export function activateCodexIntegration(): SetCodexIntegrationActiveResult {
   assertJournalTargetsConfig(existing, getCodexConfigPath());
   if (!existsSync(existing.configPath)) throw new Error(`Codex config is missing: ${existing.configPath}`);
   const current = readFileSync(existing.configPath, "utf8");
-  if (existing.version === 8 && existing.active) {
+  if (existing.version !== 9) {
+    assertRealtimeRouteCanBeReplaced(current, CODEX_REALTIME_WEBRTC_CALL_BASE_URL, false);
+  }
+  if (existing.version === 9 && existing.active) {
     verifyInstalledRoute(current, existing);
     return { changed: false, active: true };
   }
   let baseline: string;
-  if ((existing.version === 4 || existing.version === 5 || existing.version === 6 || existing.version === 7 || existing.version === 8) && !existing.active) {
+  if ((existing.version === 4 || existing.version === 5 || existing.version === 6 || existing.version === 7 || existing.version === 8 || existing.version === 9) && !existing.active) {
     verifyRestoredRoute(current, existing);
     baseline = current;
   } else {
@@ -327,20 +367,29 @@ export function activateCodexIntegration(): SetCodexIntegrationActiveResult {
     { subagentProtocol: protocol },
     true,
   );
-  assertPreservedPreviousAssignments(route.previous, existing.previous);
+  assertPreservedPreviousAssignments(
+    route.previous,
+    existing.previous,
+    route.previousRealtimeWebrtcCallBaseUrl,
+    existing.version === 9 ? existing.previousRealtimeWebrtcCallBaseUrl : undefined,
+  );
   const connected: CodexIntegrationJournal = {
-    version: 8,
+    version: 9,
     active: true,
     configPath: existing.configPath,
     installed: {
       openai_base_url: existing.installed.openai_base_url,
+      experimental_realtime_webrtc_call_base_url: CODEX_REALTIME_WEBRTC_CALL_BASE_URL,
       subagent_protocol: protocol,
-      ...(protocol === "compatibility-v1" && existing.version === 8 ? {
+      ...(protocol === "compatibility-v1" && (existing.version === 8 || existing.version === 9) ? {
         agent_max_depth: existing.installed.agent_max_depth,
       } : {}),
     },
     previous: existing.previous,
-    ...(protocol === "compatibility-v1" && existing.version === 8 ? {
+    previousRealtimeWebrtcCallBaseUrl: existing.version === 9
+      ? existing.previousRealtimeWebrtcCallBaseUrl
+      : route.previousRealtimeWebrtcCallBaseUrl,
+    ...(protocol === "compatibility-v1" && (existing.version === 8 || existing.version === 9) ? {
       previousMultiAgent: existing.previousMultiAgent,
       previousMultiAgentV2: existing.previousMultiAgentV2,
       previousAgentMaxDepth: existing.previousAgentMaxDepth,
@@ -362,7 +411,7 @@ export function uninstallCodexIntegration(): UninstallCodexIntegrationResult {
       throw new Error(`Managed legacy catalog changed after setup: ${journal.catalogPath}`);
     }
     restored = restoreLegacyV2(current, journal);
-  } else if ((journal.version === 4 || journal.version === 5 || journal.version === 6 || journal.version === 7 || journal.version === 8) && !journal.active) {
+  } else if ((journal.version === 4 || journal.version === 5 || journal.version === 6 || journal.version === 7 || journal.version === 8 || journal.version === 9) && !journal.active) {
     verifyRestoredRoute(current, journal);
     restored = current;
   } else {
@@ -411,10 +460,10 @@ export function inspectCodexIntegration(): {
     try {
       assertJournalTargetsConfig(journal, getCodexConfigPath());
       const text = readFileSync(journal.configPath, "utf8");
-      if ((journal.version === 4 || journal.version === 5 || journal.version === 6 || journal.version === 7 || journal.version === 8) && !journal.active) {
+      if ((journal.version === 4 || journal.version === 5 || journal.version === 6 || journal.version === 7 || journal.version === 8 || journal.version === 9) && !journal.active) {
         verifyRestoredRoute(text, journal);
       }
-      else if (journal.version === 3 || journal.version === 4 || journal.version === 5 || journal.version === 6 || journal.version === 7 || journal.version === 8) {
+      else if (journal.version === 3 || journal.version === 4 || journal.version === 5 || journal.version === 6 || journal.version === 7 || journal.version === 8 || journal.version === 9) {
         verifyInstalledRoute(text, journal);
       }
       else {
@@ -432,11 +481,11 @@ export function inspectCodexIntegration(): {
   }
   return {
     installed: Boolean(journal),
-    active: journal?.version === 4 || journal?.version === 5 || journal?.version === 6 || journal?.version === 7 || journal?.version === 8
+    active: journal?.version === 4 || journal?.version === 5 || journal?.version === 6 || journal?.version === 7 || journal?.version === 8 || journal?.version === 9
       ? journal.active
       : Boolean(journal),
     configPath: getCodexConfigPath(),
-    ...(journal?.version === 3 || journal?.version === 4 || journal?.version === 5 || journal?.version === 6 || journal?.version === 7 || journal?.version === 8
+    ...(journal?.version === 3 || journal?.version === 4 || journal?.version === 5 || journal?.version === 6 || journal?.version === 7 || journal?.version === 8 || journal?.version === 9
       ? { routeUrl: journal.installed.openai_base_url }
       : {}),
     ...(journal ? { journal } : {}),

--- a/tests/codex-integration.test.ts
+++ b/tests/codex-integration.test.ts
@@ -18,8 +18,11 @@ import {
   uninstallCodexIntegration,
 } from "../src/codex-integration";
 import { defaultConfig, loadConfig, saveConfig } from "../src/config";
+import { assertRealtimeRouteCanBeReplaced } from "../src/codex-integration-route";
 import {
+  MANAGED_COMMENT,
   MANAGED_MULTI_AGENT_V2_LINE,
+  MANAGED_ROUTE_COMMENT,
   managedAgentMaxDepthLine,
 } from "../src/codex-integration-shared";
 
@@ -35,6 +38,27 @@ function compatibilityV1Config(mode: "browser-only" | "full") {
   const config = defaultConfig(mode);
   config.subagentProtocol = "compatibility-v1";
   return config;
+}
+
+function downgradeActiveIntegrationToV8(
+  configPath: string,
+  unownedRealtimeLine: string,
+): { config: string; journal: string } {
+  const journal = JSON.parse(readFileSync(getCodexJournalPath(), "utf8"));
+  journal.version = 8;
+  delete journal.installed.experimental_realtime_webrtc_call_base_url;
+  delete journal.previousRealtimeWebrtcCallBaseUrl;
+  const journalText = `${JSON.stringify(journal, null, 2)}\n`;
+  const config = readFileSync(configPath, "utf8")
+    .replace(MANAGED_ROUTE_COMMENT, MANAGED_COMMENT)
+    .replace(
+      'experimental_realtime_webrtc_call_base_url = "https://chatgpt.com/backend-api/codex"',
+      unownedRealtimeLine,
+    );
+  writeFileSync(configPath, config);
+  writeFileSync(getCodexJournalPath(), journalText);
+  writeFileSync(getCodexJournalRecoveryPath(), journalText);
+  return { config, journal: journalText };
 }
 
 function fixture(): { root: string; codexHome: string; appHome: string } {
@@ -84,8 +108,13 @@ describe("reversible native Codex route integration", () => {
 
     const journal = installCodexIntegration(nativeConfig("browser-only"));
     const installed = readFileSync(configPath, "utf8");
-    expect(journal.version).toBe(8);
+    expect(journal.version).toBe(9);
     expect(installed).toContain('openai_base_url = "http://127.0.0.1:17841/v1"');
+    expect(installed).toContain(
+      'experimental_realtime_webrtc_call_base_url = "https://chatgpt.com/backend-api/codex"',
+    );
+    expect(installed.match(/^experimental_realtime_webrtc_call_base_url\s*=/gm)).toHaveLength(1);
+    expect(journal.previousRealtimeWebrtcCallBaseUrl).toEqual({ present: false });
     expect(installed).not.toContain("remote_compaction_v2");
     expect(installed).toContain("multi_agent = false # user choice");
     expect(installed).not.toContain("multi_agent_v2");
@@ -123,6 +152,7 @@ describe("reversible native Codex route integration", () => {
     expect(installed).toContain("multi_agent_v2 = true # native choice");
     expect(journal.installed).toEqual({
       openai_base_url: "http://127.0.0.1:17841/v1",
+      experimental_realtime_webrtc_call_base_url: "https://chatgpt.com/backend-api/codex",
       subagent_protocol: "native",
     });
 
@@ -147,7 +177,7 @@ describe("reversible native Codex route integration", () => {
     const journal = installCodexIntegration(compatibilityV1Config("browser-only"));
     const installed = readFileSync(configPath, "utf8");
     expect(journal).toMatchObject({
-      version: 8,
+      version: 9,
       installed: { subagent_protocol: "compatibility-v1", agent_max_depth: 2 },
       previousMultiAgent: { rawLine: "multi_agent = false # user choice", value: "false" },
       previousMultiAgentV2: { rawLine: "multi_agent_v2 = true # user choice", value: "true" },
@@ -249,6 +279,24 @@ describe("reversible native Codex route integration", () => {
 
     expect(() => uninstallCodexIntegration()).toThrow("max_depth changed after Compatibility V1 setup");
     expect(readFileSync(configPath, "utf8")).toBe(edited);
+  });
+
+  test("refuses to overwrite a newer realtime call route edit while active", () => {
+    const { codexHome } = fixture();
+    const configPath = join(codexHome, "config.toml");
+    writeFileSync(configPath, 'model = "gpt-5.6-sol"\n');
+    installCodexIntegration(nativeConfig("browser-only"));
+    const journalBefore = readFileSync(getCodexJournalPath(), "utf8");
+    const edited = readFileSync(configPath, "utf8").replace(
+      'experimental_realtime_webrtc_call_base_url = "https://chatgpt.com/backend-api/codex"',
+      'experimental_realtime_webrtc_call_base_url = "https://realtime.example/new"',
+    );
+    writeFileSync(configPath, edited);
+
+    expect(() => uninstallCodexIntegration())
+      .toThrow("experimental_realtime_webrtc_call_base_url changed after setup");
+    expect(readFileSync(configPath, "utf8")).toBe(edited);
+    expect(readFileSync(getCodexJournalPath(), "utf8")).toBe(journalBefore);
   });
 
   test("restores a missing primary journal from its exact recovery copy", () => {
@@ -417,7 +465,7 @@ describe("reversible native Codex route integration", () => {
     expect(readFileSync(configPath, "utf8")).toBe(original);
   });
 
-  test("owns only openai_base_url while active", () => {
+  test("owns only its route overrides while active", () => {
     const { codexHome } = fixture();
     const configPath = join(codexHome, "config.toml");
     const original = [
@@ -459,6 +507,35 @@ describe("reversible native Codex route integration", () => {
     expect(() => readFileSync(getCodexJournalPath(), "utf8")).toThrow();
   });
 
+  test("requires explicit replacement for a custom realtime call route", () => {
+    const { codexHome } = fixture();
+    const configPath = join(codexHome, "config.toml");
+    const original = [
+      'model = "gpt-5.6-sol"',
+      'experimental_realtime_webrtc_call_base_url = "https://realtime.example/v1" # user choice',
+      "",
+    ].join("\n");
+    writeFileSync(configPath, original);
+
+    expect(() => preflightCodexIntegration(nativeConfig("browser-only")))
+      .toThrow(/experimental_realtime_webrtc_call_base_url.*--replace-codex-route/s);
+    expect(readFileSync(configPath, "utf8")).toBe(original);
+    expect(existsSync(getCodexJournalPath())).toBe(false);
+  });
+
+  test("detects a custom realtime call route in a CR-only config", () => {
+    const text = [
+      'model = "gpt-5.6-sol"',
+      'experimental_realtime_webrtc_call_base_url = "https://realtime.example/cr"',
+      "",
+    ].join("\r");
+    expect(() => assertRealtimeRouteCanBeReplaced(
+      text,
+      "https://chatgpt.com/backend-api/codex",
+      false,
+    )).toThrow("--replace-codex-route");
+  });
+
   test("updates its own route idempotently without changing the preserved baseline", () => {
     const { codexHome } = fixture();
     const configPath = join(codexHome, "config.toml");
@@ -468,7 +545,9 @@ describe("reversible native Codex route integration", () => {
     const second = nativeConfig("browser-only");
     second.port = 17842;
     installCodexIntegration(second);
-    expect(readFileSync(configPath, "utf8")).toContain('openai_base_url = "http://127.0.0.1:17842/v1"');
+    const updated = readFileSync(configPath, "utf8");
+    expect(updated).toContain('openai_base_url = "http://127.0.0.1:17842/v1"');
+    expect(updated.match(/^experimental_realtime_webrtc_call_base_url\s*=/gm)).toHaveLength(1);
     uninstallCodexIntegration();
     expect(readFileSync(configPath, "utf8")).toBe('model = "gpt-5.6-sol"\n');
   });
@@ -476,10 +555,23 @@ describe("reversible native Codex route integration", () => {
   test("disconnects and reconnects the bridge without losing the prior route or journal", () => {
     const { codexHome } = fixture();
     const configPath = join(codexHome, "config.toml");
-    const original = 'model = "gpt-5.6-sol"\napproval_policy = "never"\nopenai_base_url = "https://native.example/v1"\n';
+    const original = [
+      'model = "gpt-5.6-sol"',
+      'approval_policy = "never"',
+      'openai_base_url = "https://native.example/v1"',
+      'experimental_realtime_webrtc_call_base_url = "https://realtime.example/v1" # user choice',
+      "",
+    ].join("\n");
     writeFileSync(configPath, original);
 
-    installCodexIntegration(nativeConfig("browser-only"), { replaceExistingRoute: true });
+    const journal = installCodexIntegration(nativeConfig("browser-only"), { replaceExistingRoute: true });
+    expect(journal.previousRealtimeWebrtcCallBaseUrl).toMatchObject({
+      present: true,
+      rawLine: 'experimental_realtime_webrtc_call_base_url = "https://realtime.example/v1" # user choice',
+    });
+    expect(readFileSync(configPath, "utf8")).toContain(
+      'experimental_realtime_webrtc_call_base_url = "https://chatgpt.com/backend-api/codex"',
+    );
     expect(deactivateCodexIntegration()).toEqual({ changed: true, active: false });
     expect(readFileSync(configPath, "utf8")).toBe(original);
     expect(inspectCodexIntegration()).toMatchObject({ installed: true, active: false });
@@ -488,6 +580,9 @@ describe("reversible native Codex route integration", () => {
     expect(activateCodexIntegration()).toEqual({ changed: true, active: true });
     const reconnected = readFileSync(configPath, "utf8");
     expect(reconnected).toContain('openai_base_url = "http://127.0.0.1:17841/v1"');
+    expect(reconnected).toContain(
+      'experimental_realtime_webrtc_call_base_url = "https://chatgpt.com/backend-api/codex"',
+    );
     expect(reconnected).not.toContain("remote_compaction_v2");
     expect(reconnected).not.toContain("multi_agent");
     expect(reconnected).toContain('approval_policy = "never"');
@@ -498,6 +593,25 @@ describe("reversible native Codex route integration", () => {
     expect(readFileSync(configPath, "utf8")).toBe(original);
   });
 
+  test("refuses to replace a newer realtime call route edit while disconnected", () => {
+    const { codexHome } = fixture();
+    const configPath = join(codexHome, "config.toml");
+    const original = [
+      'model = "gpt-5.6-sol"',
+      'experimental_realtime_webrtc_call_base_url = "https://realtime.example/old"',
+      "",
+    ].join("\n");
+    writeFileSync(configPath, original);
+    installCodexIntegration(nativeConfig("browser-only"), { replaceExistingRoute: true });
+    deactivateCodexIntegration();
+    const edited = original.replace("https://realtime.example/old", "https://realtime.example/new");
+    writeFileSync(configPath, edited);
+
+    expect(() => activateCodexIntegration())
+      .toThrow("experimental_realtime_webrtc_call_base_url changed while the bridge was disconnected");
+    expect(readFileSync(configPath, "utf8")).toBe(edited);
+  });
+
   test("keeps a disconnected bridge disabled across process-style journal reloads", () => {
     const { codexHome } = fixture();
     const configPath = join(codexHome, "config.toml");
@@ -506,7 +620,7 @@ describe("reversible native Codex route integration", () => {
     deactivateCodexIntegration();
 
     expect(JSON.parse(readFileSync(getCodexJournalPath(), "utf8"))).toMatchObject({
-      version: 8,
+      version: 9,
       active: false,
     });
     expect(inspectCodexIntegration()).toMatchObject({ installed: true, active: false, errors: [] });
@@ -521,6 +635,8 @@ describe("reversible native Codex route integration", () => {
     installCodexIntegration(nativeConfig("browser-only"));
     const previous = JSON.parse(readFileSync(getCodexJournalPath(), "utf8"));
     const legacyInstalled = readFileSync(configPath, "utf8")
+      .replace(MANAGED_ROUTE_COMMENT, MANAGED_COMMENT)
+      .replace(/^experimental_realtime_webrtc_call_base_url\s*=.*\n/gm, "")
       .replace(/^(?:remote_compaction_v2 = false|multi_agent = true|multi_agent_v2 = false).*\n/gm, "");
     writeFileSync(configPath, legacyInstalled);
     delete previous.active;
@@ -530,6 +646,8 @@ describe("reversible native Codex route integration", () => {
     delete previous.installed.remote_compaction_v2;
     delete previous.installed.multi_agent;
     delete previous.installed.multi_agent_v2;
+    delete previous.installed.experimental_realtime_webrtc_call_base_url;
+    delete previous.previousRealtimeWebrtcCallBaseUrl;
     previous.version = 3;
     const legacyJournal = `${JSON.stringify(previous, null, 2)}\n`;
     writeFileSync(getCodexJournalPath(), legacyJournal);
@@ -555,6 +673,8 @@ describe("reversible native Codex route integration", () => {
     delete legacy.installed.remote_compaction_v2;
     delete legacy.installed.multi_agent;
     delete legacy.installed.multi_agent_v2;
+    delete legacy.installed.experimental_realtime_webrtc_call_base_url;
+    delete legacy.previousRealtimeWebrtcCallBaseUrl;
     legacy.version = 4;
     const legacyJournal = `${JSON.stringify(legacy, null, 2)}\n`;
     writeFileSync(getCodexJournalPath(), legacyJournal);
@@ -562,14 +682,83 @@ describe("reversible native Codex route integration", () => {
     writeFileSync(
       configPath,
       readFileSync(configPath, "utf8")
+        .replace(MANAGED_ROUTE_COMMENT, MANAGED_COMMENT)
+        .replace(/^experimental_realtime_webrtc_call_base_url\s*=.*\n/gm, "")
         .replace(/^(?:remote_compaction_v2 = false|multi_agent = true|multi_agent_v2 = false).*\n/gm, ""),
     );
 
     const upgraded = installCodexIntegration(nativeConfig("browser-only"));
-    expect(upgraded.version).toBe(8);
+    expect(upgraded.version).toBe(9);
     expect(readFileSync(configPath, "utf8")).toContain("goals = true");
     expect(readFileSync(configPath, "utf8")).not.toContain("remote_compaction_v2");
     expect(readFileSync(configPath, "utf8")).not.toContain("multi_agent");
+  });
+
+  test("upgrades an active v8 journal while preserving a manual Voice route", () => {
+    const { codexHome } = fixture();
+    const configPath = join(codexHome, "config.toml");
+    const manualRealtimeLine =
+      'experimental_realtime_webrtc_call_base_url = "https://chatgpt.com/backend-api/codex" # manual workaround';
+    const original = ['model = "gpt-5.6-sol"', manualRealtimeLine, ""].join("\n");
+    writeFileSync(configPath, original);
+    installCodexIntegration(nativeConfig("browser-only"));
+
+    const v8 = downgradeActiveIntegrationToV8(configPath, manualRealtimeLine);
+
+    const upgraded = installCodexIntegration(nativeConfig("browser-only"));
+    expect(upgraded).toMatchObject({
+      version: 9,
+      previousRealtimeWebrtcCallBaseUrl: {
+        present: true,
+        rawLine: manualRealtimeLine,
+      },
+    });
+    const v9Config = readFileSync(configPath, "utf8");
+    const v9Journal = readFileSync(getCodexJournalRecoveryPath(), "utf8");
+    expect(v9Config).toContain(MANAGED_ROUTE_COMMENT);
+    expect(v9Config).not.toContain(MANAGED_COMMENT);
+
+    // Recovery intent and config reached disk, but primary still describes the old v8 route.
+    writeFileSync(getCodexJournalPath(), v8.journal);
+    expect(inspectCodexIntegration()).toMatchObject({ installed: true, active: true, errors: [] });
+    expect(readFileSync(getCodexJournalPath(), "utf8")).toBe(v9Journal);
+
+    uninstallCodexIntegration();
+    expect(readFileSync(configPath, "utf8")).toBe(original);
+  });
+
+  test("requires explicit replacement for an unowned custom Voice route during v8 upgrade", () => {
+    const { codexHome } = fixture();
+    const configPath = join(codexHome, "config.toml");
+    const customRealtimeLine =
+      'experimental_realtime_webrtc_call_base_url = "https://realtime.example/v8" # user choice';
+    const original = ['model = "gpt-5.6-sol"', customRealtimeLine, ""].join("\n");
+    writeFileSync(configPath, original);
+    installCodexIntegration(nativeConfig("browser-only"), { replaceExistingRoute: true });
+    const v8 = downgradeActiveIntegrationToV8(configPath, customRealtimeLine);
+
+    expect(() => preflightCodexIntegration(nativeConfig("browser-only")))
+      .toThrow(/experimental_realtime_webrtc_call_base_url.*--replace-codex-route/s);
+    expect(() => installCodexIntegration(nativeConfig("browser-only")))
+      .toThrow(/experimental_realtime_webrtc_call_base_url.*--replace-codex-route/s);
+    expect(readFileSync(configPath, "utf8")).toBe(v8.config);
+    expect(readFileSync(getCodexJournalPath(), "utf8")).toBe(v8.journal);
+
+    expect(deactivateCodexIntegration()).toEqual({ changed: true, active: false });
+    const inactiveJournal = readFileSync(getCodexJournalPath(), "utf8");
+    expect(readFileSync(configPath, "utf8")).toBe(original);
+    expect(() => activateCodexIntegration())
+      .toThrow(/experimental_realtime_webrtc_call_base_url.*--replace-codex-route/s);
+    expect(readFileSync(configPath, "utf8")).toBe(original);
+    expect(readFileSync(getCodexJournalPath(), "utf8")).toBe(inactiveJournal);
+
+    const upgraded = installCodexIntegration(
+      nativeConfig("browser-only"),
+      { replaceExistingRoute: true },
+    );
+    expect(upgraded.previousRealtimeWebrtcCallBaseUrl.rawLine).toBe(customRealtimeLine);
+    uninstallCodexIntegration();
+    expect(readFileSync(configPath, "utf8")).toBe(original);
   });
 
 });


### PR DESCRIPTION
## What this changes

- keeps normal Responses traffic on the local bridge while routing Codex HTTP WebRTC call creation through the ChatGPT backend;
- journals and restores the dedicated realtime override with v3-v8 migration and fail-closed ownership checks;
- adds focused regression coverage and updates the CLI help and architecture documentation.

Fixes #258.

Related to #252.

## Evidence

### Before

The installed v4.0.7 integration managed:

```toml
openai_base_url = "http://127.0.0.1:17841/v1"
```

Normal Responses requests worked, but starting Codex Voice produced:

```text
POST http://127.0.0.1:17841/v1/live
404 Not Found
```

The request reached the local Responses bridge, which has no HTTP WebRTC call-creation handler, and Voice did not start.

### After

A configuration-level canary added only:

```toml
experimental_realtime_webrtc_call_base_url = "https://chatgpt.com/backend-api/codex"
```

Codex Voice then started while normal Responses routing remained on the local bridge. The reporter asked that this now-working local installation remain unchanged, so the submitted commit was not installed over it. The code path that installs the same assignment and its complete setup/disconnect/reconnect/uninstall lifecycle is covered by the focused automated tests below.

### Scope of the evidence

This evidence identifies the HTTP call-creation route as the reproduced failure. It does not claim to resolve microphone permissions, account entitlement, audio-device failures, or every realtime/WebSocket mode.

## Source review and root cause

Codex exposes an override for only the HTTP WebRTC call-creation base, separately from its realtime WebSocket setting:

- [`experimental_realtime_webrtc_call_base_url`](https://github.com/openai/codex/blob/d58d0e5841e0de08e251673db2d5af8cf3a1ad51/codex-rs/config/src/config_toml.rs#L400-L404)

Its realtime call client selects the ChatGPT backend request shape when the base contains `/backend-api`; otherwise a Frameless session can select the multipart `/live` path:

- [Call path and backend-shape selection](https://github.com/openai/codex/blob/d58d0e5841e0de08e251673db2d5af8cf3a1ad51/codex-rs/codex-api/src/endpoint/realtime_call.rs#L59-L79)
- [Backend JSON versus multipart request construction](https://github.com/openai/codex/blob/d58d0e5841e0de08e251673db2d5af8cf3a1ad51/codex-rs/codex-api/src/endpoint/realtime_call.rs#L137-L202)

The integration changed the shared provider base through `openai_base_url` but did not manage the scoped HTTP call-creation base. Voice therefore inherited the local URL and emitted a request the daemon does not implement.

## Chosen resolution

Setup now manages this scoped assignment alongside `openai_base_url`:

```toml
experimental_realtime_webrtc_call_base_url = "https://chatgpt.com/backend-api/codex"
```

This keeps Responses on the bridge while current Codex builds use their native ChatGPT backend request shape for WebRTC call creation.

The alternative considered was implementing HTTP `/v1/live` in the daemon. That would add multipart-to-backend translation plus SDP, authentication, query, `Location`, and error-semantic coupling. The existing scoped Codex setting avoids that proxy surface, so this PR does not modify `src/server.ts` or add an HTTP `/v1/live` handler.

## Implementation and rollback behavior

- the current route journal moves to v9 while retaining strict v8 parsing and older-journal migration;
- the original realtime assignment is recorded independently, including its presence and exact source line/comment;
- a versioned managed marker distinguishes v8 and v9 physical states during recovery-journal crash windows;
- disconnect and uninstall restore the captured assignment, or remove the managed line when none existed;
- repeated setup remains idempotent and preserves the first owned baseline;
- an identical manual workaround is accepted without duplication and restored on uninstall;
- a different custom value remains user-owned unless `--replace-codex-route` is explicit;
- active and disconnected edits are detected and fail closed rather than being overwritten;
- v3-v8 upgrades preflight unowned realtime values before migration;
- conflict detection uses parsed document lines and covers CR-only, LF, and CRLF input;
- CLI help and architecture documentation describe both managed route overrides.

| Starting state | Result |
| --- | --- |
| No realtime override | Add the managed value; remove it on disconnect/uninstall |
| Existing identical ChatGPT value | Preserve its exact original line/comment for restoration |
| Existing different custom value | Stop before writing unless explicit replacement is requested |
| Active managed value edited later | Stop before disconnect/uninstall overwrites it |
| Disconnected restored value edited later | Stop before reconnect overwrites it |
| v3-v8 journal with no owned realtime value | Preflight ownership, capture the current baseline, then migrate |
| Repeated v9 setup | Do not duplicate the assignment or replace the original baseline |

## Related work

#252 handles WebSocket Upgrade traffic received at `/v1/live`. The reproduced failure here is an HTTP `POST /v1/live` caused by WebRTC call creation inheriting `openai_base_url`. #252's proposed handler returns 426 for non-WebSocket requests, so it does not address this reproduction.

This PR instead manages `experimental_realtime_webrtc_call_base_url`. It neither implements nor depends on #252's WebSocket relay; that separate transport proposal can be evaluated independently.

## Reviews performed

- **Contribution and duplicate review:** checked `CONTRIBUTING.md`, the current Issue/PR templates, existing Issues, and open PRs before finalizing the submission.
- **Official-source review:** traced the scoped config field, call-path selection, and backend-versus-multipart construction in Codex source.
- **Design review:** compared scoped configuration ownership with implementing an HTTP realtime proxy and selected the narrower existing Codex boundary.
- **Journal and recovery review:** checked v3-v9 parsing, baseline preservation, recovery-copy selection, reconnect, disconnect, uninstall, and rollback behavior.
- **Ownership review:** checked custom-value preflight, explicit replacement, active drift, disconnected drift, and idempotent reinstall behavior.
- **Document-format review:** checked exact-line restoration and conflict detection across CR-only, LF, and CRLF files.
- **Independent patch review:** found and fixed two issues before submission:
  1. legacy v3-v8 upgrade paths could otherwise take over an unowned custom realtime URL;
  2. a CR-only config could otherwise evade the custom-route conflict check.
- **Final patch review:** no remaining P0-P2 findings; `git diff --check` passed, and the submitted diff contains no credentials, raw logs, generated artifacts, or absolute user paths.

## Scope and invariants

- [x] I read and followed `CONTRIBUTING.md`.
- [x] This is a small, focused change with no unrelated cleanup or generated rewrite.
- [x] The change stays focused on ChatGPT web-backed Codex models; it does not add a generic provider or unrelated product surface.
- [x] Model, route, effort, connector, and capability selection remain explicit with no silent fallback or false-success path.
- [x] Full harness and MCP capabilities are unchanged; every available Web effort retains its existing turn-bound capability and Browser-only gains no broker or connector.
- [x] Terms and trademark claims remain factual; this change is not marketed as a quota or rate-limit bypass.

## Verification

- [x] I ran `bun install --frozen-lockfile` in the repository root and `launcher/` after rebasing onto the current `main`.
- [x] I ran `bun run verify` with Bun 1.4.0, the version pinned by `package.json`.
- [x] I added focused regression coverage for the behavior change.
- [x] I manually tested the affected configuration boundary: the scoped override restored Voice while the Responses bridge remained active.
- [x] Local tools, MCP execution, and the outer Codex agent loop are unchanged; their full existing test suites still pass.
- [x] ChatGPT browser UI handling is unchanged; no DOM selector or browser fixture was modified.
- [x] Launcher code and packaging are unchanged.
- [x] I did not commit browser state, credentials, Tunnel IDs, raw logs, generated artifacts, or private paths.
- [x] I did not include an unrelated dependency update, release artifact, or version change.

Commands and results:

- `bun install --frozen-lockfile` — root dependencies unchanged
- `cd launcher && bun install --frozen-lockfile` — launcher dependencies unchanged
- `bun test tests/codex-integration.test.ts` — 32 passed, 0 failed, 143 assertions
- `bun run verify`
  - root: 495 passed, 0 failed, 2,183 assertions
  - launcher: 226 total, 224 passed, 2 skipped, 0 failed
  - dependency audits, TypeScript checks, launcher build, runtime bundle, license checks, and relocatable-runtime smoke passed

The first local verification attempt before submission exposed one unrelated host-state condition: the developer machine has a launcher registered outside the default path expected by `tests/dev-profile.test.ts`. The final full gate was rerun with that registry lookup isolated, matching a clean CI host, and passed. No production registry entry or installed application was changed.

## Platform or account validation

| Item | Result |
| --- | --- |
| Platform | Windows x64 |
| OS | Windows 11 Home x64, build 26200 |
| Codex | Desktop 26.825.6671.0; `codex-cli 0.151.0` also present |
| Codex Web GPT | Installed release 4.0.7; patch rebased onto current `main` |
| ChatGPT account tier | Unknown; no tier-dependent claim is made |
| Integration mode | Full harness (MCP) |
| Affected-behavior canary | Scoped call-route override restored Voice while Responses routing remained active |
| Patched packaged build | Not run; the reporter requested that the now-working local installation remain unchanged |
| Browser-only | Not run |
| macOS | Not run |
| Linux | Not run |

## Known limitation

The Codex setting is currently named `experimental_realtime_webrtc_call_base_url`. This change targets Codex builds that expose and honor that setting; future Codex changes to this experimental surface may require follow-up work.
