### PR TITLE
fix: reopen effort menu with owned pointer fallback

### DIFF
--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -50,12 +50,13 @@ import {
   CHATGPT_COMPOSER_SELECTOR,
   CHATGPT_EFFORT_CONTROL_SELECTOR,
   CHATGPT_EFFORT_ITEM_SELECTOR,
-  CHATGPT_EFFORT_MENU_SELECTOR,
   CHATGPT_EFFORT_SLIDER_SELECTOR,
+  activateChatGptEffortMenu,
   CHATGPT_STOP_BUTTON_SELECTOR,
   CHATGPT_TEMPORARY_CHAT_URL,
   CHATGPT_USER_TURN_SELECTOR,
   detectChatGptAccountCapabilities,
+  chatGptEffortMenuForControl,
   parseChatGptEffortSliderState,
 } from "../../chatgpt-session";
 import { loginVerificationMarkerPath } from "../../browser-login";
@@ -1823,20 +1824,14 @@ export class ChatGptBrowserWorker {
     await settleChatGptUi();
     await throwIfChatGptRateLimitDialog(page);
     await captureDiagnostic?.("effort-control-ready");
-    const effortMenu = page.locator(CHATGPT_EFFORT_MENU_SELECTOR).last();
-    const menuVisible = await effortMenu.isVisible().catch(() => false);
-    const menuExpanded = await currentEffort.getAttribute("aria-expanded").catch(() => null);
-    if (!menuVisible && menuExpanded !== "true") {
-      await throwIfChatGptRateLimitDialog(page);
-      // ChatGPT's current Radix trigger no longer responds to synthetic Enter/Space on background
-      // Electron surfaces. Force only the exact, visible effort control; the menu/slider state
-      // below remains the authoritative postcondition, so this cannot become an unproved click.
-      await currentEffort.click({ force: true });
-    }
+    const effortMenu = await chatGptEffortMenuForControl(page, currentEffort);
+    const effortSlider = page.locator(CHATGPT_EFFORT_SLIDER_SELECTOR).filter({ visible: true }).last();
+    await throwIfChatGptRateLimitDialog(page);
+    const activation = await activateChatGptEffortMenu(page, currentEffort, effortMenu, effortSlider);
+    if (activation === "pointerdown") await captureDiagnostic?.("effort-menu-pointerdown-fallback");
     await captureDiagnostic?.("effort-menu-open-requested");
     const effortChoices = effortMenu.locator(CHATGPT_EFFORT_ITEM_SELECTOR);
     const effortChoice = effortChoices.nth(uiEffortIndex);
-    const effortSlider = page.locator(CHATGPT_EFFORT_SLIDER_SELECTOR).filter({ visible: true }).last();
     const waitAbort = new AbortController();
     let ready: "effort" | "slider" | "rate-limit" | "session-expired";
     try {

--- a/src/chatgpt-session.ts
+++ b/src/chatgpt-session.ts
@@ -38,6 +38,56 @@ export interface ChatGptEffortSliderState {
   value: number;
 }
 
+function selectorForOwnedMenu(menuId: string): string {
+  return `[id=${JSON.stringify(menuId)}]`;
+}
+
+export async function chatGptEffortMenuForControl(page: Page, control: Locator): Promise<Locator> {
+  const menuId = await control.getAttribute("aria-controls").catch(() => null);
+  if (menuId) return page.locator(selectorForOwnedMenu(menuId));
+  return page.locator(CHATGPT_EFFORT_MENU_SELECTOR).last();
+}
+
+async function waitForEffortSurface(menu: Locator, slider: Locator, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  do {
+    if (await menu.isVisible().catch(() => false) || await slider.isVisible().catch(() => false)) return true;
+    if (Date.now() >= deadline) return false;
+    await new Promise(resolveSleep => setTimeout(resolveSleep, 50));
+  } while (true);
+}
+
+export async function activateChatGptEffortMenu(
+  page: Page,
+  control: Locator,
+  menu: Locator,
+  slider: Locator,
+  options: { settleMs?: number } = {},
+): Promise<"already-open" | "click" | "pointerdown"> {
+  if (await waitForEffortSurface(menu, slider, 0)) return "already-open";
+  if (await control.getAttribute("aria-expanded").catch(() => null) === "true") {
+    await page.keyboard.press("Escape").catch(() => {});
+  }
+
+  await control.click({ force: true });
+  const settleMs = options.settleMs ?? 3_000;
+  if (await waitForEffortSurface(menu, slider, settleMs)) return "click";
+
+  if (await control.getAttribute("aria-expanded").catch(() => null) === "true") {
+    await page.keyboard.press("Escape").catch(() => {});
+  }
+  await control.dispatchEvent("pointerdown", {
+    button: 0,
+    buttons: 1,
+    pointerType: "mouse",
+    isPrimary: true,
+  });
+  if (await waitForEffortSurface(menu, slider, settleMs)) return "pointerdown";
+  throw new Error(
+    "ChatGPT effort control did not expose its owned menu or slider after click and primary pointerdown",
+  );
+}
+
 function safeIntegerAttribute(value: string | null): number | undefined {
   if (value === null || !/^-?\d+$/.test(value)) return undefined;
   const parsed = Number(value);

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -1094,7 +1094,7 @@ test("effort selection uses structural menu and slider indices instead of locali
   const workerSource = readFileSync(new URL("../src/adapters/chatgpt-web/browser-worker.ts", import.meta.url), "utf8");
   const sessionSource = readFileSync(new URL("../src/chatgpt-session.ts", import.meta.url), "utf8");
   expect(workerSource).toContain("mode.uiEffortIndex");
-  expect(workerSource).toContain("CHATGPT_EFFORT_MENU_SELECTOR");
+  expect(sessionSource).toContain("CHATGPT_EFFORT_MENU_SELECTOR");
   expect(workerSource).toContain("CHATGPT_EFFORT_ITEM_SELECTOR");
   expect(workerSource).toContain('timeout: 70_000');
   expect(sessionSource).toContain('[role="menu"]:has([role="menuitemradio"], [data-model-reasoning-effort-slider])');
@@ -1208,14 +1208,15 @@ test("effort selection handles the known ChatGPT rate-limit dialog before backgr
   const selectionEnd = workerSource.indexOf("private async activeComposer", selectionStart);
   const selectionSource = workerSource.slice(selectionStart, selectionEnd);
   const guard = selectionSource.indexOf("throwIfChatGptRateLimitDialog(page)");
-  const activation = selectionSource.indexOf("currentEffort.click({ force: true })");
+  const activation = selectionSource.indexOf("activateChatGptEffortMenu(page, currentEffort, effortMenu, effortSlider)");
 
   expect(workerSource).toContain("Too many requests");
   expect(workerSource).toContain("making requests too quickly");
   expect(guard).toBeGreaterThan(-1);
   expect(activation).toBeGreaterThan(guard);
   expect(selectionSource).not.toContain('currentEffort.press("Enter")');
-  expect(selectionSource).not.toContain("currentEffort.evaluate(");
+  const sessionSource = readFileSync(new URL("../src/chatgpt-session.ts", import.meta.url), "utf8");
+  expect(sessionSource).toContain('dispatchEvent("pointerdown"');
   expect(selectionSource).toContain('effortChoice.press("Enter")');
   expect(selectionSource).not.toContain("effortChoice.click(");
   expect(selectionSource).not.toContain("is unavailable");

--- a/tests/chatgpt-session.test.ts
+++ b/tests/chatgpt-session.test.ts
@@ -4,8 +4,55 @@ import {
   CHATGPT_EFFORT_CONTROL_SELECTOR,
   CHATGPT_EFFORT_MENU_SELECTOR,
   CHATGPT_EFFORT_SLIDER_SELECTOR,
+  activateChatGptEffortMenu,
+  chatGptEffortMenuForControl,
   detectChatGptAccountCapabilities,
 } from "../src/chatgpt-session";
+
+test("the effort menu is bound to the control-owned surface without localized text", async () => {
+  const ownedMenu = {} as never;
+  const control = { getAttribute: async () => "radix-effort-menu" };
+  const page = { locator: (selector: string) => {
+    expect(selector).toBe('[id="radix-effort-menu"]');
+    return ownedMenu;
+  } };
+  await expect(chatGptEffortMenuForControl(page as never, control as never)).resolves.toBe(ownedMenu);
+});
+
+test("effort activation uses one primary pointerdown only after click did not open the owned surface", async () => {
+  let visible = false;
+  const events: unknown[] = [];
+  const control = {
+    click: async (options: unknown) => { events.push(["click", options]); },
+    getAttribute: async () => "false",
+    dispatchEvent: async (name: string, detail: unknown) => {
+      events.push([name, detail]);
+      visible = true;
+    },
+  };
+  const surface = { isVisible: async () => visible };
+  const page = { keyboard: { press: async () => {} } };
+  await expect(activateChatGptEffortMenu(page as never, control as never, surface as never, surface as never, {
+    settleMs: 0,
+  })).resolves.toBe("pointerdown");
+  expect(events).toEqual([
+    ["click", { force: true }],
+    ["pointerdown", { button: 0, buttons: 1, pointerType: "mouse", isPrimary: true }],
+  ]);
+});
+
+test("effort activation fails closed when neither activation exposes a structural surface", async () => {
+  const control = {
+    click: async () => {},
+    getAttribute: async () => "false",
+    dispatchEvent: async () => {},
+  };
+  const surface = { isVisible: async () => false };
+  const page = { keyboard: { press: async () => {} } };
+  await expect(activateChatGptEffortMenu(page as never, control as never, surface as never, surface as never, {
+    settleMs: 0,
+  })).rejects.toThrow("did not expose its owned menu or slider");
+});
 
 test("login keeps the established turn composer contract", () => {
   const turnSelectors = CHATGPT_COMPOSER_SELECTOR.split(",").map(selector => selector.trim());


### PR DESCRIPTION
## Summary

- bind the effort picker to the trigger's exact `aria-controls` surface
- retry one failed forced click with a primary mouse `pointerdown`
- require the owned menu or structural slider to become visible, otherwise fail closed
- add locale-independent ownership, fallback, and failure tests

Fixes #268.

## Why

The current Radix trigger can accept a Playwright forced click without exposing its popover. The existing worker then waits 70 seconds and reports `item count: 0`, although slider parsing itself is already correct when the surface opens.

This keeps visible labels diagnostic-only and does not weaken model/effort verification.

## Verification

- `tsc --noEmit`: passed
- `bun test tests/chatgpt-session.test.ts tests/browser-worker-contract.test.ts`: 112 passed
- full `bun test`: 654 passed; four host/optional-launcher failures unrelated to this patch (missing Electron in the reused dependency tree, Windows host-path expectation, and Linux AppImage spawn fixture)