### PR TITLE
feat: opt-in coexistence routing behind an existing Codex router

### DIFF
--- a/src/codex-integration-document.ts
+++ b/src/codex-integration-document.ts
@@ -108,6 +108,12 @@ export function readCodexModelContextOverride(): CodexModelContextOverride | und
   return contextWindow === undefined ? undefined : { contextWindow };
 }
 
+export function readCodexOpenAiBaseUrl(): string | undefined {
+  const path = getCodexConfigPath();
+  if (!existsSync(path)) return undefined;
+  return findTopLevelAssignment(splitLines(readFileSync(path, "utf8")), "openai_base_url").value;
+}
+
 export function assignments(lines: string[]): Record<ManagedAssignmentKey, PreviousAssignment> {
   return {
     openai_base_url: findTopLevelAssignment(lines, "openai_base_url"),

--- a/src/codex-integration.ts
+++ b/src/codex-integration.ts
@@ -80,7 +80,7 @@ export {
   getCodexJournalRecoveryPath,
   getCodexModelsCachePath,
 } from "./codex-integration-shared";
-export { readCodexModelContextOverride } from "./codex-integration-document";
+export { readCodexModelContextOverride, readCodexOpenAiBaseUrl } from "./codex-integration-document";
 export type {
   CodexIntegrationJournal,
   CodexModelContextOverride,

--- a/src/config.ts
+++ b/src/config.ts
@@ -82,6 +82,8 @@ export interface AppConfig {
   experimentalBiggerContext: boolean;
   /** Optional adapter-silence budget for the Responses watchdog. */
   stallTimeoutSec?: number;
+  /** Existing loopback Responses route used for every non-Web model. */
+  nativePassthroughBaseUrl?: string;
   autoApproveToolCalls: boolean;
   controlToken: string;
   runtimeCommand: string[];
@@ -112,6 +114,22 @@ export function defaultBrokerEndpoint(home = getConfigDir(), platform = process.
   if (platform !== "win32") return join(home, "runtime", "turn-broker.sock");
   const identity = createHash("sha256").update(resolve(home).toLowerCase()).digest("hex").slice(0, 20);
   return `\\\\.\\pipe\\codex-chatgpt-web-${identity}`;
+}
+
+export function normalizeNativePassthroughBaseUrl(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error("nativePassthroughBaseUrl must be a valid URL");
+  }
+  if (url.protocol !== "http:" || !["127.0.0.1", "localhost", "[::1]"].includes(url.hostname)) {
+    throw new Error("nativePassthroughBaseUrl must use an HTTP loopback address");
+  }
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error("nativePassthroughBaseUrl must not contain credentials, query parameters, or a fragment");
+  }
+  return url.toString().replace(/\/+$/, "");
 }
 
 export function resolveBrokerEndpoint(value: string): string {
@@ -414,6 +432,11 @@ function parseConfig(value: unknown, path: string): AppConfig {
   if (parsed.stallTimeoutSec !== undefined
     && (!Number.isFinite(parsed.stallTimeoutSec) || parsed.stallTimeoutSec <= 0)) {
     throw new Error(`Invalid stallTimeoutSec in ${path}`);
+  }
+  if (parsed.nativePassthroughBaseUrl !== undefined) {
+    parsed.nativePassthroughBaseUrl = normalizeNativePassthroughBaseUrl(
+      parsed.nativePassthroughBaseUrl,
+    );
   }
   const solAvailable = parsed.solAvailable !== false;
   const proAvailable = parsed.proAvailable === true;

--- a/src/native-passthrough.ts
+++ b/src/native-passthrough.ts
@@ -204,6 +204,7 @@ export async function forwardNativeCodexRequest(
   endpoint: NativeCodexEndpoint,
   fetchUpstream: NativeFetch = fetch,
   decodedBody?: unknown,
+  backendBaseUrl = CODEX_BACKEND,
 ): Promise<Response> {
   const authorization = request.headers.get("authorization") ?? "";
   if (!authorization.startsWith("Bearer ") || authorization.length <= "Bearer ".length) {
@@ -232,7 +233,7 @@ export async function forwardNativeCodexRequest(
       body = originalBody;
     }
   }
-  const upstreamRequest = new Request(`${CODEX_BACKEND}/${endpoint}${incomingUrl.search}`, {
+  const upstreamRequest = new Request(`${backendBaseUrl}/${endpoint}${incomingUrl.search}`, {
     method,
     headers,
     ...(body ? { body } : {}),

--- a/src/server.ts
+++ b/src/server.ts
@@ -318,9 +318,10 @@ export async function modelsRequest(
 export async function nativeSearchRequest(
   req: Request,
   fetchUpstream?: NativeFetch,
+  backendBaseUrl?: string,
 ): Promise<Response> {
   try {
-    return await forwardNativeCodexRequest(req, "alpha/search", fetchUpstream);
+    return await forwardNativeCodexRequest(req, "alpha/search", fetchUpstream, undefined, backendBaseUrl);
   } catch (error) {
     return formatErrorResponse(502, "upstream_error", error instanceof Error ? error.message : String(error));
   }
@@ -364,7 +365,13 @@ export async function responseRequest(
     : undefined;
   if (typeof requestedModel === "string" && !isChatGptWebModelSlug(requestedModel)) {
     try {
-      return await forwardNativeCodexRequest(nativeRequest, "responses", undefined, raw);
+      return await forwardNativeCodexRequest(
+        nativeRequest,
+        "responses",
+        undefined,
+        raw,
+        config.nativePassthroughBaseUrl,
+      );
     } catch (error) {
       return formatErrorResponse(502, "upstream_error", error instanceof Error ? error.message : String(error));
     }
@@ -559,7 +566,13 @@ export async function compactRequest(
   }
   if (!isChatGptWebModelSlug(raw.model)) {
     try {
-      return await forwardNativeCodexRequest(nativeRequest, "responses/compact", undefined, raw);
+      return await forwardNativeCodexRequest(
+        nativeRequest,
+        "responses/compact",
+        undefined,
+        raw,
+        config.nativePassthroughBaseUrl,
+      );
     } catch (error) {
       return formatErrorResponse(502, "upstream_error", error instanceof Error ? error.message : String(error));
     }
@@ -799,7 +812,11 @@ export function startServer(
       if (req.method === "POST" && url.pathname === "/v1/alpha/search") {
         if (draining) return formatErrorResponse(503, "server_error", "codex-chatgpt-web is draining for a requested service operation");
         return httpTurns.track(
-          signal => nativeSearchRequest(new Request(req, { signal }), dependencies.fetchUpstream),
+          signal => nativeSearchRequest(
+            new Request(req, { signal }),
+            dependencies.fetchUpstream,
+            config.nativePassthroughBaseUrl,
+          ),
           req.signal,
           process.platform,
           "search",

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -7,6 +7,7 @@ import {
   currentRuntimeCommand,
   defaultBrokerEndpoint,
   defaultConfig,
+  normalizeNativePassthroughBaseUrl,
   getConfigPath,
   loadConfigForSetup,
   resolveDevSetupConnectorName,
@@ -22,6 +23,7 @@ import {
 import {
   installCodexIntegration,
   preflightCodexIntegration,
+  readCodexOpenAiBaseUrl,
   readCodexSubagentProtocol,
 } from "./codex-integration";
 import { inspectLauncherBrowserHost } from "./launcher-browser-host";
@@ -124,6 +126,7 @@ function meaningfulRuntimeChange(before: AppConfig, after: AppConfig): boolean {
     solAvailable: before.solAvailable,
     proAvailable: before.proAvailable,
     experimentalBiggerContext: before.experimentalBiggerContext,
+    nativePassthroughBaseUrl: before.nativePassthroughBaseUrl,
     autoApproveToolCalls: before.autoApproveToolCalls,
     controlToken: before.controlToken,
     runtimeCommand: before.runtimeCommand,
@@ -145,6 +148,7 @@ function meaningfulRuntimeChange(before: AppConfig, after: AppConfig): boolean {
     solAvailable: after.solAvailable,
     proAvailable: after.proAvailable,
     experimentalBiggerContext: after.experimentalBiggerContext,
+    nativePassthroughBaseUrl: after.nativePassthroughBaseUrl,
     autoApproveToolCalls: after.autoApproveToolCalls,
     controlToken: after.controlToken,
     runtimeCommand: after.runtimeCommand,
@@ -317,6 +321,11 @@ export async function setup(options: SetupOptions): Promise<SetupResult> {
       ?? readCodexSubagentProtocol(existing?.subagentProtocol ?? "compatibility-v1"),
   });
   delete config.purpose;
+  const installedRoute = `http://${config.host}:${config.port}/v1`;
+  const currentRoute = readCodexOpenAiBaseUrl();
+  if (!config.nativePassthroughBaseUrl && currentRoute && currentRoute !== installedRoute) {
+    config.nativePassthroughBaseUrl = normalizeNativePassthroughBaseUrl(currentRoute);
+  }
   const launcherOwned = config.browserHost === "launcher";
   if (!launcherOwned && process.platform !== "darwin") {
     throw new Error(

--- a/tests/codex-integration.test.ts
+++ b/tests/codex-integration.test.ts
@@ -14,6 +14,7 @@ import {
   preflightCodexIntegration,
   readCodexSubagentProtocol,
   readCodexModelContextOverride,
+  readCodexOpenAiBaseUrl,
   setCodexSubagentProtocol,
   uninstallCodexIntegration,
 } from "../src/codex-integration";
@@ -74,6 +75,20 @@ describe("reversible native Codex route integration", () => {
     expect(readCodexModelContextOverride()).toEqual({
       contextWindow: 1_000_000,
     });
+  });
+
+  test("reads the existing Codex route for downstream passthrough", () => {
+    const { codexHome } = fixture();
+    writeFileSync(
+      join(codexHome, "config.toml"),
+      [
+        'openai_base_url = "http://127.0.0.1:4202/_codex-router/private/v1"',
+        "",
+      ].join("\n"),
+    );
+
+    expect(readCodexOpenAiBaseUrl())
+      .toBe("http://127.0.0.1:4202/_codex-router/private/v1");
   });
 
   test("keeps the built-in openai provider without changing native feature defaults", () => {

--- a/tests/native-passthrough.test.ts
+++ b/tests/native-passthrough.test.ts
@@ -38,6 +38,47 @@ test("forwards native Codex requests verbatim to the official backend", async ()
   expect(await response.text()).toBe("data: native\n\n");
 });
 
+test("forwards non-Web requests to a configured loopback Codex Router route", async () => {
+  const routerBase = "http://127.0.0.1:4202/_codex-router/private-capability/v1";
+  const cases = [
+    { endpoint: "responses" as const, source: "/v1/responses", expected: "/responses" },
+    {
+      endpoint: "responses/compact" as const,
+      source: "/v1/responses/compact",
+      expected: "/responses/compact",
+    },
+    {
+      endpoint: "alpha/search" as const,
+      source: "/v1/alpha/search?locale=en",
+      expected: "/alpha/search?locale=en",
+    },
+  ];
+
+  for (const entry of cases) {
+    const request = new Request(`http://127.0.0.1:17841${entry.source}`, {
+      method: "POST",
+      headers: {
+        authorization: "Bearer codex-oauth-token",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ model: "bai/glm-5.3-flash", input: [] }),
+    });
+    let upstreamRequest: Request | undefined;
+    await forwardNativeCodexRequest(
+      request,
+      entry.endpoint,
+      async input => {
+        upstreamRequest = input;
+        return Response.json({ ok: true });
+      },
+      undefined,
+      routerBase,
+    );
+    expect(upstreamRequest!.url).toBe(`${routerBase}${entry.expected}`);
+    expect(upstreamRequest!.headers.get("authorization")).toBe("Bearer codex-oauth-token");
+  }
+});
+
 test("forwards native Codex compaction requests to the official compact endpoint", async () => {
   const originalBody = Bun.zstdCompressSync(Buffer.from('{"model":"gpt-5.6-sol","input":[]}'));
   const encoded = new ArrayBuffer(originalBody.byteLength);

--- a/tests/runtime-layout.test.ts
+++ b/tests/runtime-layout.test.ts
@@ -13,6 +13,7 @@ import {
   installedBunExecutable,
   loadConfig,
   loadConfigForSetup,
+  normalizeNativePassthroughBaseUrl,
   providerConfig,
   resolveBrokerEndpoint,
   resolveDevSetupConnectorName,
@@ -86,6 +87,19 @@ test("permission-denied process probes preserve ownership evidence", () => {
 test("user-home expansion accepts native Unix and Windows separators", () => {
   expect(expandUserPath("~/runtime")).toBe(join(homedir(), "runtime"));
   expect(expandUserPath("~\\runtime")).toBe(join(homedir(), "runtime"));
+});
+
+test("native passthrough accepts only credential-free loopback URLs", () => {
+  expect(normalizeNativePassthroughBaseUrl("http://127.0.0.1:4202/capability/v1/"))
+    .toBe("http://127.0.0.1:4202/capability/v1");
+  expect(normalizeNativePassthroughBaseUrl("http://localhost:4202/v1"))
+    .toBe("http://localhost:4202/v1");
+  expect(() => normalizeNativePassthroughBaseUrl("https://127.0.0.1:4202/v1"))
+    .toThrow("HTTP loopback");
+  expect(() => normalizeNativePassthroughBaseUrl("http://example.com/v1"))
+    .toThrow("HTTP loopback");
+  expect(() => normalizeNativePassthroughBaseUrl("http://user:secret@127.0.0.1:4202/v1"))
+    .toThrow("must not contain credentials");
 });
 
 test("the direct-turn connector identity migrates known legacy setup without overwriting custom names", () => {


### PR DESCRIPTION
## Summary

Setup currently refuses to run whenever `openai_base_url` is already configured, naming the other wrapper and stopping there. That is the right default, but it means users of local model routers (codex-router, OpenCodex, Headroom, …) had to disconnect their router entirely to use the bridge — even though the two compose naturally: ChatGPT Web turns go to the browser, everything else forwards to the router.

This PR adds an opt-in chaining mode. When setup replaces a non-empty `openai_base_url`, the previous value is stored privately as `nativePassthroughBaseUrl` and used as the upstream for every non-ChatGPT-Web request:

- `POST /v1/responses`
- `POST /v1/responses/compact`
- `POST /v1/alpha/search`

Native model discovery (`GET /v1/models`) stays on the official backend, and ChatGPT Web turns are byte-for-byte unchanged. With no configured value the official backend is used, exactly as before — the field is optional and nothing changes for existing installs.

## Changes

- `src/config.ts` — optional `nativePassthroughBaseUrl`; `normalizeNativePassthroughBaseUrl()` accepts only HTTP loopback URLs with no credentials, query, or fragment, so the existing same-OS-user trust boundary is preserved rather than widened. Validated in `parseConfig`.
- `src/codex-integration-document.ts` / `codex-integration.ts` — `readCodexOpenAiBaseUrl()` reads the previous route for capture.
- `src/setup.ts` — setup captures the pre-existing `openai_base_url` (when it differs from the bridge's own route) into the config field; the value participates in `meaningfulRuntimeChange` so daemon restarts track it.
- `src/native-passthrough.ts` — `forwardNativeCodexRequest()` accepts an optional upstream base (defaults to the official backend).
- `src/server.ts` — non-Web responses, compaction, and search forward to the configured value; `/v1/models` is untouched.
- tests — loopback/credential validation, exact Router URL construction for all three forwarded endpoints, and route capture from a fixture Codex config.

## Notes for review

- **Security:** the stored URL must be loopback and credential-free. No secrets enter command lines or logs; the value is a route, not a credential, and follows the same user-only storage as the rest of the app config.
- **Restorability:** unchanged — the integration journal still owns only `openai_base_url` and restores the prior value byte-for-byte on disconnect/uninstall; `model_provider` / `model_catalog_json` continue to be preserved, never removed.
- **Verified against a real router:** with codex-router on `127.0.0.1:4202`, `codex-chatgpt-web setup --browser-only --replace-codex-route …` captured the router URL, and a packaged build served a ChatGPT Web Luna turn (smoke test: all 11 checkpoints, `turn completed`) plus a routed-provider turn that reached the router and completed `200`.

## Testing

- [x] `bun test tests/native-passthrough.test.ts tests/runtime-layout.test.ts tests/codex-integration.test.ts tests/server-models.test.ts tests/server-compaction.test.ts` — 71 pass, 0 fail
- [x] `tsc --noEmit` clean
- [x] End-to-end on Windows: browser-only setup against a live codex-router; Web turn and router-chained turn both completed
