### PR TITLE
fix: recover cwd from first workspace root when resumed turn omits it (fixes #288)

### DIFF
--- a/src/adapters/chatgpt-web/environment.ts
+++ b/src/adapters/chatgpt-web/environment.ts
@@ -510,13 +510,16 @@ function matchesPath(root: string, path: string): boolean {
 
 export function extractChatGptTurnEnvironment(parsed: CodexParsedRequest): ChatGptTurnEnvironment {
   const text = trustedEnvironmentText(parsed);
+  const rootMatches = [...text.matchAll(/<workspace_roots>[\s\S]*?<\/workspace_roots>/g)]
+    .flatMap(section => [...section[0].matchAll(/<root>([^<]+)<\/root>/g)].map(match => match[1] ?? ""));
   const cwdMatches = environmentCwdMatches(text, clientMetadataWorkspaceRoots(parsed));
-  const cwdCandidates = uniqueAbsolutePaths(cwdMatches, "cwd");
+  const cwdCandidates = uniqueAbsolutePaths(
+    cwdMatches.length > 0 ? cwdMatches : rootMatches.slice(0, 1),
+    "cwd",
+  );
   if (cwdCandidates.length !== 1) throw new Error("ChatGPT web turn has conflicting trusted Codex cwd values");
   const cwd = cwdCandidates[0]!;
 
-  const rootMatches = [...text.matchAll(/<workspace_roots>[\s\S]*?<\/workspace_roots>/g)]
-    .flatMap(section => [...section[0].matchAll(/<root>([^<]+)<\/root>/g)].map(match => match[1] ?? ""));
   const roots = rootMatches.length > 0 ? uniqueAbsolutePaths(rootMatches, "workspace_roots") : [cwd];
   if (!roots.some(root => matchesPath(root, cwd))) {
     throw new Error("ChatGPT web cwd is outside the trusted Codex workspace roots");

--- a/tests/environment.test.ts
+++ b/tests/environment.test.ts
@@ -104,6 +104,28 @@ describe("trusted current Codex environment envelope", () => {
     });
   });
 
+  test("uses the first workspace root when a resumed turn omits cwd", () => {
+    const visualizationsRoot = resolve(root, "visualizations", "thread_current");
+    const resumedEnvironment = `<environment_context>
+  <current_date>2026-09-02</current_date>
+  <timezone>America/Asuncion</timezone>
+  <filesystem><workspace_roots><root>${root}</root><root>${visualizationsRoot}</root></workspace_roots>${dangerFullAccessProfileXml}</filesystem>
+</environment_context>`;
+    const request = currentWire({ environmentXml: resumedEnvironment });
+    const body = request._rawBody as { input: Array<Record<string, unknown>> };
+    for (const item of body.input) {
+      item.internal_chat_message_metadata_passthrough = { turn_id: "turn_current" };
+    }
+
+    expect(extractChatGptTurnEnvironment(request)).toEqual({
+      cwd: root,
+      roots: [root, visualizationsRoot],
+      writableRoots: [root, visualizationsRoot],
+      sandboxPolicy: { type: "dangerFullAccess" },
+      tools: [],
+    });
+  });
+
   test("accepts either canonical provenance form on an intervening developer message", () => {
     for (const developer of [
       {


### PR DESCRIPTION
Fixes #288

## Summary

Resumed turns from Codex CLI `0.150.0-alpha.8` (bundled in ChatGPT.app `151.0.7922.170` / macOS 26.2 arm64) omit `<cwd>` from `<environment_context>` whenever the thread is resumed after the user switches the model to a ChatGPT Web model. The bridge correctly fail-closes with:

> `ChatGPT web turn is missing cwd in trusted Codex environment context`

but the turn then stays stuck in `Reconnecting… / waiting for network` and never completes. Fresh `codex exec` sessions from the same binary and `0.144.1` turns are unaffected — see the verified rollout payload in #288.

This implements the suggested fix verbatim: when cwd candidates are empty, recover cwd from the **first `<workspace_roots><root>` entry** (Codex's convention: first root = primary workspace) and keep the entire existing validation chain.

## Root cause

In the failing turn the `<environment_context>` contains no `<cwd>` at all:

```xml
<environment_context>
  <filesystem><workspace_roots><root>/Users/…</root><root>/Users/…/.codex/visualizations/…/<thread-id></root></workspace_roots><permission_profile type="disabled"><file_system type="unrestricted" /></permission_profile></filesystem>
</environment_context>
```

Working turns do include `<cwd>…</cwd>` as an additional `input_text` part of the same user message. The previous parser threw before it could derive the trusted envelope.

## Change

`src/adapters/chatgpt-web/environment.ts` — `extractChatGptTurnEnvironment`:

```ts
const rootMatches = [...text.matchAll(/<workspace_roots>[\s\S]*?<\/workspace_roots>/g)]
  .flatMap(section => [...section[0].matchAll(/<root>([^<]+)<\/root>/g)].map(match => match[1] ?? ""));
const cwdMatches = environmentCwdMatches(text, clientMetadataWorkspaceRoots(parsed));
const cwdCandidates = uniqueAbsolutePaths(
  cwdMatches.length > 0 ? cwdMatches : rootMatches.slice(0, 1),
  "cwd",
);
```

* `roots` is now parsed before `cwdCandidates` so the fallback source exists.
* If `cwdMatches` is non-empty the path is unchanged; if empty we pass `rootMatches.slice(0, 1)` — exactly one candidate — to the same `uniqueAbsolutePaths(..., "cwd")` dedup.
* If neither `<cwd>` nor `<workspace_roots>` exist, the empty array still throws `MissingTrustedCodexEnvironmentError` — fail-closed is preserved.

Why this is safe:

* the absolute-path check still applies to the recovered value
* `cwd is outside the trusted Codex workspace roots` passes trivially since the value comes from `workspace_roots`
* `sandboxTypeFromEnvironment` already recognizes this shape (`permission_profile type="disabled"` / `file_system type="unrestricted"` → `dangerFullAccess`), so no sandbox change is needed

## Tests

`tests/environment.test.ts` — new case `uses the first workspace root when a resumed turn omits cwd` replays the #288 payload byte-for-byte (two roots, no `<cwd>`, `dangerFullAccess`) and asserts:

```ts
{ cwd: root, roots: [root, visualizationsRoot], writableRoots: [root, visualizationsRoot], sandboxPolicy: { type: "dangerFullAccess" } }
```

```
bun test ./tests/environment.test.ts — 29 pass 0 fail
bun test — 523 pass 0 fail
```

## How to verify

1. Rebuild the runtime (`bun run build` requires Bun `1.4.0`) — `dist/runtime/app/cli.js` should contain the fallback `r.length>0?r:n.slice(0,1)` path.
2. Promote the bundle to `~/.codex-chatgpt-web/versions/<version>-<platform>-<arch>/` (atomic copy via `launcher/electron/runtime-install.cjs` semantics) or reinstall via the launcher.
3. Replay the failing payload or do a real end-to-end resume-after-model-switch on macOS — previously failing turns now complete.

Closes #288. Related #248.

## Checklist

- [x] Rebuild verified with Bun 1.4.0 — `dist/runtime/manifest.json` `bundleId` matches file records
- [x] No new dependencies
- [x] Dist is gitignored; only `src/` + `tests/` are in the PR
