### PR TITLE
fix: support native v2 cross-backend subagents

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -160,9 +160,12 @@ ChatGPT のツール呼び出しを現在の Codex タスクへ接続します�
 アンインストール前の Codex 統合削除も行えます。すべてのブラウザーチェックポイントでスクリーンショットが必要な場合にのみ、
 `CODEX_CHATGPT_WEB_BROWSER_DIAGNOSTICS=1` を設定してください。
 
-新規インストールでは、クロスバックエンドのサブエージェントに **Compatibility V1** を使用します。
-**Native** は Codex 独自の機能設定を維持し、プレーンテキストの Web-to-Web V2 delegation を有効にします。
-プロトコル変更後は Codex を再起動し、新しいタスクを開始してください。
+新規インストールでは、保守的なクロスバックエンド方式として **Compatibility V1** を使用します。
+**Native** は Codex 独自の機能設定を維持し、ネイティブモデルと ChatGPT Web モデル間の V2 delegation を有効にします。
+Native モードでは、ローカルの認証済みプロキシが `spawn_agent`、`send_message`、`followup_task` の
+メッセージ引数だけをプレーンテキストにするため、どちらのバックエンドでも読み取れます。そのため、これらの委任プロンプトは
+プロバイダー専用の暗号化データではなく、ローカルで読み取り可能になります。プロトコル変更後は Codex Web GPT と Codex を再起動し、
+新しいタスクを開始してください。
 
 ```bash
 codex-chatgpt-web subagents status

--- a/README.md
+++ b/README.md
@@ -163,9 +163,12 @@ Use **Activity** for safe local diagnostics and **Settings → Run doctor** for 
 Settings can also cancel a retained browser turn or remove the Codex integration before uninstall.
 Set `CODEX_CHATGPT_WEB_BROWSER_DIAGNOSTICS=1` only when every browser checkpoint needs a screenshot.
 
-New installs use **Compatibility V1** for cross-backend subagents. **Native** preserves Codex's own
-feature settings and enables plaintext Web-to-Web V2 delegation. Restart Codex and start a new task
-after changing the protocol:
+New installs use **Compatibility V1** for the conservative cross-backend path. **Native** preserves
+Codex's own feature settings and enables V2 delegation between native and ChatGPT Web models. In
+Native mode, the authenticated local proxy makes only `spawn_agent`, `send_message`, and
+`followup_task` message arguments plaintext so either backend can read them; those delegation
+prompts are therefore locally readable instead of provider-opaque. Restart Codex Web GPT and Codex,
+then start a new task after changing the protocol:
 
 ```bash
 codex-chatgpt-web subagents status

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -152,8 +152,11 @@ bun run app
 取消保留的浏览器任务，或在卸载前移除 Codex 集成。仅在需要为每个浏览器检查点保存截图时设置
 `CODEX_CHATGPT_WEB_BROWSER_DIAGNOSTICS=1`。
 
-新安装默认使用 **Compatibility V1** 以支持跨后端 subagent。**Native** 会保留 Codex 自身的
-功能设置，并启用明文 Web-to-Web V2 委派。切换协议后，请重启 Codex 并创建新任务：
+新安装默认使用较保守的 **Compatibility V1** 跨后端方案。**Native** 会保留 Codex 自身的
+功能设置，并支持原生模型与 ChatGPT Web 模型之间的 V2 委派。在 Native 模式下，本地认证代理
+只会将 `spawn_agent`、`send_message` 和 `followup_task` 的消息参数改为明文，使任一后端都能
+读取；因此这些委派提示在本机可读，而不再是仅提供方可解密的内容。切换协议后，请重启
+Codex Web GPT 和 Codex，然后创建新任务：
 
 ```bash
 codex-chatgpt-web subagents status

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -150,8 +150,7 @@ Setup keeps Codex's built-in `openai` provider; its only managed provider-routin
 `openai_base_url`. The daemon
 forwards the authenticated official model catalog and appends only the routed models owned by the
 `chatgpt-web/` namespace; no static catalog is installed. Subagent protocol selection is explicit,
-and new installations default to Compatibility V1 because it is the only surface portable across
-native and routed Web backends:
+and new installations default to Compatibility V1 as the conservative cross-backend surface:
 
 - **Compatibility V1** pins every delegation-capable native and routed row to V1 and atomically
   manages `multi_agent = true`, `multi_agent_v2 = false`, and `[agents].max_depth` of at least 2 so
@@ -161,15 +160,20 @@ native and routed Web backends:
   10-second polling contract: terminal semantics stay native, while every non-terminal poll releases
   the serialized MCP channel so Web children can run their own harness tools.
 - **Native** preserves every official native row and gives routed rows the selected template's
-  protocol surface. Under MultiAgent V2, Web-origin `spawn_agent`, `send_message`, and
-  `followup_task` calls include Codex's explicit `encrypted_function_args: []` plaintext marker.
-  A genuinely encrypted native-to-Web payload is rejected with one HTTP 400 before a browser is
-  opened; it is never turned into an SSE disconnect/retry loop.
+  protocol surface. For authenticated native Responses turns, the proxy recognizes the V2
+  collaboration surface in ordinary tools and Responses Lite `additional_tools`, removes the
+  `encrypted: true` schema marker only from `spawn_agent`, `send_message`, and `followup_task`
+  message fields, and normalizes their returned calls with Codex's explicit
+  `encrypted_function_args: []` plaintext-delivery marker. The same marker is emitted directly for
+  Web-origin calls. This makes native-to-Web, Web-to-native, and Web-to-Web V2 delegation readable
+  across providers while leaving unrelated schemas and encrypted response fields untouched. A
+  genuinely encrypted payload is still rejected with one HTTP 400 before a browser is opened; it
+  is never turned into an SSE disconnect/retry loop.
 
 Catalog metadata alone never claims to change an existing task's protocol. Codex pins the protocol
 when a task starts, and its global `multi_agent_v2` override wins over per-model metadata. Switching
-protocol therefore requires restarting Codex and starting a new task. Model choice, effort,
-context, and service tiers are otherwise unchanged.
+protocol therefore requires restarting Codex Web GPT and Codex, then starting a new task. Model
+choice, effort, context, and service tiers are otherwise unchanged.
 
 The built-in provider attempts a Responses WebSocket prewarm. The local route explicitly returns
 HTTP `426`, which is Codex's native capability-negotiation signal for an immediate, session-sticky

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -76,6 +76,17 @@ request and long-lived browser/tool loop are idle, flush response state, and sto
 token does not turn loopback into a hostile-local-process security boundary; it prevents accidental
 or unauthenticated lifecycle control through ordinary requests.
 
+### Native V2 subagent message confidentiality
+
+Native MultiAgent V2 normally marks delegation messages for provider-private encryption. When the
+user selects the **Native** subagent protocol, this proxy deliberately removes that marker only for
+the `message` fields of `spawn_agent`, `send_message`, and `followup_task`, then marks the returned
+calls for Codex's plaintext delivery path. This is what lets native and ChatGPT Web agents delegate
+to each other, but it also means those delegation prompts can appear as plaintext in the trusted
+local Codex history and rollout files. Compatibility V1 also uses readable cross-agent messages.
+Use either mode only on a trusted workstation, and do not place secrets in subagent prompts that
+should not be present in local task history.
+
 ### Browser/UI drift
 
 ChatGPT DOM and labels are not a stable API. Selectors are narrow; Full-mode completion requires

--- a/scripts/smoke-codex-subagents.ts
+++ b/scripts/smoke-codex-subagents.ts
@@ -5,11 +5,14 @@ import { spawnSync } from "node:child_process";
 import { bridgeToResponsesSSE } from "../src/bridge";
 import { defaultConfig } from "../src/config";
 import { augmentNativeModelCatalog } from "../src/model-catalog";
+import { forwardNativeCodexRequest } from "../src/native-passthrough";
 import type { AdapterEvent } from "../src/types";
 
 const protocol = process.argv.includes("--v1") ? "v1" : "v2";
-const explicitChildModel = "gpt-5.6-sol";
-const explicitChildReasoningEffort = "max";
+const rootModel = protocol === "v2" ? "gpt-5.6-sol" : "chatgpt-web/pro";
+const explicitChildModel = protocol === "v2" ? "chatgpt-web/pro" : "gpt-5.6-sol";
+const requestedChildReasoningEffort = protocol === "v2" ? "ultra" : "max";
+const effectiveChildReasoningEffort = protocol === "v2" ? "medium" : "max";
 const codexArg = process.argv.slice(2).find(argument => argument !== "--v1" && argument !== "--v2");
 const codex = resolve(codexArg ?? "/Applications/ChatGPT.app/Contents/Resources/codex");
 if (!existsSync(codex)) throw new Error(`Codex executable is missing: ${codex}`);
@@ -61,6 +64,68 @@ const collaborationMap = new Map([
     name: protocol === "v1" ? "send_input" : "followup_task",
   }],
 ]);
+
+const v2MessageTools = new Set(["spawn_agent", "send_message", "followup_task"]);
+
+function hasEncryptedV2MessageSchema(value: unknown): boolean {
+  if (!value || typeof value !== "object") return false;
+  if (Array.isArray(value)) return value.some(hasEncryptedV2MessageSchema);
+  const record = value as Record<string, unknown>;
+  const parameters = record.parameters && typeof record.parameters === "object"
+    ? record.parameters as Record<string, unknown>
+    : undefined;
+  const properties = parameters?.properties && typeof parameters.properties === "object"
+    ? parameters.properties as Record<string, unknown>
+    : undefined;
+  const message = properties?.message && typeof properties.message === "object"
+    ? properties.message as Record<string, unknown>
+    : undefined;
+  if (record.type === "function"
+    && typeof record.name === "string"
+    && v2MessageTools.has(record.name)
+    && message?.encrypted === true) return true;
+  return Object.values(record).some(hasEncryptedV2MessageSchema);
+}
+
+function removePlaintextV2Markers(value: unknown): boolean {
+  if (!value || typeof value !== "object") return false;
+  if (Array.isArray(value)) {
+    return value.reduce((changed, item) => removePlaintextV2Markers(item) || changed, false);
+  }
+  const record = value as Record<string, unknown>;
+  let changed = false;
+  if (record.type === "function_call"
+    && record.namespace === "collaboration"
+    && typeof record.name === "string"
+    && v2MessageTools.has(record.name)
+    && Array.isArray(record.encrypted_function_args)
+    && record.encrypted_function_args.length === 0) {
+    delete record.encrypted_function_args;
+    changed = true;
+  }
+  for (const child of Object.values(record)) {
+    if (removePlaintextV2Markers(child)) changed = true;
+  }
+  return changed;
+}
+
+async function nativeResponseWithoutPlaintextMarkers(
+  events: ReadableStream<Uint8Array>,
+): Promise<Response> {
+  const text = await new Response(events).text();
+  const rewritten = text.split("\n").map(line => {
+    if (!line.startsWith("data: ") || line === "data: [DONE]") return line;
+    try {
+      const event = JSON.parse(line.slice(6)) as unknown;
+      return removePlaintextV2Markers(event) ? `data: ${JSON.stringify(event)}` : line;
+    } catch {
+      return line;
+    }
+  }).join("\n");
+  return new Response(rewritten, {
+    headers: { "content-type": "text/event-stream", "cache-control": "no-cache" },
+  });
+}
 
 function hasEncryptedContent(value: unknown): boolean {
   if (!value || typeof value !== "object") return false;
@@ -176,13 +241,13 @@ function responseFor(role: Role, step: number, body: Record<string, unknown>): A
       message: "CHILD_LIFECYCLE: spawn the requested grandchild, wait for it, then report success.",
       fork_context: false,
       model: explicitChildModel,
-      reasoning_effort: explicitChildReasoningEffort,
+      reasoning_effort: requestedChildReasoningEffort,
     } : {
       task_name: "lifecycle_child",
       message: "CHILD_LIFECYCLE: spawn the requested grandchild, wait for it, then report success.",
       fork_turns: "none",
       model: explicitChildModel,
-      reasoning_effort: explicitChildReasoningEffort,
+      reasoning_effort: requestedChildReasoningEffort,
     });
     if (step === 1) return toolCall("wait_agent", protocol === "v1"
       ? { targets: [spawnedAgentId(body)], timeout_ms: 500 }
@@ -205,13 +270,13 @@ function responseFor(role: Role, step: number, body: Record<string, unknown>): A
       message: "GRANDCHILD_LIFECYCLE: reply with GRANDCHILD_LIFECYCLE_OK.",
       fork_context: false,
       model: explicitChildModel,
-      reasoning_effort: explicitChildReasoningEffort,
+      reasoning_effort: requestedChildReasoningEffort,
     } : {
       task_name: "lifecycle_grandchild",
       message: "GRANDCHILD_LIFECYCLE: reply with GRANDCHILD_LIFECYCLE_OK.",
       fork_turns: "none",
       model: explicitChildModel,
-      reasoning_effort: explicitChildReasoningEffort,
+      reasoning_effort: requestedChildReasoningEffort,
     });
     if (step === 1) return toolCall("wait_agent", protocol === "v1"
       ? { targets: [spawnedAgentId(body)], timeout_ms: 500 }
@@ -276,11 +341,29 @@ const server = Bun.serve({
           failures.push(`${role} received encrypted_content instead of plaintext agent_message input`);
         }
       }
-      return new Response(bridgeToResponsesSSE(
+      const responseStream = bridgeToResponsesSSE(
         responseFor(role, step, body),
         "chatgpt-web/pro",
         collaborationMap,
-      ), {
+      );
+      if (protocol === "v2" && role === "root") {
+        const proxyRequest = new Request(request.url, {
+          method: "POST",
+          headers: {
+            authorization: "Bearer local-lifecycle-smoke",
+            "content-type": "application/json",
+          },
+          body: JSON.stringify(body),
+        });
+        return await forwardNativeCodexRequest(proxyRequest, "responses", async upstreamRequest => {
+          const forwarded = await upstreamRequest.clone().json() as unknown;
+          if (hasEncryptedV2MessageSchema(forwarded)) {
+            failures.push("native V2 proxy left collaboration message schemas encrypted");
+          }
+          return await nativeResponseWithoutPlaintextMarkers(responseStream);
+        }, body, { plaintextMultiAgentV2Messages: true });
+      }
+      return new Response(responseStream, {
         headers: {
           "content-type": "text/event-stream",
           "cache-control": "no-cache",
@@ -294,7 +377,7 @@ const server = Bun.serve({
 });
 
 writeFileSync(join(codexHome, "config.toml"), [
-  'model = "chatgpt-web/pro"',
+  `model = ${JSON.stringify(rootModel)}`,
   'model_provider = "lifecycle"',
   `model_catalog_json = ${JSON.stringify(join(root, "models.json"))}`,
   "",
@@ -329,7 +412,7 @@ try {
     "--json",
     "--dangerously-bypass-approvals-and-sandbox",
     "--model",
-    "chatgpt-web/pro",
+    rootModel,
     "ROOT_LIFECYCLE: complete the nested subagent lifecycle and the follow-up.",
   ], {
     cwd: root,
@@ -368,9 +451,9 @@ try {
     if (firstRequest?.model !== explicitChildModel) {
       failures.push(`${role} used ${firstRequest?.model ?? "no model"}, expected ${explicitChildModel}`);
     }
-    if (firstRequest?.reasoningEffort !== explicitChildReasoningEffort) {
+    if (firstRequest?.reasoningEffort !== effectiveChildReasoningEffort) {
       failures.push(
-        `${role} used reasoning ${firstRequest?.reasoningEffort ?? "none"}, expected ${explicitChildReasoningEffort}`,
+        `${role} used reasoning ${firstRequest?.reasoningEffort ?? "none"}, expected ${effectiveChildReasoningEffort}`,
       );
     }
   }

--- a/src/native-passthrough.ts
+++ b/src/native-passthrough.ts
@@ -29,6 +29,10 @@ const HOP_BY_HOP_HEADERS = new Set([
 export type NativeFetch = (request: Request) => Promise<Response>;
 export type NativeCodexEndpoint = "models" | "responses" | "responses/compact" | "alpha/search";
 
+export interface NativeCodexPassthroughOptions {
+  plaintextMultiAgentV2Messages?: boolean;
+}
+
 type JsonObject = Record<string, unknown>;
 type BridgeCompactionItem = JsonObject & { type: "compaction"; encrypted_content: string };
 
@@ -122,6 +126,124 @@ export function scrubBridgeArtifactsForNative(value: unknown): { value: unknown;
   return { value: clean, changed: true };
 }
 
+const MULTI_AGENT_V2_MESSAGE_TOOLS = new Set([
+  "spawn_agent",
+  "send_message",
+  "followup_task",
+]);
+
+interface PlaintextMultiAgentV2Surface {
+  namespaces: Set<string>;
+  unnamespaced: boolean;
+}
+
+function emptyPlaintextMultiAgentV2Surface(): PlaintextMultiAgentV2Surface {
+  return { namespaces: new Set(), unnamespaced: false };
+}
+
+function isMultiAgentV2Namespace(tool: JsonObject): tool is JsonObject & { name: string; tools: unknown[] } {
+  if (tool.type !== "namespace" || typeof tool.name !== "string" || !Array.isArray(tool.tools)) {
+    return false;
+  }
+  if (tool.name === "collaboration") return true;
+  const names = new Set(tool.tools.flatMap(inner => isObject(inner)
+    && inner.type === "function"
+    && typeof inner.name === "string"
+    ? [inner.name]
+    : []));
+  return [...MULTI_AGENT_V2_MESSAGE_TOOLS].every(name => names.has(name));
+}
+
+function plaintextMultiAgentV2MessageTool(tool: unknown): { tool: unknown; changed: boolean } {
+  if (!isObject(tool)
+    || tool.type !== "function"
+    || typeof tool.name !== "string"
+    || !MULTI_AGENT_V2_MESSAGE_TOOLS.has(tool.name)
+    || !isObject(tool.parameters)
+    || !isObject(tool.parameters.properties)
+    || !isObject(tool.parameters.properties.message)
+    || tool.parameters.properties.message.encrypted !== true) return { tool, changed: false };
+  const message = { ...tool.parameters.properties.message };
+  delete message.encrypted;
+  return {
+    tool: {
+      ...tool,
+      parameters: {
+        ...tool.parameters,
+        properties: {
+          ...tool.parameters.properties,
+          message,
+        },
+      },
+    },
+    changed: true,
+  };
+}
+
+function plaintextMultiAgentV2ToolSchemas(
+  tools: unknown[],
+  surface: PlaintextMultiAgentV2Surface,
+): { tools: unknown[]; changed: boolean } {
+  let changed = false;
+  const topLevelNames = new Set(tools.flatMap(tool => isObject(tool)
+    && tool.type === "function"
+    && typeof tool.name === "string"
+    ? [tool.name]
+    : []));
+  const unnamespaced = [...MULTI_AGENT_V2_MESSAGE_TOOLS]
+    .every(name => topLevelNames.has(name));
+  if (unnamespaced) surface.unnamespaced = true;
+  const rewritten = tools.map(tool => {
+    if (unnamespaced && isObject(tool) && tool.type === "function") {
+      const result = plaintextMultiAgentV2MessageTool(tool);
+      if (result.changed) changed = true;
+      return result.tool;
+    }
+    if (!isObject(tool) || !isMultiAgentV2Namespace(tool)) return tool;
+    surface.namespaces.add(tool.name);
+    let namespaceChanged = false;
+    const innerTools = tool.tools.map(inner => {
+      const result = plaintextMultiAgentV2MessageTool(inner);
+      if (!result.changed) return inner;
+      changed = true;
+      namespaceChanged = true;
+      return result.tool;
+    });
+    return namespaceChanged ? { ...tool, tools: innerTools } : tool;
+  });
+  return { tools: changed ? rewritten : tools, changed };
+}
+
+function plaintextMultiAgentV2MessageSchemas(value: unknown): {
+  value: unknown;
+  changed: boolean;
+  surface: PlaintextMultiAgentV2Surface;
+} {
+  const surface = emptyPlaintextMultiAgentV2Surface();
+  if (!isObject(value)) return { value, changed: false, surface };
+  const topLevel = Array.isArray(value.tools)
+    ? plaintextMultiAgentV2ToolSchemas(value.tools, surface)
+    : { tools: value.tools, changed: false };
+  let inputChanged = false;
+  const input = Array.isArray(value.input) ? value.input.map(item => {
+    if (!isObject(item) || item.type !== "additional_tools" || !Array.isArray(item.tools)) return item;
+    const rewritten = plaintextMultiAgentV2ToolSchemas(item.tools, surface);
+    if (!rewritten.changed) return item;
+    inputChanged = true;
+    return { ...item, tools: rewritten.tools };
+  }) : value.input;
+  if (!topLevel.changed && !inputChanged) return { value, changed: false, surface };
+  return {
+    value: {
+      ...value,
+      ...(topLevel.changed ? { tools: topLevel.tools } : {}),
+      ...(inputChanged ? { input } : {}),
+    },
+    changed: true,
+    surface,
+  };
+}
+
 function endToEndHeaders(source: Headers): Headers {
   const headers = new Headers();
   for (const [name, value] of source) {
@@ -199,11 +321,80 @@ function withUncleanCloseTolerance(
   });
 }
 
+function markPlaintextMultiAgentV2Calls(
+  value: unknown,
+  surface: PlaintextMultiAgentV2Surface,
+): boolean {
+  if (Array.isArray(value)) {
+    return value.reduce(
+      (changed, item) => markPlaintextMultiAgentV2Calls(item, surface) || changed,
+      false,
+    );
+  }
+  if (!isObject(value)) return false;
+  let changed = false;
+  const surfaceMatches = typeof value.namespace === "string"
+    ? surface.namespaces.has(value.namespace)
+    : value.namespace === undefined && surface.unnamespaced;
+  if (value.type === "function_call"
+    && surfaceMatches
+    && typeof value.name === "string"
+    && MULTI_AGENT_V2_MESSAGE_TOOLS.has(value.name)
+    && value.encrypted_function_args === undefined) {
+    value.encrypted_function_args = [];
+    changed = true;
+  }
+  for (const child of Object.values(value)) {
+    if (markPlaintextMultiAgentV2Calls(child, surface)) changed = true;
+  }
+  return changed;
+}
+
+function withPlaintextMultiAgentV2Markers(
+  body: ReadableStream<Uint8Array>,
+  surface: PlaintextMultiAgentV2Surface,
+): ReadableStream<Uint8Array> {
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+  let buffered = "";
+  const rewriteLine = (line: string): string => {
+    const suffix = line.endsWith("\r\n") ? "\r\n" : line.endsWith("\n") ? "\n" : "";
+    const content = suffix ? line.slice(0, -suffix.length) : line;
+    if (!content.startsWith("data:")) return line;
+    const data = content.slice(5).trimStart();
+    if (!data || data === "[DONE]") return line;
+    try {
+      const event = JSON.parse(data) as unknown;
+      return markPlaintextMultiAgentV2Calls(event, surface)
+        ? `data: ${JSON.stringify(event)}${suffix}`
+        : line;
+    } catch {
+      return line;
+    }
+  };
+  return body.pipeThrough(new TransformStream<Uint8Array, Uint8Array>({
+    transform(chunk, controller) {
+      buffered += decoder.decode(chunk, { stream: true });
+      let newline = buffered.indexOf("\n");
+      while (newline >= 0) {
+        controller.enqueue(encoder.encode(rewriteLine(buffered.slice(0, newline + 1))));
+        buffered = buffered.slice(newline + 1);
+        newline = buffered.indexOf("\n");
+      }
+    },
+    flush(controller) {
+      buffered += decoder.decode();
+      if (buffered) controller.enqueue(encoder.encode(rewriteLine(buffered)));
+    },
+  }));
+}
+
 export async function forwardNativeCodexRequest(
   request: Request,
   endpoint: NativeCodexEndpoint,
   fetchUpstream: NativeFetch = fetch,
   decodedBody?: unknown,
+  options: NativeCodexPassthroughOptions = {},
 ): Promise<Response> {
   const authorization = request.headers.get("authorization") ?? "";
   if (!authorization.startsWith("Bearer ") || authorization.length <= "Bearer ".length) {
@@ -219,15 +410,24 @@ export async function forwardNativeCodexRequest(
   if (endpoint === "models") headers.delete("if-none-match");
   const method = endpoint === "models" ? "GET" : "POST";
   let body: BodyInit | undefined;
+  let plaintextSurface = emptyPlaintextMultiAgentV2Surface();
   if (method === "POST") {
     const parseRequest = decodedBody === undefined ? request.clone() : undefined;
     const originalBody = await request.arrayBuffer();
     const scrubbed = scrubBridgeArtifactsForNative(
       decodedBody === undefined ? await readJsonRequestBody(parseRequest!) : decodedBody,
     );
-    if (scrubbed.changed) {
+    const prepared = options.plaintextMultiAgentV2Messages
+      ? plaintextMultiAgentV2MessageSchemas(scrubbed.value)
+      : {
+        value: scrubbed.value,
+        changed: false,
+        surface: emptyPlaintextMultiAgentV2Surface(),
+      };
+    plaintextSurface = prepared.surface;
+    if (scrubbed.changed || prepared.changed) {
       headers.delete("content-encoding");
-      body = JSON.stringify(scrubbed.value);
+      body = JSON.stringify(prepared.value);
     } else {
       body = originalBody;
     }
@@ -240,18 +440,45 @@ export async function forwardNativeCodexRequest(
   });
   const upstream = await fetchUpstream(upstreamRequest);
   const responseHeaders = endToEndHeaders(upstream.headers);
-  const isEventStream = (upstream.headers.get("content-type") ?? "")
-    .toLowerCase()
-    .includes("text/event-stream");
+  const contentType = (upstream.headers.get("content-type") ?? "").toLowerCase();
+  const isEventStream = contentType.includes("text/event-stream");
+  const rewritePlaintextCalls = plaintextSurface.unnamespaced
+    || plaintextSurface.namespaces.size > 0;
+  if (rewritePlaintextCalls && upstream.body && contentType.includes("application/json")) {
+    const original = await upstream.text();
+    let rewritten = original;
+    try {
+      const json = JSON.parse(original) as unknown;
+      if (markPlaintextMultiAgentV2Calls(json, plaintextSurface)) {
+        rewritten = JSON.stringify(json);
+      }
+    } catch {
+      // Preserve a malformed upstream body so the native Codex client reports the protocol error.
+    }
+    responseHeaders.delete("content-encoding");
+    responseHeaders.delete("content-length");
+    return new Response(rewritten, {
+      status: upstream.status,
+      statusText: upstream.statusText,
+      headers: responseHeaders,
+    });
+  }
+  if (rewritePlaintextCalls && upstream.body && isEventStream) {
+    responseHeaders.delete("content-encoding");
+    responseHeaders.delete("content-length");
+  }
+  const upstreamBody = upstream.body
+    ? withUncleanCloseTolerance(upstream.body, isEventStream, bytes => {
+      console.warn(
+        `[codex-chatgpt-web] native_upstream_unclean_close endpoint=${endpoint} bytes=${bytes}`
+        + " (turn had already completed; closing the client stream normally)",
+      );
+    })
+    : upstream.body;
   return new Response(
-    upstream.body
-      ? withUncleanCloseTolerance(upstream.body, isEventStream, bytes => {
-        console.warn(
-          `[codex-chatgpt-web] native_upstream_unclean_close endpoint=${endpoint} bytes=${bytes}`
-          + " (turn had already completed; closing the client stream normally)",
-        );
-      })
-      : upstream.body,
+    rewritePlaintextCalls && upstreamBody && isEventStream
+      ? withPlaintextMultiAgentV2Markers(upstreamBody, plaintextSurface)
+      : upstreamBody,
     {
       status: upstream.status,
       statusText: upstream.statusText,

--- a/src/server.ts
+++ b/src/server.ts
@@ -278,6 +278,8 @@ export interface ResponseRequestOptions {
   rememberState?: boolean;
   /** Observe the exact production adapter stream when invoking the handler in-process. */
   onAdapterEvent?: (event: AdapterEvent) => void;
+  /** Test and embedding seam for authenticated native Codex passthrough. */
+  fetchUpstream?: NativeFetch;
 }
 
 export function routeChatGptWebRequest(parsed: CodexParsedRequest, config: AppConfig): ChatGptWebModelRoute {
@@ -364,7 +366,9 @@ export async function responseRequest(
     : undefined;
   if (typeof requestedModel === "string" && !isChatGptWebModelSlug(requestedModel)) {
     try {
-      return await forwardNativeCodexRequest(nativeRequest, "responses", undefined, raw);
+      return await forwardNativeCodexRequest(nativeRequest, "responses", options.fetchUpstream, raw, {
+        plaintextMultiAgentV2Messages: config.subagentProtocol === "native",
+      });
     } catch (error) {
       return formatErrorResponse(502, "upstream_error", error instanceof Error ? error.message : String(error));
     }
@@ -386,7 +390,8 @@ export async function responseRequest(
       400,
       "invalid_request_error",
       "ChatGPT Web cannot read this encrypted cross-backend subagent payload. "
-        + "Start a new Compatibility V1 task, or delegate from a Web model whose collaboration call uses the plaintext-delivery marker.",
+        + "Restart Codex Web GPT and Codex, then start a new Native V2 task; "
+        + "use Compatibility V1 if the native backend still requires encrypted delegation.",
     );
   }
   if (typeof requestedPreviousResponseId === "string" && expanded === raw) {
@@ -781,7 +786,9 @@ export function startServer(
       if (req.method === "POST" && url.pathname === "/v1/responses") {
         if (draining) return formatErrorResponse(503, "server_error", "codex-chatgpt-web is draining for a requested service operation");
         return httpTurns.track(
-          signal => responseRequest(new Request(req, { signal }), config),
+          signal => responseRequest(new Request(req, { signal }), config, createChatGptWebAdapter, {
+            fetchUpstream: dependencies.fetchUpstream,
+          }),
           req.signal,
           process.platform,
           "responses",

--- a/tests/native-passthrough.test.ts
+++ b/tests/native-passthrough.test.ts
@@ -38,6 +38,383 @@ test("forwards native Codex requests verbatim to the official backend", async ()
   expect(await response.text()).toBe("data: native\n\n");
 });
 
+test("Native V2 removes encryption from collaboration message schemas", async () => {
+  const body = {
+    model: "gpt-5.6-sol",
+    stream: true,
+    tools: [{
+      type: "namespace",
+      name: "collaboration",
+      description: "Subagent tools",
+      tools: [
+        {
+          type: "function",
+          name: "spawn_agent",
+          parameters: {
+            type: "object",
+            properties: {
+              task_name: { type: "string" },
+              message: { type: "string", encrypted: true },
+            },
+          },
+        },
+        {
+          type: "function",
+          name: "send_message",
+          parameters: {
+            type: "object",
+            properties: { message: { type: "string", encrypted: true } },
+          },
+        },
+        {
+          type: "function",
+          name: "followup_task",
+          parameters: {
+            type: "object",
+            properties: { message: { type: "string", encrypted: true } },
+          },
+        },
+        {
+          type: "function",
+          name: "wait_agent",
+          parameters: {
+            type: "object",
+            properties: { timeout_ms: { type: "integer", encrypted: true } },
+          },
+        },
+      ],
+    }],
+  };
+  const compressedBody = Uint8Array.from(
+    Bun.zstdCompressSync(new TextEncoder().encode(JSON.stringify(body))),
+  );
+  const request = new Request("http://127.0.0.1:17841/v1/responses", {
+    method: "POST",
+    headers: {
+      authorization: "Bearer codex-oauth-token",
+      "content-type": "application/json",
+      "content-encoding": "zstd",
+    },
+    body: compressedBody,
+  });
+  let upstreamRequest: Request | undefined;
+
+  await forwardNativeCodexRequest(request, "responses", async input => {
+    upstreamRequest = input;
+    return new Response("data: [DONE]\n\n", {
+      headers: { "content-type": "text/event-stream" },
+    });
+  }, body, { plaintextMultiAgentV2Messages: true });
+
+  expect(upstreamRequest!.headers.get("content-encoding")).toBeNull();
+  const forwarded = await upstreamRequest!.json() as {
+    tools: Array<{ tools: Array<{ name: string; parameters: { properties: Record<string, Record<string, unknown>> } }> }>;
+  };
+  const tools = forwarded.tools[0]!.tools;
+  for (const name of ["spawn_agent", "send_message", "followup_task"]) {
+    expect(tools.find(tool => tool.name === name)!.parameters.properties.message)
+      .not.toHaveProperty("encrypted");
+  }
+  expect(tools.find(tool => tool.name === "wait_agent")!.parameters.properties.timeout_ms)
+    .toHaveProperty("encrypted", true);
+});
+
+test("Native V2 marks plaintext collaboration calls for Codex delivery", async () => {
+  const body = {
+    model: "gpt-5.6-sol",
+    stream: true,
+    tools: [{
+      type: "namespace",
+      name: "collaboration",
+      tools: [{
+        type: "function",
+        name: "spawn_agent",
+        parameters: {
+          type: "object",
+          properties: { message: { type: "string", encrypted: true } },
+        },
+      }],
+    }],
+  };
+  const request = new Request("http://127.0.0.1:17841/v1/responses", {
+    method: "POST",
+    headers: { authorization: "Bearer codex-oauth-token", "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const event = {
+    type: "response.output_item.done",
+    item: {
+      type: "function_call",
+      name: "spawn_agent",
+      namespace: "collaboration",
+      call_id: "call_plaintext_spawn",
+      arguments: JSON.stringify({ task_name: "inspect", message: "Inspect the repository" }),
+    },
+  };
+
+  const response = await forwardNativeCodexRequest(request, "responses", async () => new Response(
+    `event: response.output_item.done\ndata: ${JSON.stringify(event)}\n\ndata: [DONE]\n\n`,
+    { headers: { "content-type": "text/event-stream" } },
+  ), body, { plaintextMultiAgentV2Messages: true });
+
+  const data = (await response.text())
+    .split("\n")
+    .find(line => line.startsWith("data: {") && line.includes("function_call"));
+  expect(JSON.parse(data!.slice(6))).toMatchObject({
+    item: {
+      type: "function_call",
+      name: "spawn_agent",
+      namespace: "collaboration",
+      encrypted_function_args: [],
+    },
+  });
+});
+
+test("Native V2 preserves encrypted and unrelated collaboration calls", async () => {
+  const body = {
+    model: "gpt-5.6-sol",
+    stream: true,
+    tools: [{
+      type: "namespace",
+      name: "collaboration",
+      tools: [{
+        type: "function",
+        name: "spawn_agent",
+        parameters: {
+          type: "object",
+          properties: { message: { type: "string", encrypted: true } },
+        },
+      }],
+    }],
+  };
+  const request = new Request("http://127.0.0.1:17841/v1/responses", {
+    method: "POST",
+    headers: { authorization: "Bearer codex-oauth-token", "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const encryptedCall = {
+    type: "response.output_item.done",
+    item: {
+      type: "function_call",
+      name: "spawn_agent",
+      namespace: "collaboration",
+      call_id: "call_encrypted_spawn",
+      arguments: "opaque",
+      encrypted_function_args: ["ciphertext"],
+    },
+  };
+  const unrelatedCall = {
+    type: "response.output_item.done",
+    item: {
+      type: "function_call",
+      name: "wait_agent",
+      namespace: "collaboration",
+      call_id: "call_wait",
+      arguments: JSON.stringify({ timeout_ms: 500 }),
+    },
+  };
+
+  const response = await forwardNativeCodexRequest(request, "responses", async () => new Response(
+    `data: ${JSON.stringify(encryptedCall)}\n\ndata: ${JSON.stringify(unrelatedCall)}\n\ndata: [DONE]\n\n`,
+    { headers: { "content-type": "text/event-stream" } },
+  ), body, { plaintextMultiAgentV2Messages: true });
+
+  const events = (await response.text())
+    .split("\n")
+    .filter(line => line.startsWith("data: {") && line.includes("function_call"))
+    .map(line => JSON.parse(line.slice(6)) as { item: Record<string, unknown> });
+  expect(events[0]!.item.encrypted_function_args).toEqual(["ciphertext"]);
+  expect(events[1]!.item).not.toHaveProperty("encrypted_function_args");
+});
+
+test("Native V2 rewrites Responses Lite additional collaboration tools", async () => {
+  const body = {
+    model: "gpt-5.6-sol",
+    stream: true,
+    input: [{
+      type: "additional_tools",
+      role: "developer",
+      tools: [{
+        type: "namespace",
+        name: "collaboration",
+        tools: [{
+          type: "function",
+          name: "followup_task",
+          parameters: {
+            type: "object",
+            properties: { message: { type: "string", encrypted: true } },
+          },
+        }],
+      }],
+    }],
+  };
+  const request = new Request("http://127.0.0.1:17841/v1/responses", {
+    method: "POST",
+    headers: { authorization: "Bearer codex-oauth-token", "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  let upstreamRequest: Request | undefined;
+
+  await forwardNativeCodexRequest(request, "responses", async input => {
+    upstreamRequest = input;
+    return new Response("data: [DONE]\n\n", {
+      headers: { "content-type": "text/event-stream" },
+    });
+  }, body, { plaintextMultiAgentV2Messages: true });
+
+  const forwarded = await upstreamRequest!.json() as {
+    input: Array<{ tools: Array<{ tools: Array<{ parameters: { properties: { message: Record<string, unknown> } } }> }> }>;
+  };
+  expect(forwarded.input[0]!.tools[0]!.tools[0]!.parameters.properties.message)
+    .not.toHaveProperty("encrypted");
+});
+
+test("Native V2 recognizes a configured collaboration namespace by its tool set", async () => {
+  const messageTool = (name: string) => ({
+    type: "function",
+    name,
+    parameters: {
+      type: "object",
+      properties: { message: { type: "string", encrypted: true } },
+    },
+  });
+  const body = {
+    model: "gpt-5.6-sol",
+    stream: true,
+    tools: [{
+      type: "namespace",
+      name: "agents",
+      tools: [
+        messageTool("spawn_agent"),
+        messageTool("send_message"),
+        messageTool("followup_task"),
+      ],
+    }],
+  };
+  const request = new Request("http://127.0.0.1:17841/v1/responses", {
+    method: "POST",
+    headers: { authorization: "Bearer codex-oauth-token", "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  let upstreamRequest: Request | undefined;
+  const event = {
+    type: "response.output_item.done",
+    item: {
+      type: "function_call",
+      name: "spawn_agent",
+      namespace: "agents",
+      call_id: "call_custom_namespace",
+      arguments: JSON.stringify({ task_name: "inspect", message: "Inspect the repository" }),
+    },
+  };
+
+  const response = await forwardNativeCodexRequest(request, "responses", async input => {
+    upstreamRequest = input;
+    return new Response(
+      `data: ${JSON.stringify(event)}\n\ndata: [DONE]\n\n`,
+      { headers: { "content-type": "text/event-stream" } },
+    );
+  }, body, { plaintextMultiAgentV2Messages: true });
+
+  const forwarded = await upstreamRequest!.json() as {
+    tools: Array<{ tools: Array<{ parameters: { properties: { message: Record<string, unknown> } } }> }>;
+  };
+  expect(forwarded.tools[0]!.tools.every(tool => !("encrypted" in tool.parameters.properties.message)))
+    .toBe(true);
+  const callData = (await response.text()).split("\n").find(line => line.includes("function_call"));
+  expect(JSON.parse(callData!.slice(6)).item.encrypted_function_args).toEqual([]);
+});
+
+test("Native V2 recognizes an unnamespaced collaboration surface", async () => {
+  const messageTool = (name: string) => ({
+    type: "function",
+    name,
+    parameters: {
+      type: "object",
+      properties: { message: { type: "string", encrypted: true } },
+    },
+  });
+  const body = {
+    model: "gpt-5.6-sol",
+    stream: true,
+    tools: [
+      messageTool("spawn_agent"),
+      messageTool("send_message"),
+      messageTool("followup_task"),
+    ],
+  };
+  const request = new Request("http://127.0.0.1:17841/v1/responses", {
+    method: "POST",
+    headers: { authorization: "Bearer codex-oauth-token", "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  let upstreamRequest: Request | undefined;
+  const event = {
+    type: "response.output_item.done",
+    item: {
+      type: "function_call",
+      name: "followup_task",
+      call_id: "call_unnamespaced",
+      arguments: JSON.stringify({ target: "/root/inspect", message: "Continue" }),
+    },
+  };
+
+  const response = await forwardNativeCodexRequest(request, "responses", async input => {
+    upstreamRequest = input;
+    return new Response(
+      `data: ${JSON.stringify(event)}\n\ndata: [DONE]\n\n`,
+      { headers: { "content-type": "text/event-stream" } },
+    );
+  }, body, { plaintextMultiAgentV2Messages: true });
+
+  const forwarded = await upstreamRequest!.json() as {
+    tools: Array<{ parameters: { properties: { message: Record<string, unknown> } } }>;
+  };
+  expect(forwarded.tools.every(tool => !("encrypted" in tool.parameters.properties.message)))
+    .toBe(true);
+  const callData = (await response.text()).split("\n").find(line => line.includes("function_call"));
+  expect(JSON.parse(callData!.slice(6)).item.encrypted_function_args).toEqual([]);
+});
+
+test("Native V2 marks plaintext collaboration calls in JSON responses", async () => {
+  const body = {
+    model: "gpt-5.6-sol",
+    stream: false,
+    tools: [{
+      type: "namespace",
+      name: "collaboration",
+      tools: [{
+        type: "function",
+        name: "send_message",
+        parameters: {
+          type: "object",
+          properties: { message: { type: "string", encrypted: true } },
+        },
+      }],
+    }],
+  };
+  const request = new Request("http://127.0.0.1:17841/v1/responses", {
+    method: "POST",
+    headers: { authorization: "Bearer codex-oauth-token", "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  const response = await forwardNativeCodexRequest(request, "responses", async () => Response.json({
+    id: "resp_native_v2_json",
+    output: [{
+      type: "function_call",
+      name: "send_message",
+      namespace: "collaboration",
+      call_id: "call_json_message",
+      arguments: JSON.stringify({ target: "/root/inspect", message: "Status?" }),
+    }],
+  }), body, { plaintextMultiAgentV2Messages: true });
+
+  expect(await response.json()).toMatchObject({
+    output: [{ encrypted_function_args: [] }],
+  });
+});
+
 test("forwards native Codex compaction requests to the official compact endpoint", async () => {
   const originalBody = Bun.zstdCompressSync(Buffer.from('{"model":"gpt-5.6-sol","input":[]}'));
   const encoded = new ArrayBuffer(originalBody.byteLength);

--- a/tests/server-subagents.test.ts
+++ b/tests/server-subagents.test.ts
@@ -35,3 +35,77 @@ test("rejects encrypted cross-backend delegation before constructing the browser
   });
   expect(adapterConstructions).toBe(0);
 });
+
+test("subagent protocol selection controls plaintext MultiAgent V2 passthrough", async () => {
+  const config = defaultConfig("browser-only");
+  config.subagentProtocol = "native";
+  const body = {
+    model: "gpt-5.6-sol",
+    stream: true,
+    tools: [{
+      type: "namespace",
+      name: "collaboration",
+      tools: [{
+        type: "function",
+        name: "spawn_agent",
+        parameters: {
+          type: "object",
+          properties: { message: { type: "string", encrypted: true } },
+        },
+      }],
+    }],
+  };
+  let upstreamRequest: Request | undefined;
+
+  const response = await responseRequest(new Request("http://127.0.0.1:17841/v1/responses", {
+    method: "POST",
+    headers: {
+      authorization: "Bearer codex-oauth-token",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body),
+  }), config, () => {
+    throw new Error("native passthrough must not construct the browser adapter");
+  }, {
+    fetchUpstream: async input => {
+      upstreamRequest = input;
+      return new Response("data: [DONE]\n\n", {
+        headers: { "content-type": "text/event-stream" },
+      });
+    },
+  });
+
+  expect(response.status).toBe(200);
+  const forwarded = await upstreamRequest!.json() as {
+    tools: Array<{ tools: Array<{ parameters: { properties: { message: Record<string, unknown> } } }> }>;
+  };
+  expect(forwarded.tools[0]!.tools[0]!.parameters.properties.message)
+    .not.toHaveProperty("encrypted");
+
+  config.subagentProtocol = "compatibility-v1";
+  let compatibilityRequest: Request | undefined;
+  const compatibilityResponse = await responseRequest(new Request(
+    "http://127.0.0.1:17841/v1/responses",
+    {
+      method: "POST",
+      headers: {
+        authorization: "Bearer codex-oauth-token",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+    },
+  ), config, () => {
+    throw new Error("native passthrough must not construct the browser adapter");
+  }, {
+    fetchUpstream: async input => {
+      compatibilityRequest = input;
+      return new Response("data: [DONE]\n\n", {
+        headers: { "content-type": "text/event-stream" },
+      });
+    },
+  });
+  expect(compatibilityResponse.status).toBe(200);
+  const compatibilityBody = await compatibilityRequest!.json() as typeof forwarded;
+  expect(compatibilityBody.tools[0]!.tools[0]!.parameters.properties.message)
+    .toHaveProperty("encrypted", true);
+});


### PR DESCRIPTION
## What this changes

Fixes #297.

Native mode now rewrites only the MultiAgent V2 collaboration message boundary that must cross providers:

- authenticated native Responses requests remove `encrypted: true` only from the `message` schemas of `spawn_agent`, `send_message`, and `followup_task`;
- ordinary `tools`, Responses Lite `additional_tools`, configured collaboration namespaces, and unnamespaced surfaces are covered;
- matching plaintext function calls receive `encrypted_function_args: []` in SSE and JSON responses so Codex delivers readable arguments;
- genuinely encrypted calls, unrelated schemas, model discovery, compaction, and Compatibility V1 remain unchanged;
- documentation now explains local plaintext history exposure and the required launcher/Codex restart plus new-task boundary.

## Evidence

Before this change, a native V2 spawn targeting a `chatgpt-web/*` child forwards an encrypted message schema. The official backend returns provider-private function arguments and the routed Web child fails before browser construction with the encrypted cross-backend payload error.

Focused request/response fixtures now prove schema rewriting and plaintext markers for namespace, configured-namespace, unnamespaced, Responses Lite, SSE, and JSON shapes. Negative cases prove that encrypted arguments, unrelated tool fields, and Compatibility V1 remain untouched.

`bun run smoke:subagents` exercises a stock Codex binary through nested root/child/grandchild spawn, wait, and follow-up lifecycles:

```text
CODEX_SUBAGENT_V1_LIFECYCLE_SMOKE_OK
CODEX_SUBAGENT_V2_LIFECYCLE_SMOKE_OK
```

## Scope and invariants

- [x] I read and followed `CONTRIBUTING.md`.
- [x] This is a small, focused change with no unrelated cleanup or generated rewrite.
- [x] The change stays focused on ChatGPT web-backed Codex models; it does not add a generic provider or unrelated product surface.
- [x] Model, route, effort, connector, and capability selection remain explicit with no silent fallback or false-success path.
- [x] If this touches Full harness or MCP, every available Web effort retains the same turn-bound capability and Browser-only gains no broker or connector.
- [x] Terms and trademark claims remain factual; this change is not marketed as a quota or rate-limit bypass.

## Verification

- [x] I ran `bun install --frozen-lockfile` in the repository root and `launcher/` (Bun 1.4.0; no changes).
- [ ] I ran `bun run verify` with the Bun version pinned by `package.json`.
  - The gate currently stops at unchanged dependency audits: root reports 4 high and 2 moderate advisories in `fast-uri`/`qs`; launcher reports 4 high and 1 moderate in `fast-uri`/`@xmldom/xmldom`. No package or lockfile is changed by this PR.
  - Running the remaining stages directly produced 530/530 core tests, 248/248 runnable launcher tests (1 platform skip), clean root/launcher typechecks, a successful launcher production build, runtime bundle, and third-party notices.
  - The final relocated-runtime smoke reached its macOS browser check and failed because `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome` is absent on this host.
- [x] I added or updated a focused regression test for behavior changes.
- [ ] I manually tested the affected behavior.
  - The stock-Codex V1/V2 lifecycle smoke is green; a fresh account-bound browser task after a full launcher/Codex restart remains to be run.
- [ ] If this changes local tools, MCP execution, or the outer Codex agent loop, I tested it through a real installed Codex integration; DEV mode alone is acceptable only when execution is not affected.
  - A signed macOS arm64 package was installed and its authenticated launcher browser/protocol checks passed, but the post-restart cross-backend task is not yet claimed.
- [x] If this changes ChatGPT browser UI handling, I included observed DOM evidence and a reproducible fixture instead of broadening selectors speculatively. (Not applicable: no browser selectors or UI handling changed.)
- [x] If this changes the launcher, I preserved macOS, Windows, and Linux packaging and named the platform packages actually built below. (Not applicable: no launcher source changed.)
- [x] I did not commit browser state, credentials, Tunnel IDs, raw logs, generated artifacts, or private paths.
- [x] I did not include an unrelated dependency update, release artifact, or version change.

## Platform or account validation

- macOS arm64, Full mode: packaged application installed; Native protocol is active; authenticated embedded-browser check passed.
- macOS arm64: stock Codex V1 and V2 nested lifecycle smoke passed.
- Account-bound browser-backed V2 delegation after full restart: not run yet.
- Windows and Linux packages: not run; no launcher code changed.
