### PR TITLE
fix(doctor): report truthful model-catalog request evidence and routing

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -32,6 +32,12 @@ If the models still do not appear:
 - make sure another Codex wrapper is not replacing the route; and
 - export a safe log after the failed catalog check.
 
+Doctor can prove whether this daemon received a Codex `/v1/models` request. A green setup step and a
+healthy proxy are not catalog evidence. If top-level `model_provider` selects a provider other than
+the built-in `openai` provider, or `model_catalog_json` is set, Codex may never query the ChatGPT Web
+catalog; a `[model_providers.*]` table alone does not select a provider. First-class
+external-provider coexistence is tracked in [#205](https://github.com/miuuyy/codex-chatgpt-web/issues/205).
+
 A green step 3 followed by a browser-turn error means installation succeeded. Repeating step 3 will
 not repair an unrelated ChatGPT browser or model-turn failure.
 

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -3,12 +3,17 @@ import type { AppConfig } from "./config";
 import { getConfigDir, getConfigPath, loadConfig } from "./config";
 import { join } from "node:path";
 import { inspectCodexIntegration } from "./codex-integration";
+import { findTopLevelAssignment, parseDocument } from "./codex-integration-document";
+import { getCodexConfigPath } from "./codex-integration-shared";
 import { browserLoginStateExists, loginVerificationMarkerPath } from "./browser-login";
 import { getServiceStatus } from "./service";
 import { tunnelStatus } from "./tunnel";
 import { getTunnelServiceStatus } from "./tunnel-service";
 import { inspectLauncherBrowserHost, readLauncherBrowserHostDescriptor } from "./launcher-browser-host";
 import { processRunning } from "./process";
+
+const BUILTIN_CODEX_MODEL_PROVIDER = "openai";
+const EXTERNAL_PROVIDER_COEXISTENCE_ISSUE = "https://github.com/miuuyy/codex-chatgpt-web/issues/205";
 
 export type CheckStatus = "ok" | "warning" | "error";
 
@@ -23,6 +28,17 @@ export interface DoctorReport {
   ok: boolean;
   mode?: AppConfig["mode"];
   checks: DoctorCheck[];
+}
+
+export type CodexCatalogRouting =
+  | { status: "default" }
+  | { status: "custom-provider"; provider: string; explicitCatalog: boolean }
+  | { status: "explicit-catalog" }
+  | { status: "unreadable"; detail: string };
+
+interface ProxyInspection {
+  check: DoctorCheck;
+  body?: Record<string, unknown>;
 }
 
 function secureFile(path: string): boolean {
@@ -57,40 +73,139 @@ function launcherOwnershipError(config: AppConfig, health: Record<string, unknow
   return undefined;
 }
 
-async function proxyCheck(config: AppConfig): Promise<DoctorCheck> {
+async function inspectProxy(config: AppConfig): Promise<ProxyInspection> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 2_000);
   try {
     const response = await fetch(`http://${config.host}:${config.port}/healthz`, { signal: controller.signal });
-    if (!response.ok) return { id: "proxy", status: "error", message: `Responses proxy returned HTTP ${response.status}` };
+    if (!response.ok) return { check: { id: "proxy", status: "error", message: `Responses proxy returned HTTP ${response.status}` } };
     const body = await response.json() as Record<string, unknown>;
     if (body.service !== "codex-chatgpt-web" || body.status !== "ok") {
-      return { id: "proxy", status: "error", message: "The configured port belongs to another service" };
+      return { check: { id: "proxy", status: "error", message: "The configured port belongs to another service" } };
     }
     if (body.mode !== config.mode) {
-      return { id: "proxy", status: "error", message: `Daemon is running in ${String(body.mode)} mode; config requires ${config.mode}` };
+      return { check: { id: "proxy", status: "error", message: `Daemon is running in ${String(body.mode)} mode; config requires ${config.mode}` } };
     }
     if (body.version !== config.releaseVersion) {
-      return { id: "proxy", status: "error", message: `Daemon version is ${String(body.version)}; config requires ${config.releaseVersion}` };
+      return { check: { id: "proxy", status: "error", message: `Daemon version is ${String(body.version)}; config requires ${config.releaseVersion}` } };
     }
     if (body.accepting_turns !== true) {
       return {
-        id: "proxy",
-        status: "error",
-        message: "Responses proxy is still drained and is not accepting Codex turns",
+        check: {
+          id: "proxy",
+          status: "error",
+          message: "Responses proxy is still drained and is not accepting Codex turns",
+        },
       };
     }
     const ownershipError = launcherOwnershipError(config, body);
     if (ownershipError) {
-      return { id: "proxy", status: "error", message: "Responses proxy ownership could not be verified", detail: ownershipError };
+      return { check: { id: "proxy", status: "error", message: "Responses proxy ownership could not be verified", detail: ownershipError } };
     }
-    return { id: "proxy", status: "ok", message: `Responses proxy is healthy on 127.0.0.1:${config.port}` };
+    return {
+      check: { id: "proxy", status: "ok", message: `Responses proxy is healthy on 127.0.0.1:${config.port}` },
+      body,
+    };
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
-    return { id: "proxy", status: "error", message: "Responses proxy is not reachable", detail };
+    return { check: { id: "proxy", status: "error", message: "Responses proxy is not reachable", detail } };
   } finally {
     clearTimeout(timeout);
   }
+}
+
+export function readCatalogRequestCount(health: Record<string, unknown>): number | undefined {
+  const value = health.successful_model_catalog_requests;
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+export function inspectCodexCatalogRoutingFromText(text: string): CodexCatalogRouting {
+  try {
+    const lines = parseDocument(text).lines;
+    const provider = findTopLevelAssignment(lines, "model_provider");
+    const catalog = findTopLevelAssignment(lines, "model_catalog_json");
+    if (provider.present && !provider.value?.trim()) {
+      return { status: "unreadable", detail: "top-level model_provider is empty" };
+    }
+    const customProvider = provider.present && provider.value && provider.value !== BUILTIN_CODEX_MODEL_PROVIDER
+      ? provider.value
+      : undefined;
+    if (customProvider) {
+      return { status: "custom-provider", provider: customProvider, explicitCatalog: catalog.present };
+    }
+    if (catalog.present) return { status: "explicit-catalog" };
+    return { status: "default" };
+  } catch (error) {
+    return { status: "unreadable", detail: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+export function readCodexCatalogRouting(readText: (path: string) => string = (path) => readFileSync(path, "utf8")): CodexCatalogRouting {
+  const path = getCodexConfigPath();
+  if (!existsSync(path)) return { status: "default" };
+  try {
+    return inspectCodexCatalogRoutingFromText(readText(path));
+  } catch {
+    return { status: "unreadable", detail: "Codex config could not be read" };
+  }
+}
+
+export function modelCatalogDoctorCheck(input: {
+  successfulModelCatalogRequests: number | undefined;
+  routing: CodexCatalogRouting;
+}): DoctorCheck {
+  if (input.successfulModelCatalogRequests === undefined) {
+    return {
+      id: "model-catalog",
+      status: "warning",
+      message: "Responses proxy did not report model catalog request counts",
+      detail: "Doctor cannot prove whether Codex requested /v1/models.",
+    };
+  }
+  if (input.successfulModelCatalogRequests > 0) {
+    return {
+      id: "model-catalog",
+      status: "ok",
+      message: "Codex has requested the ChatGPT Web model catalog from this daemon",
+    };
+  }
+
+  if (input.routing.status === "custom-provider") {
+    return {
+      id: "model-catalog",
+      status: "warning",
+      message: `Codex is obtaining its model catalog from the selected provider ${JSON.stringify(input.routing.provider)}`,
+      detail: [
+        "A top-level model_provider other than the built-in openai provider owns model discovery, so zero requests to this daemon's /v1/models endpoint are expected.",
+        "A [model_providers.*] table definition alone does not select a provider.",
+        ...(input.routing.explicitCatalog
+          ? ["Codex also has a top-level model_catalog_json assignment, which may bypass this daemon's catalog route."]
+          : []),
+        `First-class external-provider coexistence is tracked in ${EXTERNAL_PROVIDER_COEXISTENCE_ISSUE}.`,
+      ].join(" "),
+    };
+  }
+  if (input.routing.status === "explicit-catalog") {
+    return {
+      id: "model-catalog",
+      status: "warning",
+      message: "Codex has a top-level model_catalog_json assignment that may bypass this daemon's model catalog",
+      detail: [
+        "Zero requests to /v1/models can be expected in this configuration.",
+        `First-class external-provider coexistence is tracked in ${EXTERNAL_PROVIDER_COEXISTENCE_ISSUE}.`,
+      ].join(" "),
+    };
+  }
+
+  const unreadable = input.routing.status === "unreadable"
+    ? ` Codex catalog routing could not be inspected (${input.routing.detail}); doctor did not assume an alternate catalog owner.`
+    : "";
+  return {
+    id: "model-catalog",
+    status: "warning",
+    message: "Codex has not requested the ChatGPT Web model catalog since this daemon started",
+    detail: `The ChatGPT Web models in the Codex picker are not proven. Setup and a healthy proxy are not catalog evidence. Fully restart Codex, including its background process, while this launcher remains open, then run doctor again.${unreadable}`,
+  };
 }
 
 export async function runDoctor(): Promise<DoctorReport> {
@@ -164,7 +279,14 @@ export async function runDoctor(): Promise<DoctorReport> {
   } else {
     checks.push({ id: "service", status: "ok", message: "macOS background service is loaded" });
   }
-  checks.push(await proxyCheck(config));
+  const proxy = await inspectProxy(config);
+  checks.push(proxy.check);
+  if (proxy.check.status === "ok" && proxy.body && codex.installed && codex.active && codex.errors.length === 0) {
+    checks.push(modelCatalogDoctorCheck({
+      successfulModelCatalogRequests: readCatalogRequestCount(proxy.body),
+      routing: readCodexCatalogRouting(),
+    }));
+  }
 
   if (config.mode === "full") {
     const settings = config.tunnel!;

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -116,7 +116,7 @@ async function inspectProxy(config: AppConfig): Promise<ProxyInspection> {
 
 export function readCatalogRequestCount(health: Record<string, unknown>): number | undefined {
   const value = health.successful_model_catalog_requests;
-  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : undefined;
 }
 
 export function inspectCodexCatalogRoutingFromText(text: string): CodexCatalogRouting {
@@ -126,6 +126,9 @@ export function inspectCodexCatalogRoutingFromText(text: string): CodexCatalogRo
     const catalog = findTopLevelAssignment(lines, "model_catalog_json");
     if (provider.present && !provider.value?.trim()) {
       return { status: "unreadable", detail: "top-level model_provider is empty" };
+    }
+    if (catalog.present && !catalog.value?.trim()) {
+      return { status: "unreadable", detail: "top-level model_catalog_json is empty" };
     }
     const customProvider = provider.present && provider.value && provider.value !== BUILTIN_CODEX_MODEL_PROVIDER
       ? provider.value

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -131,6 +131,22 @@ describe("model catalog doctor evidence", () => {
     expect(check.detail).toContain("duplicate top-level model_provider");
   });
 
+  test("fails closed when model_catalog_json is empty or whitespace", () => {
+    for (const emptyAssignment of ['model_catalog_json = ""', 'model_catalog_json = "   "', "model_catalog_json = ''"]) {
+      const routing = inspectCodexCatalogRoutingFromText([
+        'openai_base_url = "http://127.0.0.1:17841/v1"',
+        emptyAssignment,
+        "",
+      ].join("\n"));
+      expect(routing).toEqual({ status: "unreadable", detail: "top-level model_catalog_json is empty" });
+      const check = modelCatalogDoctorCheck({ successfulModelCatalogRequests: 0, routing });
+      expect(check.status).toBe("warning");
+      expect(check.message).toBe("Codex has not requested the ChatGPT Web model catalog since this daemon started");
+      expect(check.detail).toContain("top-level model_catalog_json is empty");
+      expect(check.detail).toContain("did not assume an alternate catalog owner");
+    }
+  });
+
   test("keeps catalog proof even when a custom provider is also selected", () => {
     const check = modelCatalogDoctorCheck({
       successfulModelCatalogRequests: 4,
@@ -183,12 +199,17 @@ describe("Codex catalog routing inspection", () => {
 });
 
 describe("healthz catalog counters", () => {
-  test("reads successful_model_catalog_requests and rejects malformed counts", () => {
+  test("reads successful_model_catalog_requests and rejects non-integer or malformed counts", () => {
     expect(readCatalogRequestCount({ successful_model_catalog_requests: 0 })).toBe(0);
-    expect(readCatalogRequestCount({ successful_model_catalog_requests: 2 })).toBe(2);
-    expect(readCatalogRequestCount({})).toBeUndefined();
+    expect(readCatalogRequestCount({ successful_model_catalog_requests: 1 })).toBe(1);
+    expect(readCatalogRequestCount({ successful_model_catalog_requests: 42 })).toBe(42);
     expect(readCatalogRequestCount({ successful_model_catalog_requests: -1 })).toBeUndefined();
-    expect(readCatalogRequestCount({ successful_model_catalog_requests: "0" })).toBeUndefined();
+    expect(readCatalogRequestCount({ successful_model_catalog_requests: 0.5 })).toBeUndefined();
+    expect(readCatalogRequestCount({ successful_model_catalog_requests: 1.25 })).toBeUndefined();
+    expect(readCatalogRequestCount({ successful_model_catalog_requests: "1" })).toBeUndefined();
+    expect(readCatalogRequestCount({ successful_model_catalog_requests: null })).toBeUndefined();
+    expect(readCatalogRequestCount({ successful_model_catalog_requests: undefined })).toBeUndefined();
+    expect(readCatalogRequestCount({})).toBeUndefined();
   });
 
   test("warns when healthz omits catalog request counts", () => {

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  inspectCodexCatalogRoutingFromText,
+  modelCatalogDoctorCheck,
+  readCatalogRequestCount,
+  readCodexCatalogRouting,
+} from "../src/doctor";
+
+const roots: string[] = [];
+
+function fixture(): { root: string; codexHome: string } {
+  const root = join(tmpdir(), `codex-chatgpt-web-doctor-${process.pid}-${Date.now()}-${Math.random()}`);
+  const codexHome = join(root, "codex");
+  mkdirSync(codexHome, { recursive: true });
+  roots.push(root);
+  process.env.CODEX_HOME = codexHome;
+  return { root, codexHome };
+}
+
+afterEach(() => {
+  delete process.env.CODEX_HOME;
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("model catalog doctor evidence", () => {
+  test("treats a successful /v1/models request as catalog proof", () => {
+    const check = modelCatalogDoctorCheck({
+      successfulModelCatalogRequests: 1,
+      routing: { status: "default" },
+    });
+    expect(check).toMatchObject({
+      id: "model-catalog",
+      status: "ok",
+      message: "Codex has requested the ChatGPT Web model catalog from this daemon",
+    });
+    expect(check.detail).toBeUndefined();
+  });
+
+  test("warns when the daemon has received no catalog requests under built-in routing", () => {
+    const check = modelCatalogDoctorCheck({
+      successfulModelCatalogRequests: 0,
+      routing: inspectCodexCatalogRoutingFromText([
+        'openai_base_url = "http://127.0.0.1:17841/v1"',
+        "",
+        "[features]",
+        "multi_agent = true",
+        "",
+      ].join("\n")),
+    });
+    expect(check.status).toBe("warning");
+    expect(check.message).toBe("Codex has not requested the ChatGPT Web model catalog since this daemon started");
+    expect(check.detail).toContain("Setup and a healthy proxy are not catalog evidence");
+    expect(check.detail).not.toContain("model_provider");
+  });
+
+  test("explains zero catalog requests when a custom model_provider is selected", () => {
+    const routing = inspectCodexCatalogRoutingFromText([
+      'model_provider = "sub2api"',
+      'openai_base_url = "http://127.0.0.1:17841/v1"',
+      "",
+      "[model_providers.sub2api]",
+      'name = "Sub2API"',
+      'base_url = "http://127.0.0.1:8080/v1"',
+      "",
+    ].join("\n"));
+    const check = modelCatalogDoctorCheck({ successfulModelCatalogRequests: 0, routing });
+    expect(routing).toEqual({ status: "custom-provider", provider: "sub2api", explicitCatalog: false });
+    expect(check.status).toBe("warning");
+    expect(check.message).toBe('Codex is obtaining its model catalog from the selected provider "sub2api"');
+    expect(check.detail).toContain("zero requests to this daemon's /v1/models endpoint are expected");
+    expect(check.detail).toContain("https://github.com/miuuyy/codex-chatgpt-web/issues/205");
+    expect(check.detail).not.toContain("not proven");
+  });
+
+  test("explains zero catalog requests when model_catalog_json is set", () => {
+    const routing = inspectCodexCatalogRoutingFromText([
+      'openai_base_url = "http://127.0.0.1:17841/v1"',
+      'model_catalog_json = "models.json"',
+      "",
+    ].join("\n"));
+    const check = modelCatalogDoctorCheck({ successfulModelCatalogRequests: 0, routing });
+    expect(routing).toEqual({ status: "explicit-catalog" });
+    expect(check.status).toBe("warning");
+    expect(check.message).toContain("model_catalog_json");
+    expect(check.detail).toContain("Zero requests to /v1/models can be expected");
+    expect(check.detail).toContain("https://github.com/miuuyy/codex-chatgpt-web/issues/205");
+    expect(check.detail).not.toContain("models.json");
+  });
+
+  test("does not treat a model_providers table as selected routing", () => {
+    const withBuiltIn = inspectCodexCatalogRoutingFromText([
+      'openai_base_url = "http://127.0.0.1:17841/v1"',
+      'model_provider = "openai"',
+      "",
+      "[model_providers.sub2api]",
+      'name = "Sub2API (Tailscale)"',
+      'base_url = "http://127.0.0.1:8080/v1"',
+      'wire_api = "responses"',
+      "",
+    ].join("\n"));
+    const tableOnly = inspectCodexCatalogRoutingFromText([
+      'openai_base_url = "http://127.0.0.1:17841/v1"',
+      "",
+      "[model_providers.sub2api]",
+      'name = "Sub2API (Tailscale)"',
+      'base_url = "http://127.0.0.1:8080/v1"',
+      "",
+    ].join("\n"));
+    for (const routing of [withBuiltIn, tableOnly]) {
+      const check = modelCatalogDoctorCheck({ successfulModelCatalogRequests: 0, routing });
+      expect(routing).toEqual({ status: "default" });
+      expect(check.message).toBe("Codex has not requested the ChatGPT Web model catalog since this daemon started");
+      expect(check.detail).not.toContain("sub2api");
+    }
+  });
+
+  test("does not assume an alternate catalog owner when Codex config is unreadable", () => {
+    const routing = inspectCodexCatalogRoutingFromText([
+      'model_provider = "first"',
+      'model_provider = "second"',
+      "",
+    ].join("\n"));
+    const check = modelCatalogDoctorCheck({ successfulModelCatalogRequests: 0, routing });
+    expect(routing.status).toBe("unreadable");
+    expect(check.status).toBe("warning");
+    expect(check.message).toBe("Codex has not requested the ChatGPT Web model catalog since this daemon started");
+    expect(check.detail).toContain("did not assume an alternate catalog owner");
+    expect(check.detail).toContain("duplicate top-level model_provider");
+  });
+
+  test("keeps catalog proof even when a custom provider is also selected", () => {
+    const check = modelCatalogDoctorCheck({
+      successfulModelCatalogRequests: 4,
+      routing: { status: "custom-provider", provider: "sub2api", explicitCatalog: true },
+    });
+    expect(check.status).toBe("ok");
+    expect(check.message).toBe("Codex has requested the ChatGPT Web model catalog from this daemon");
+  });
+});
+
+describe("Codex catalog routing inspection", () => {
+  test("reads top-level assignments from Codex config without mutating it", async () => {
+    const { codexHome } = fixture();
+    const path = join(codexHome, "config.toml");
+    const original = [
+      'model_provider = "sub2api" # selected',
+      'model_catalog_json = "models.json"',
+      "",
+      "[model_providers.sub2api]",
+      'name = "Sub2API"',
+      "",
+    ].join("\n");
+    writeFileSync(path, original);
+
+    expect(readCodexCatalogRouting()).toEqual({
+      status: "custom-provider",
+      provider: "sub2api",
+      explicitCatalog: true,
+    });
+    expect(await Bun.file(path).text()).toBe(original);
+  });
+
+  test("treats a missing Codex config as built-in routing", () => {
+    fixture();
+    expect(readCodexCatalogRouting()).toEqual({ status: "default" });
+  });
+
+  test("fails closed when Codex config cannot be read", () => {
+    const { codexHome } = fixture();
+    writeFileSync(join(codexHome, "config.toml"), 'model_provider = "sub2api"\n');
+    expect(readCodexCatalogRouting(() => {
+      throw new Error("EACCES");
+    })).toEqual({ status: "unreadable", detail: "Codex config could not be read" });
+  });
+
+  test("parses CR-only Codex config with the existing document splitter", () => {
+    const routing = inspectCodexCatalogRoutingFromText('model_provider = "sub2api"\r[model_providers.sub2api]\rname = "Sub2API"\r');
+    expect(routing).toEqual({ status: "custom-provider", provider: "sub2api", explicitCatalog: false });
+  });
+});
+
+describe("healthz catalog counters", () => {
+  test("reads successful_model_catalog_requests and rejects malformed counts", () => {
+    expect(readCatalogRequestCount({ successful_model_catalog_requests: 0 })).toBe(0);
+    expect(readCatalogRequestCount({ successful_model_catalog_requests: 2 })).toBe(2);
+    expect(readCatalogRequestCount({})).toBeUndefined();
+    expect(readCatalogRequestCount({ successful_model_catalog_requests: -1 })).toBeUndefined();
+    expect(readCatalogRequestCount({ successful_model_catalog_requests: "0" })).toBeUndefined();
+  });
+
+  test("warns when healthz omits catalog request counts", () => {
+    const check = modelCatalogDoctorCheck({
+      successfulModelCatalogRequests: undefined,
+      routing: { status: "default" },
+    });
+    expect(check.status).toBe("warning");
+    expect(check.message).toBe("Responses proxy did not report model catalog request counts");
+  });
+});


### PR DESCRIPTION
## Summary

Enhance `doctor` and troubleshooting guidance to report truthful evidence about Codex model-catalog requests.

A green setup step and a healthy Responses proxy prove that the daemon is ready, but do not prove that Codex requested `/v1/models`. This change:

- Treats `/healthz` `successful_model_catalog_requests > 0` as proof that a catalog request reached the daemon.
- Warns when zero requests have reached the daemon under default routing, explaining that ChatGPT Web models in the picker are unproven and reminding users to fully restart Codex (including background processes).
- Explains when zero catalog requests are expected because a top-level `model_provider` selects an external provider or `model_catalog_json` bypasses the daemon.
- Clarifies that a `[model_providers.*]` table alone does not select a provider.
- Fails closed if top-level routing assignments are duplicate or empty.
- Links to #205 where external router coexistence is tracked.

Addresses model-catalog diagnostics discussed in #290; does not close #290 or implement #205.

## Verification

- `bun test tests/doctor.test.ts` (14 pass / 63 expects)
- `bun run typecheck` (clean)
- `bun test` (784 pass / 1 skip)
- `bun run launcher:typecheck` (clean)
- `bun run launcher:test` (248 pass / 1 skip)