### PR TITLE
fix: resolve slider-overflow tiers through their model radio row

### DIFF
--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -133,6 +133,8 @@ const CHATGPT_SMOKE_EXPECTED = "CODEX WEB GPT READY";
  */
 export const CHATGPT_UI_SETTLE_MS = 250;
 export const CHATGPT_SEND_ENABLE_GRACE_MS = 5_000;
+const CHATGPT_EFFORT_TIER_ROW_TIMEOUT_MS = 5_000;
+const CHATGPT_EFFORT_TIER_ACTIVATION_TIMEOUT_MS = 10_000;
 
 const CHATGPT_DOM_REVISION_ATTRIBUTES = [
   "aria-hidden",
@@ -2268,11 +2270,55 @@ export class ChatGptBrowserWorker {
       }
       const targetValue = sliderState.min + uiEffortIndex;
       if (targetValue > sliderState.max) {
-        throw new ChatGptWebAdapterError(
-          `ChatGPT effort slider does not expose item index ${uiEffortIndex}`
-          + ` (min=${sliderState.min}; max=${sliderState.max})`,
-          { status: 502, errorType: "server_error", code: "upstream_server_error", retryable: false },
-        );
+        // ChatGPT's redesigned picker renders tiers beyond the slider range (e.g. Pro)
+        // as model radio rows inside the same menu instead of slider positions.
+        const tierChoice = effortMenu
+          .locator(`${CHATGPT_EFFORT_ITEM_SELECTOR}[aria-label="${mode.displayLabel}"]`)
+          .filter({ visible: true })
+          .first();
+        await tierChoice.waitFor({ state: "visible", timeout: CHATGPT_EFFORT_TIER_ROW_TIMEOUT_MS }).catch(() => undefined);
+        if (!await tierChoice.isVisible().catch(() => false)) {
+          throw new ChatGptWebAdapterError(
+            `ChatGPT effort slider does not expose item index ${uiEffortIndex}`
+            + ` (min=${sliderState.min}; max=${sliderState.max})`,
+            { status: 502, errorType: "server_error", code: "upstream_server_error", retryable: false },
+          );
+        }
+        await throwIfChatGptRateLimitDialog(page);
+        const [tierDisabled, tierDataDisabled] = await Promise.all([
+          tierChoice.getAttribute("aria-disabled").catch(() => null),
+          tierChoice.getAttribute("data-disabled").catch(() => null),
+        ]);
+        if (tierDisabled === "true" || tierDataDisabled !== null) {
+          throw new ChatGptWebAdapterError(
+            `ChatGPT web UI currently has the ${mode.displayLabel} option disabled`
+            + " (quota exhausted or account gating); retry later or select an exposed tier",
+            { status: 502, errorType: "server_error", code: "upstream_server_error", retryable: false },
+          );
+        }
+        if (await tierChoice.getAttribute("aria-checked").catch(() => null) !== "true") {
+          await tierChoice.click();
+          await captureDiagnostic?.("effort-choice-activated");
+          const activationDeadline = Date.now() + CHATGPT_EFFORT_TIER_ACTIVATION_TIMEOUT_MS;
+          while (Date.now() < activationDeadline) {
+            if (await tierChoice.getAttribute("aria-checked").catch(() => null) === "true") break;
+            // The menu closes once a model tier switch is committed; that is success.
+            if (!await effortMenu.isVisible().catch(() => false)) break;
+            await new Promise(resolveSleep => setTimeout(resolveSleep, 100));
+          }
+          if (
+            await tierChoice.isVisible().catch(() => false)
+            && await tierChoice.getAttribute("aria-checked").catch(() => null) !== "true"
+          ) {
+            throw new ChatGptWebAdapterError(
+              `ChatGPT ${mode.displayLabel} tier item did not activate`,
+              { status: 502, errorType: "server_error", code: "upstream_server_error", retryable: true },
+            );
+          }
+        }
+        await captureDiagnostic?.("effort-selected");
+        if (await effortMenu.isVisible().catch(() => false)) await page.keyboard.press("Escape");
+        return mode;
       }
       const sliderControl = effortSlider.locator("xpath=ancestor::*[@role='menuitem'][1]");
       while (sliderState.value !== targetValue) {

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -1549,6 +1549,406 @@ test("effort slider ARIA state fails closed on malformed and unsupported ranges"
   }
 });
 
+test("slider overflow resolves the requested tier through its model radio row", async () => {
+  const neverVisible = new Promise<void>(() => {});
+  let pressed: string[] = [];
+  let tierClicks = 0;
+  let tierChecked = "false";
+  const tierRow = {
+    filter() { return this; },
+    first() { return this; },
+    waitFor: async () => {},
+    isVisible: async () => true,
+    getAttribute: async (attribute: string) => {
+      if (attribute === "aria-disabled") return null;
+      if (attribute === "data-disabled") return null;
+      if (attribute === "aria-checked") return tierChecked;
+      return null;
+    },
+    click: async () => {
+      tierClicks += 1;
+      tierChecked = "true";
+    },
+  };
+  const effortMenu = {
+    last() { return this; },
+    isVisible: async () => true,
+    locator: (selector: string) => {
+      if (selector.includes('aria-label="Pro"')) return tierRow;
+      return {
+        nth: () => ({ waitFor: async () => await neverVisible }),
+        count: async () => 3,
+      };
+    },
+  };
+  const effortSlider = {
+    filter() { return this; },
+    last() { return this; },
+    waitFor: async () => "slider",
+    getAttribute: async (attribute: string) => ({
+      "aria-valuemin": "0",
+      "aria-valuemax": "3",
+      "aria-valuenow": "0",
+    })[attribute as "aria-valuemin"] ?? null,
+  };
+  const hiddenDialog = {
+    filter() { return this; },
+    last() { return this; },
+    waitFor: async () => await neverVisible,
+    isVisible: async () => false,
+  };
+  const checkpoints: string[] = [];
+  const page = {
+    keyboard: { press: async (key: string) => { pressed.push(key); } },
+    locator: (selector: string) => {
+      if (selector.includes('[role="menu"]') || selector.includes("composer-intelligence-picker-content")) return effortMenu;
+      if (selector.includes("data-model-reasoning-effort-slider")) return effortSlider;
+      return hiddenDialog;
+    },
+  };
+  const composerForm = {
+    locator: () => ({
+      last() { return this; },
+      waitFor: async () => {},
+      getAttribute: async () => "true",
+    }),
+  };
+  const composer = { locator: () => composerForm };
+  const selectModelAndEffort = (ChatGptBrowserWorker.prototype as unknown as {
+    selectModelAndEffort(
+      page: unknown,
+      modelId: string,
+      reasoning: string,
+      capabilities: { localToolsEnabled: boolean; solAvailable: boolean; proAvailable: boolean },
+      captureDiagnostic: (checkpoint: string) => Promise<void>,
+    ): Promise<{ displayLabel: string; uiEffortIndex: number }>;
+  }).selectModelAndEffort;
+
+  const mode = await selectModelAndEffort.call({
+    activeComposer: async () => composer,
+  }, page, "gpt-5.6-sol", "max", {
+    localToolsEnabled: true,
+    solAvailable: true,
+    proAvailable: true,
+  }, async checkpoint => { checkpoints.push(checkpoint); });
+
+  expect(mode).toMatchObject({ displayLabel: "Pro", uiEffortIndex: 4 });
+  expect(tierClicks).toBe(1);
+  expect(pressed).toEqual(["Escape"]);
+  expect(checkpoints).toEqual([
+    "effort-control-ready",
+    "effort-menu-open-requested",
+    "effort-slider-visible",
+    "effort-choice-activated",
+    "effort-selected",
+  ]);
+});
+
+test("slider overflow tiers fail closed when the model radio row is disabled or absent", async () => {
+  const neverVisible = new Promise<void>(() => {});
+  const makeHarness = (tierVisible: boolean, tierDisabled: string | null) => {
+    let tierClicks = 0;
+    const tierRow = {
+      filter() { return this; },
+      first() { return this; },
+      waitFor: async () => {
+        if (!tierVisible) throw new Error("tier row not rendered");
+      },
+      isVisible: async () => tierVisible,
+      getAttribute: async (attribute: string) => {
+        if (attribute === "aria-disabled") return tierDisabled;
+        if (attribute === "data-disabled") return null;
+        return "false";
+      },
+      click: async () => { tierClicks += 1; },
+    };
+    const effortMenu = {
+      last() { return this; },
+      isVisible: async () => true,
+      locator: (selector: string) => {
+        if (selector.includes('aria-label="Pro"')) return tierRow;
+        return {
+          nth: () => ({ waitFor: async () => await neverVisible }),
+          count: async () => 3,
+        };
+      },
+    };
+    const effortSlider = {
+      filter() { return this; },
+      last() { return this; },
+      waitFor: async () => "slider",
+      getAttribute: async (attribute: string) => ({
+        "aria-valuemin": "0",
+        "aria-valuemax": "3",
+        "aria-valuenow": "0",
+      })[attribute as "aria-valuemin"] ?? null,
+    };
+    const page = {
+      locator: (selector: string) => {
+        if (selector.includes('[role="menu"]') || selector.includes("composer-intelligence-picker-content")) return effortMenu;
+        if (selector.includes("data-model-reasoning-effort-slider")) return effortSlider;
+        return {
+          filter() { return this; },
+          last() { return this; },
+          waitFor: async () => await neverVisible,
+          isVisible: async () => false,
+        };
+      },
+    };
+    const composerForm = {
+      locator: () => ({
+        last() { return this; },
+        waitFor: async () => {},
+        getAttribute: async () => "true",
+      }),
+    };
+    return {
+      clicks: () => tierClicks,
+      select: (ChatGptBrowserWorker.prototype as unknown as {
+        selectModelAndEffort(
+          page: unknown,
+          modelId: string,
+          reasoning: string,
+          capabilities: { localToolsEnabled: boolean; solAvailable: boolean; proAvailable: boolean },
+        ): Promise<unknown>;
+      }).selectModelAndEffort,
+      page,
+    };
+  };
+  const composerForm = {
+    locator: () => ({
+      last() { return this; },
+      waitFor: async () => {},
+      getAttribute: async () => "true",
+    }),
+  };
+  const composer = { locator: () => composerForm };
+
+  const disabledHarness = makeHarness(true, "true");
+  await expect(disabledHarness.select.call({
+    activeComposer: async () => composer,
+  }, disabledHarness.page, "gpt-5.6-sol", "max", {
+    localToolsEnabled: true,
+    solAvailable: true,
+    proAvailable: true,
+  })).rejects.toMatchObject({
+    name: "ChatGptWebAdapterError",
+    status: 502,
+    code: "upstream_server_error",
+    retryable: false,
+    message: expect.stringContaining("Pro option disabled"),
+  });
+  expect(disabledHarness.clicks()).toBe(0);
+
+  const absentHarness = makeHarness(false, null);
+  await expect(absentHarness.select.call({
+    activeComposer: async () => composer,
+  }, absentHarness.page, "gpt-5.6-sol", "max", {
+    localToolsEnabled: true,
+    solAvailable: true,
+    proAvailable: true,
+  })).rejects.toThrow("ChatGPT effort slider does not expose item index 4 (min=0; max=3)");
+});
+
+test("slider overflow skips clicking an already-selected tier row", async () => {
+  const neverVisible = new Promise<void>(() => {});
+  let tierClicks = 0;
+  const tierRow = {
+    filter() { return this; },
+    first() { return this; },
+    waitFor: async () => {},
+    isVisible: async () => true,
+    getAttribute: async (attribute: string) => {
+      if (attribute === "data-disabled") return null;
+      if (attribute === "aria-checked") return "true";
+      return null;
+    },
+    click: async () => { tierClicks += 1; },
+  };
+  const effortMenu = {
+    last() { return this; },
+    isVisible: async () => true,
+    locator: (selector: string) => {
+      if (selector.includes('aria-label="Pro"')) return tierRow;
+      return {
+        nth: () => ({ waitFor: async () => await neverVisible }),
+        count: async () => 3,
+      };
+    },
+  };
+  const effortSlider = {
+    filter() { return this; },
+    last() { return this; },
+    waitFor: async () => "slider",
+    getAttribute: async (attribute: string) => ({
+      "aria-valuemin": "0",
+      "aria-valuemax": "3",
+      "aria-valuenow": "0",
+    })[attribute as "aria-valuemin"] ?? null,
+  };
+  const pressed: string[] = [];
+  const checkpoints: string[] = [];
+  const page = {
+    keyboard: { press: async (key: string) => { pressed.push(key); } },
+    locator: (selector: string) => {
+      if (selector.includes('[role="menu"]') || selector.includes("composer-intelligence-picker-content")) return effortMenu;
+      if (selector.includes("data-model-reasoning-effort-slider")) return effortSlider;
+      return {
+        filter() { return this; },
+        last() { return this; },
+        waitFor: async () => await neverVisible,
+        isVisible: async () => false,
+      };
+    },
+  };
+  const composerForm = {
+    locator: () => ({
+      last() { return this; },
+      waitFor: async () => {},
+      getAttribute: async () => "true",
+    }),
+  };
+  const composer = { locator: () => composerForm };
+  const selectModelAndEffort = (ChatGptBrowserWorker.prototype as unknown as {
+    selectModelAndEffort(
+      page: unknown,
+      modelId: string,
+      reasoning: string,
+      capabilities: { localToolsEnabled: boolean; solAvailable: boolean; proAvailable: boolean },
+      captureDiagnostic: (checkpoint: string) => Promise<void>,
+    ): Promise<{ displayLabel: string; uiEffortIndex: number }>;
+  }).selectModelAndEffort;
+
+  const mode = await selectModelAndEffort.call({
+    activeComposer: async () => composer,
+  }, page, "gpt-5.6-sol", "max", {
+    localToolsEnabled: true,
+    solAvailable: true,
+    proAvailable: true,
+  }, async checkpoint => { checkpoints.push(checkpoint); });
+
+  expect(mode).toMatchObject({ displayLabel: "Pro", uiEffortIndex: 4 });
+  expect(tierClicks).toBe(0);
+  expect(pressed).toEqual(["Escape"]);
+  expect(checkpoints).toEqual([
+    "effort-control-ready",
+    "effort-menu-open-requested",
+    "effort-slider-visible",
+    "effort-selected",
+  ]);
+});
+
+test("slider overflow treats a closed effort menu as a committed tier switch", async () => {
+  const neverVisible = new Promise<void>(() => {});
+  let menuOpen = true;
+  let tierClicks = 0;
+  const tierRow = {
+    filter() { return this; },
+    first() { return this; },
+    waitFor: async () => {},
+    isVisible: async () => menuOpen,
+    getAttribute: async (attribute: string) => {
+      if (attribute === "data-disabled") return null;
+      if (attribute === "aria-checked") return "false";
+      return null;
+    },
+    click: async () => {
+      tierClicks += 1;
+      menuOpen = false;
+    },
+  };
+  const effortMenu = {
+    last() { return this; },
+    isVisible: async () => menuOpen,
+    locator: (selector: string) => {
+      if (selector.includes('aria-label="Pro"')) return tierRow;
+      return {
+        nth: () => ({ waitFor: async () => await neverVisible }),
+        count: async () => 3,
+      };
+    },
+  };
+  const effortSlider = {
+    filter() { return this; },
+    last() { return this; },
+    waitFor: async () => "slider",
+    getAttribute: async (attribute: string) => ({
+      "aria-valuemin": "0",
+      "aria-valuemax": "3",
+      "aria-valuenow": "0",
+    })[attribute as "aria-valuemin"] ?? null,
+  };
+  const pressed: string[] = [];
+  const checkpoints: string[] = [];
+  const page = {
+    keyboard: { press: async (key: string) => { pressed.push(key); } },
+    locator: (selector: string) => {
+      if (selector.includes('[role="menu"]') || selector.includes("composer-intelligence-picker-content")) return effortMenu;
+      if (selector.includes("data-model-reasoning-effort-slider")) return effortSlider;
+      return {
+        filter() { return this; },
+        last() { return this; },
+        waitFor: async () => await neverVisible,
+        isVisible: async () => false,
+      };
+    },
+  };
+  const composerForm = {
+    locator: () => ({
+      last() { return this; },
+      waitFor: async () => {},
+      getAttribute: async () => "true",
+    }),
+  };
+  const composer = { locator: () => composerForm };
+  const selectModelAndEffort = (ChatGptBrowserWorker.prototype as unknown as {
+    selectModelAndEffort(
+      page: unknown,
+      modelId: string,
+      reasoning: string,
+      capabilities: { localToolsEnabled: boolean; solAvailable: boolean; proAvailable: boolean },
+      captureDiagnostic: (checkpoint: string) => Promise<void>,
+    ): Promise<{ displayLabel: string; uiEffortIndex: number }>;
+  }).selectModelAndEffort;
+
+  const mode = await selectModelAndEffort.call({
+    activeComposer: async () => composer,
+  }, page, "gpt-5.6-sol", "max", {
+    localToolsEnabled: true,
+    solAvailable: true,
+    proAvailable: true,
+  }, async checkpoint => { checkpoints.push(checkpoint); });
+
+  expect(mode).toMatchObject({ displayLabel: "Pro", uiEffortIndex: 4 });
+  expect(tierClicks).toBe(1);
+  expect(pressed).toEqual([]);
+  expect(checkpoints).toEqual([
+    "effort-control-ready",
+    "effort-menu-open-requested",
+    "effort-slider-visible",
+    "effort-choice-activated",
+    "effort-selected",
+  ]);
+});
+
+test("slider overflow keeps the structural failure when no tier row matches", () => {
+  const workerSource = readFileSync(new URL("../src/adapters/chatgpt-web/browser-worker.ts", import.meta.url), "utf8");
+  const selectionStart = workerSource.indexOf("private async selectModelAndEffort");
+  const selectionEnd = workerSource.indexOf("private async activeComposer", selectionStart);
+  const selectionSource = workerSource.slice(selectionStart, selectionEnd);
+  const overflowBranch = selectionSource.indexOf("targetValue > sliderState.max");
+  const tierFallback = selectionSource.indexOf('aria-label="${mode.displayLabel}"', overflowBranch);
+  const overflowFailure = selectionSource.indexOf("does not expose item index", tierFallback);
+  expect(overflowBranch).toBeGreaterThan(-1);
+  expect(tierFallback).toBeGreaterThan(overflowBranch);
+  expect(overflowFailure).toBeGreaterThan(tierFallback);
+  expect(selectionSource).toContain('getAttribute("aria-disabled")');
+  expect(selectionSource).toContain('getAttribute("data-disabled")');
+  expect(selectionSource).toContain("CHATGPT_EFFORT_TIER_ROW_TIMEOUT_MS");
+  expect(selectionSource).toContain("CHATGPT_EFFORT_TIER_ACTIVATION_TIMEOUT_MS");
+  expect(selectionSource).toContain("ChatGPT web UI currently has the ${mode.displayLabel} option disabled");
+});
+
 test("Luna-only browser turns verify selector absence instead of opening an effort menu", async () => {
   const checkpoints: string[] = [];
   const hiddenDialog = {


### PR DESCRIPTION
## What this changes

<!-- Describe one focused behavior change. Link the issue or prior discussion when applicable.
Large features, broad refactors, rewrites, new providers, and core architecture changes are normally
not accepted without prior maintainer discussion; prior discussion does not guarantee acceptance. -->

When the requested effort tier's slider position exceeds the slider's `aria-valuemax`, `selectModelAndEffort` now resolves the tier through its model radio row in the same effort menu instead of failing outright: it waits briefly for a row matching `[role="menuitemradio"][aria-label="<displayLabel>"]`, fails closed (non-retryable, explicit error) when the row is `aria-disabled`/`data-disabled`, otherwise clicks it and confirms `aria-checked` (treating the menu closing as a committed switch). Tiers within the slider range behave exactly as before. Fixes #300.

## Evidence

<!-- Give the reproduction before the change and the exact result afterward. Browser UI changes need observed DOM evidence, not guessed selectors. -->

Reproduction (v4.0.8, chatgpt.com current UI, Pro account, model `chatgpt-web/pro`): every turn fails at effort selection with

```text
ChatGPT effort slider does not expose item index 4 (min=0; max=3)
```

Observed DOM (captured from the live page, zh-CN Temporary Chat; also reproduced on the normal chat root):

```html
<div tabindex="0" data-disabled="" aria-label="Pro" role="menuitemradio" aria-disabled="true" aria-checked="false" data-state="unchecked" data-orientation="vertical" data-radix-collection-item="" class="group __menu-item cursor-not-allowed!">…</div>
```

The menu exposes a 4-position effort slider (`aria-valuemin=0`, `aria-valuemax=3`) plus the model rows `GPT-5.6 Sol` / `GPT-5.5` / `Pro`; diagnostic checkpoints show `effort-slider-visible` → `turn-failed` (issue #300). Enter/Space does not activate these rows — observed live: pressing Enter left the row `aria-checked="false"` — so the fallback uses a real click, then confirms `aria-checked` or the menu closing before returning.

With the equivalent change running in my installed helper: a slider-path turn (`chatgpt-web/extra-high`) completed end to end (`effort-selected` → `turn-completed`), and a `chatgpt-web/pro` turn while the row is `aria-disabled` failed fast with the new explicit error (checkpoint `pro-choice-disabled` → non-retryable adapter error). The enabled-row click path is pinned by the new contract tests; I could not observe it live because the account currently gates the row.

## Scope and invariants

- [x] I read and followed `CONTRIBUTING.md`.
- [x] This is a small, focused change with no unrelated cleanup or generated rewrite.
- [x] The change stays focused on ChatGPT web-backed Codex models; it does not add a generic provider or unrelated product surface.
- [x] Model, route, effort, connector, and capability selection remain explicit with no silent fallback or false-success path.
- [x] If this touches Full harness or MCP, every available Web effort retains the same turn-bound capability and Browser-only gains no broker or connector.
- [x] Terms and trademark claims remain factual; this change is not marketed as a quota or rate-limit bypass.

## Verification

- [x] I ran `bun install --frozen-lockfile` in the repository root and `launcher/`.
- [x] I ran `bun run verify` with the Bun version pinned by `package.json`.
- [x] I added or updated a focused regression test for behavior changes.
- [x] I manually tested the affected behavior.
- [x] If this changes local tools, MCP execution, or the outer Codex agent loop, I tested it through a real installed Codex integration; DEV mode alone is acceptable only when execution is not affected.
- [x] If this changes ChatGPT browser UI handling, I included observed DOM evidence and a reproducible fixture instead of broadening selectors speculatively.
- [x] If this changes the launcher, I preserved macOS, Windows, and Linux packaging and named the platform packages actually built below.

Note on `bun run verify`: every step passes except the `audit` step, which fails on this commit for me exactly as it does on `main` — 6 pre-existing advisories in the committed lockfile (fast-uri via `ajv`, qs via `@modelcontextprotocol/sdk > express > body-parser`), none introduced by this branch (no dependency or lockfile changes). `typecheck`, the full `test` suite (525 → 528 tests, 0 failures), `launcher:typecheck`, `launcher:test`, `launcher:build`, the runtime bundle build, and `smoke-release` all pass on this branch.

The launcher is not touched by this change.