### PR TITLE
fix: extend Pro compaction handoff timeout

### DIFF
--- a/src/adapters/chatgpt-web/compaction-handoff.ts
+++ b/src/adapters/chatgpt-web/compaction-handoff.ts
@@ -127,7 +127,18 @@ function currentToolResults(
   return results;
 }
 
-export const MAX_COMPACTION_HANDOFF_TIMEOUT_MS = 5 * 60_000;
+export const DEFAULT_COMPACTION_HANDOFF_TIMEOUT_MS = 5 * 60_000;
+export const MAX_COMPACTION_HANDOFF_TIMEOUT_MS = 50 * 60_000;
+
+export function resolveCompactionHandoffTimeoutMs(
+  proCompaction: boolean,
+  configuredTimeoutMs?: number,
+): number {
+  const modelTimeoutMs = proCompaction
+    ? MAX_COMPACTION_HANDOFF_TIMEOUT_MS
+    : DEFAULT_COMPACTION_HANDOFF_TIMEOUT_MS;
+  return Math.min(configuredTimeoutMs ?? modelTimeoutMs, modelTimeoutMs);
+}
 
 function boundedCompactionTimeout(timeoutMs: number): number {
   return Math.min(timeoutMs, MAX_COMPACTION_HANDOFF_TIMEOUT_MS);

--- a/src/adapters/chatgpt-web/index.ts
+++ b/src/adapters/chatgpt-web/index.ts
@@ -1,6 +1,9 @@
 import { createHash, randomBytes } from "node:crypto";
 import { resolve } from "node:path";
-import { isChatGptWebZeroRiskBackendModel } from "../../chatgpt-web-models";
+import {
+  CHATGPT_WEB_ZERO_RISK_PRO_BACKEND_MODEL,
+  isChatGptWebZeroRiskBackendModel,
+} from "../../chatgpt-web-models";
 import { defaultBrokerEndpoint, expandUserPath, resolveBrokerEndpoint } from "../../config";
 import {
   cancelLauncherManualTurn,
@@ -39,8 +42,8 @@ import { ChatGptExternalTurnProgress } from "./turn-progress";
 import {
   canonicalizeCompactionHandoff,
   existingStructuredCompactionRun,
-  MAX_COMPACTION_HANDOFF_TIMEOUT_MS,
   requestRetainedCompactionHandoff,
+  resolveCompactionHandoffTimeoutMs,
   runStructuredCompactionOnce,
   settleActiveCompactionSource,
   settleActiveZeroRiskCompactionSource,
@@ -829,9 +832,11 @@ export function createChatGptWebAdapter(
                   ],
                 },
                 async operatorSignal => {
-                  const handoffTimeoutMs = Math.min(
-                    timeoutMs ?? MAX_COMPACTION_HANDOFF_TIMEOUT_MS,
-                    MAX_COMPACTION_HANDOFF_TIMEOUT_MS,
+                  const proCompaction = parsed.modelId === CHATGPT_WEB_ZERO_RISK_PRO_BACKEND_MODEL
+                    || ("effort" in mode && mode.effort === "max");
+                  const handoffTimeoutMs = resolveCompactionHandoffTimeoutMs(
+                    proCompaction,
+                    timeoutMs,
                   );
                   const handoffDeadline = new AbortController();
                   const handoffTimeoutError = new ChatGptWebAdapterError(

--- a/tests/retained-compaction.test.ts
+++ b/tests/retained-compaction.test.ts
@@ -6,11 +6,13 @@ import type { BrowserTurn } from "../src/adapters/chatgpt-web/browser-worker";
 import { ChatGptBrowserWorker } from "../src/adapters/chatgpt-web/browser-worker";
 import { chatGptRetainedConversationUnavailableError } from "../src/adapters/chatgpt-web/adapter-error";
 import {
+  DEFAULT_COMPACTION_HANDOFF_TIMEOUT_MS,
   MAX_COMPACTION_HANDOFF_TIMEOUT_MS,
   cancelAllStructuredCompactions,
   cancelStructuredCompactionTrace,
   existingStructuredCompactionRun,
   requestRetainedCompactionHandoff,
+  resolveCompactionHandoffTimeoutMs,
   runStructuredCompactionOnce,
   settleActiveCompactionSource,
   settleActiveZeroRiskCompactionSource,
@@ -45,6 +47,15 @@ import {
   structuredCompactionHandoffInstruction,
 } from "../src/adapters/chatgpt-web/native-compaction-control";
 import type { AdapterEvent, CodexParsedRequest, CodexProviderConfig } from "../src/types";
+
+test("Pro compaction gets a 50-minute handoff budget without widening other efforts", () => {
+  expect(DEFAULT_COMPACTION_HANDOFF_TIMEOUT_MS).toBe(5 * 60_000);
+  expect(MAX_COMPACTION_HANDOFF_TIMEOUT_MS).toBe(50 * 60_000);
+  expect(resolveCompactionHandoffTimeoutMs(false)).toBe(DEFAULT_COMPACTION_HANDOFF_TIMEOUT_MS);
+  expect(resolveCompactionHandoffTimeoutMs(true)).toBe(MAX_COMPACTION_HANDOFF_TIMEOUT_MS);
+  expect(resolveCompactionHandoffTimeoutMs(true, 60 * 60_000)).toBe(MAX_COMPACTION_HANDOFF_TIMEOUT_MS);
+  expect(resolveCompactionHandoffTimeoutMs(true, 2 * 60_000)).toBe(2 * 60_000);
+});
 
 /**
  * These fixtures hand the turn broker a Unix socket under their temp root. macOS puts TMPDIR at
@@ -287,7 +298,7 @@ test("active compaction drains an MCP call already queued without an outer Codex
 });
 
 test("a completed retained agent returns an exact checkpoint and its browser is physically retired", async () => {
-  expect(MAX_COMPACTION_HANDOFF_TIMEOUT_MS).toBe(5 * 60_000);
+  expect(MAX_COMPACTION_HANDOFF_TIMEOUT_MS).toBe(50 * 60_000);
   const sourceRequest = request(false);
   const conversationKey = chatGptConversationKey(sourceRequest, "provider")!;
   const source = new ChatGptTurnSession({


### PR DESCRIPTION
## What this changes

- keep the existing five-minute structured compaction handoff budget for non-Pro efforts
- give Pro and Zero Risk Pro compaction handoffs a 50-minute default and maximum budget
- preserve an explicitly configured shorter safety ceiling
- add focused regression coverage for the effort-specific timeout policy

The previous hard five-minute ceiling caused long Pro checkpoint handoffs to fail with:

`ChatGPT compaction did not fully settle within 300000ms`

## Evidence

Before the change, a requested 60-minute handoff was unconditionally clamped to 300,000 ms. The new regression test proves that:

- non-Pro compaction remains capped at 300,000 ms
- Pro compaction defaults to and is capped at 3,000,000 ms
- a shorter explicit timeout still wins

## Scope and invariants

- [x] I read and followed `CONTRIBUTING.md`.
- [x] This is a small, focused change with no unrelated cleanup or generated rewrite.
- [x] The change stays focused on ChatGPT web-backed Codex models; it does not add a generic provider or unrelated product surface.
- [x] Model, route, effort, connector, and capability selection remain explicit with no silent fallback or false-success path.
- [x] If this touches Full harness or MCP, every available Web effort retains the same turn-bound capability and Browser-only gains no broker or connector.
- [x] Terms and trademark claims remain factual; this change is not marketed as a quota or rate-limit bypass.

## Verification

- [x] I ran `bun install --frozen-lockfile` in the repository root and `launcher/`.
- [x] I ran `bun run verify` with Bun 1.4.0.
- [x] I added a focused regression test for the behavior change.
- [ ] I manually exercised a real 5-to-50-minute Pro compaction timeout.
- [ ] I tested the changed outer Codex compaction loop through a real installed integration.
- [x] This does not change ChatGPT browser UI handling.
- [x] This does not change launcher packaging.
- [x] I did not commit browser state, credentials, Tunnel IDs, raw logs, generated artifacts, or private paths.
- [x] I did not include an unrelated dependency update, release artifact, or version change.

## Platform or account validation

- macOS arm64: complete automated verification passed
- Pro account, Full mode: live 50-minute boundary not run; the installed integration will be exercised separately
- Packaged builds: not run; launcher code and packaging are unchanged
