### PR TITLE
perf: capture+polling speedups; Codex 0.153.x env_context carrier

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,22 @@ bun run app
 
 This source path requires Bun 1.4.0. The command installs locked dependencies and opens the app.
 
+## Headless CLI mode (Linux servers)
+
+Full lifecycle from a terminal — no launcher, no Electron, no persistent Xvfb:
+
+```bash
+codex-chatgpt-web setup --full --browser-host managed-chrome --headless \
+  --chrome /usr/bin/google-chrome --login-headless auto --acknowledge-unofficial
+codex-chatgpt-web login             # headless-first; auto-falls back to ephemeral Xvfb
+codex-chatgpt-web service install   # systemd user unit (+ linger) for daemon and tunnel
+codex-chatgpt-web doctor            # xvfb, linger, browser-host, headless checks
+```
+
+- `--browser-host managed-chrome --headless` runs turns through a Playwright-managed headless Chrome.
+- `--login-headless auto` tries Chromium headless first; if ChatGPT serves a bot challenge it retries under an ephemeral Xvfb display. `--storage-state-file` imports a `storageState` JSON instead of interactive login.
+- `service` manages systemd **user** units (daemon + tunnel client, `Restart=always`, linger); macOS keeps launchd.
+
 ## Modes
 
 | Mode | Models | Local Codex tools | Extra setup |

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "chromium-bidi": "12.1.0",
         "fflate": "^0.8.2",
         "patchright": "^1.62.2",
+        "patchright-difz": "^1.0.4",
         "playwright-core": "^1.62.0",
         "tiktoken": "1.0.22",
         "turndown": "7.2.0",
@@ -178,6 +179,8 @@
     "patchright": ["patchright@1.62.2", "", { "dependencies": { "patchright-core": "1.62.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "patchright": "cli.js" } }, "sha512-IAj57p3NhXWJH3SlOCooDa/OoRveulUW1n/H6SY79S0j0sRd/0LLfBH9VMYDkDw5LUOlF0tCp3vkWMfOTiHsXQ=="],
 
     "patchright-core": ["patchright-core@1.62.2", "", { "bin": { "patchright-core": "cli.js" } }, "sha512-XDl3HB/Kjm9ZBFn4ygD5mxdsqK4aIWNGXdea46XAGd0hvHuJJ84w1M83JqofpXIbD2aJfQ2Rtz4YcqPVrxjSzw=="],
+
+    "patchright-difz": ["patchright-difz@1.0.4", "", { "dependencies": { "patchright": "^1.59.4" } }, "sha512-l5vwZPN3b9AaMOWeV77SaY479vxHC09x0A3DzUePwve/XMQQf2RdZ4lxoAudV0sD6vecrfQiuFmkc2Di3rPtCw=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@modelcontextprotocol/sdk": "^1.30.0",
         "chromium-bidi": "12.1.0",
         "fflate": "^0.8.2",
+        "patchright": "^1.62.2",
         "playwright-core": "^1.62.0",
         "tiktoken": "1.0.22",
         "turndown": "7.2.0",
@@ -112,6 +113,8 @@
 
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
@@ -171,6 +174,10 @@
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "patchright": ["patchright@1.62.2", "", { "dependencies": { "patchright-core": "1.62.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "patchright": "cli.js" } }, "sha512-IAj57p3NhXWJH3SlOCooDa/OoRveulUW1n/H6SY79S0j0sRd/0LLfBH9VMYDkDw5LUOlF0tCp3vkWMfOTiHsXQ=="],
+
+    "patchright-core": ["patchright-core@1.62.2", "", { "bin": { "patchright-core": "cli.js" } }, "sha512-XDl3HB/Kjm9ZBFn4ygD5mxdsqK4aIWNGXdea46XAGd0hvHuJJ84w1M83JqofpXIbD2aJfQ2Rtz4YcqPVrxjSzw=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "chromium-bidi": "12.1.0",
     "fflate": "^0.8.2",
     "patchright": "^1.62.2",
+    "patchright-difz": "^1.0.4",
     "playwright-core": "^1.62.0",
     "tiktoken": "1.0.22",
     "turndown": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@modelcontextprotocol/sdk": "^1.30.0",
     "chromium-bidi": "12.1.0",
     "fflate": "^0.8.2",
+    "patchright": "^1.62.2",
     "playwright-core": "^1.62.0",
     "tiktoken": "1.0.22",
     "turndown": "7.2.0",

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from "node:crypto";
 import { chmodSync, existsSync, mkdirSync, readdirSync, rmSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
-import { chromium, type Browser, type BrowserContext, type Locator, type Page } from "playwright-core";
+import { chromium } from "patchright";
+import type { Browser, BrowserContext, Locator, Page } from "playwright-core";
 import {
   atomicWriteFile,
   CHATGPT_CONNECTOR_NAME,
@@ -1483,7 +1484,7 @@ export class ChatGptBrowserWorker {
     this.browser = await chromium.launch({
       executablePath: this.config.chromeExecutablePath,
       headless: !this.config.headed,
-    });
+    }) as unknown as Browser;
     this.context = await this.browser.newContext({ storageState: this.config.storageStatePath });
     this.page = await this.context.newPage();
     return this.page;
@@ -1501,7 +1502,7 @@ export class ChatGptBrowserWorker {
       const browser = await chromium.launch({
         executablePath: this.config.chromeExecutablePath,
         headless: !this.config.headed,
-      });
+      }) as unknown as Browser;
       const context = await browser.newContext({ storageState: this.config.storageStatePath });
       this.browser = browser;
       this.context = context;

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -1311,6 +1311,7 @@ export class ChatGptBrowserWorker {
   private managedBrowserReady?: Promise<{ browser: Browser; context: BrowserContext }>;
   private launcherHelper?: LauncherBrowserHelperClient;
   private maintenanceTail: Promise<void> = Promise.resolve();
+  private lastTurnActivityAt = 0;
   private readonly activeRuns = new Map<string, Promise<string>>();
 
   private constructor(private readonly config: ResolvedBrowserConfig) {}
@@ -3159,8 +3160,9 @@ export class ChatGptBrowserWorker {
           maxMessageChars,
         );
       }
+      // Cap unbounded turns: codex background-terminal waits must not hang the SSE forever.
       const deadline = this.config.turnTimeoutMs === undefined
-        ? undefined
+        ? Date.now() + 30 * 60_000
         : Date.now() + this.config.turnTimeoutMs;
       let page = await this.runStage(turn.traceId, "browser_page", browserStageTimeouts.browserPage, async (abortSignal) => {
         if (maintenancePage) return maintenancePage;
@@ -3232,6 +3234,19 @@ export class ChatGptBrowserWorker {
       console.info(
         `[chatgpt-web] browser turn ${turn.traceId} opened (transport=${prepared.multipart ? `multipart-${prepared.multipart.parts.length}` : "inline"}, maxMessageChars=${maxMessageChars}, estimatedInputTokens=${estimatedInputTokens}, images=${prepared.images.length}, compactionTrimmedMessages=${prepared.trimmedCompactionMessages ?? 0})`,
       );
+      if (reuseConversation && Date.now() - this.lastTurnActivityAt > 120_000) {
+        // Long idle gaps (codex background terminals) let ChatGPT drop the temp-chat
+        // stream; reload the surface before sending or the stage send stalls forever.
+        await this.runStage(
+          turn.traceId,
+          "idle_reconnect_preparation",
+          browserStageTimeouts.temporaryChatPreparation,
+          () => this.prepareTemporaryChatSurface(
+            page,
+            checkpoint => diagnostics.capture(page, checkpoint),
+          ),
+        );
+      }
       if (!reuseConversation) {
         await this.runStage(
           turn.traceId,
@@ -3620,6 +3635,7 @@ export class ChatGptBrowserWorker {
       }
       throw error;
     } finally {
+      this.lastTurnActivityAt = Date.now();
       prepared.release();
       if (turnConnection) {
         await turnConnection.close().catch(error => {

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -407,6 +407,19 @@ export async function throwIfChatGptTerminalErrorAlert(scope: ChatGptTextScope):
   );
 }
 
+const chatGptMessageTooLongAlert = (page: Page): Locator => page
+  .locator('[role="alert"]')
+  .filter({ hasText: /message you submitted was too long/i })
+  .last();
+
+export async function throwIfChatGptMessageTooLongAlert(page: Page): Promise<void> {
+  if (!await chatGptMessageTooLongAlert(page).isVisible().catch(() => false)) return;
+  throw new ChatGptWebAdapterError(
+    "ChatGPT rejected a staged message as too long for the accumulated conversation. Compact the Codex task (for example /compact) and retry the turn.",
+    { status: 400, errorType: "invalid_request_error", code: "chatgpt_message_too_long", retryable: false },
+  );
+}
+
 export async function resolveChatGptToolConfirmation(
   page: Page,
   appName: string,
@@ -499,7 +512,7 @@ export function assertChatGptWebMultipartInputWithinLimits(
   effort: ChatGptWebModelMode["effort"],
   capabilities: ChatGptWebCapabilities,
   maxMessageChars: number,
-  partCount: 2 | 3,
+  partCount: number,
   transport?: {
     stagingEffort: ChatGptWebModelMode["effort"];
     maxStageMessageTokens: number;
@@ -864,6 +877,7 @@ export class ChatGptTurnDomHealthTracker {
     running: boolean;
     currentText: string;
     completionActionVisible: boolean;
+    streamingStatusVisible?: boolean;
   }, now = Date.now()): string | undefined {
     if (state.responsePresent) {
       this.sawResponse = true;
@@ -892,6 +906,10 @@ export class ChatGptTurnDomHealthTracker {
 
     const missingCompletionAction = state.responsePresent
       && !state.running
+      // A live status container (tool/activity pill) means the connector turn is still
+      // executing even when generation looks stopped; a background terminal can hold that
+      // state with static text far beyond the completion-action grace window.
+      && state.streamingStatusVisible !== true
       && state.currentText.length > 0
       && !state.completionActionVisible;
     if (!missingCompletionAction) {
@@ -947,6 +965,7 @@ interface ChatGptResponseDomSnapshot {
   markdownSegments: ChatGptMarkdownSegment[];
   completionActionVisible: boolean;
   stoppedThinkingVisible: boolean;
+  streamingStatusVisible: boolean;
   traceBlocks: ChatGptVisibleTraceBlock[];
 }
 
@@ -964,6 +983,7 @@ const absentResponseDomSnapshot = (): ChatGptResponseDomSnapshot => ({
   markdownSegments: [],
   completionActionVisible: false,
   stoppedThinkingVisible: false,
+  streamingStatusVisible: false,
   traceBlocks: [],
 });
 
@@ -1074,6 +1094,10 @@ class ChatGptBrowserDiagnostics {
   private readonly directory: string;
   private sequence = 0;
   private initialized = false;
+  // Serialize disk I/O across concurrent captures so sequence numbers stay monotonic and
+  // capture-N.png / capture-N.json pairs never overlap on disk. The queue is never awaited
+  // by callers — see `capture()` below — it just keeps writes from racing each other.
+  private captureQueue: Promise<void> = Promise.resolve();
 
   constructor(private readonly traceId: string, private readonly root: string) {
     if (!/^[A-Za-z0-9_-]{6,128}$/.test(traceId)) {
@@ -1083,6 +1107,15 @@ class ChatGptBrowserDiagnostics {
   }
 
   async capture(page: Page, checkpoint: string, error?: unknown): Promise<void> {
+    // Fire-and-forget: the polling loop should not block on screenshot I/O (page.screenshot has a
+    // 5s timeout that can stall the whole turn when the renderer is slow). Disk writes still run
+    // serially through `captureQueue` so the captured files land in the right order.
+    this.captureQueue = this.captureQueue
+      .catch(() => {})
+      .then(() => this.captureBody(page, checkpoint, error));
+  }
+
+  private async captureBody(page: Page, checkpoint: string, error?: unknown): Promise<void> {
     try {
       if (!this.initialized) {
         privateDirectory(this.root);
@@ -2344,6 +2377,7 @@ export class ChatGptBrowserWorker {
         throw new Error("ChatGPT Bigger Context transaction timed out while awaiting a stage acknowledgement");
       }
       await throwIfChatGptSessionFailureAlert(page);
+      await throwIfChatGptMessageTooLongAlert(page);
       await throwIfChatGptTerminalErrorAlert(responseTurn.locator);
       let snapshot = await this.responseDomSnapshot(responseTurn.locator, responseDomCache);
       if (!snapshot.responsePresent && await responseTurn.locator.count() !== 1) {
@@ -2364,6 +2398,7 @@ export class ChatGptBrowserWorker {
         running,
         currentText: snapshot.visibleText,
         completionActionVisible: snapshot.completionActionVisible,
+        streamingStatusVisible: snapshot.streamingStatusVisible,
       });
       if (domError) throw new Error(domError);
       if (completionTracker.update({
@@ -2894,6 +2929,11 @@ export class ChatGptBrowserWorker {
         }
         return false;
       })();
+      // A connector turn can keep working (for example a background terminal waiting on output)
+      // with the stop button hidden and no text growth for minutes. The live status container is
+      // the only DOM signal that the turn is still executing in that state.
+      const streamingStatusVisible = [...root.querySelectorAll<HTMLElement>("[data-streaming-response-status]")]
+        .some(container => renderedInDom(container) && container.innerText.trim().length > 0);
       return {
         key: observerKey,
         snapshot: {
@@ -2903,6 +2943,7 @@ export class ChatGptBrowserWorker {
           markdownSegments,
           completionActionVisible: completionAction !== undefined,
           stoppedThinkingVisible,
+          streamingStatusVisible,
           traceBlocks,
         },
       };
@@ -3427,6 +3468,15 @@ export class ChatGptBrowserWorker {
       let loggedCompletionWait = false;
       let capturedResponse = false;
       const sentAt = Date.now();
+      // Poll cadence: keep it tight once a snapshot exists (ChatGPT is streaming, the user sees
+      // deltas faster), back off before the first snapshot (give the DOM time to settle without
+      // burning CPU on empty scans). Reuses the existing responseDomCache to decide.
+      const POLL_LIVE_MS = 100;
+      const POLL_IDLE_MS = 250;
+      const pollSleep = () => new Promise<void>(resolveSleep => setTimeout(
+        resolveSleep,
+        responseDomCache.snapshot ? POLL_LIVE_MS : POLL_IDLE_MS,
+      ));
       const visibleTrace = new ChatGptVisibleTraceTracker();
       const markdownBuffer = new ChatGptMarkdownBuffer();
       const checkpointStream = turn.captureLunaCheckpoint
@@ -3468,6 +3518,7 @@ export class ChatGptBrowserWorker {
         }
 
         await throwIfChatGptSessionFailureAlert(page);
+        await throwIfChatGptMessageTooLongAlert(page);
         await throwIfChatGptTerminalErrorAlert(responseTurn.locator);
 
         if (mode.localTools && await resolveChatGptToolConfirmation(
@@ -3478,7 +3529,7 @@ export class ChatGptBrowserWorker {
           CHATGPT_TOOL_CONFIRMATION_TIMEOUT_MS,
           () => diagnostics.capture(page, "tool-confirmation-visible"),
         )) {
-          await new Promise(resolveSleep => setTimeout(resolveSleep, 250));
+          await pollSleep();
           continue;
         }
 
@@ -3532,7 +3583,7 @@ export class ChatGptBrowserWorker {
           // Current-turn MCP activity proves that ChatGPT is still executing even if its renderer
           // temporarily cannot expose the response subtree. DOM remains authoritative for text and
           // completion; this only prevents a live turn from being misclassified as vanished.
-          await new Promise(resolveSleep => setTimeout(resolveSleep, 250));
+          await pollSleep();
           continue;
         }
         const stop = page.locator(CHATGPT_STOP_BUTTON_SELECTOR).last();
@@ -3560,6 +3611,7 @@ export class ChatGptBrowserWorker {
             running,
             currentText: snapshot.visibleText,
             completionActionVisible: snapshot.completionActionVisible,
+            streamingStatusVisible: snapshot.streamingStatusVisible,
           });
           if (domError) throw new Error(domError);
           if (completionTracker.update({
@@ -3604,6 +3656,13 @@ export class ChatGptBrowserWorker {
               `[chatgpt-web] waiting for completed-turn evidence (running=${running}, sawRunning=${sawRunning}, textChars=${snapshot.visibleText.length}, completionActionVisible=${snapshot.completionActionVisible}, ui=${diagnostic})`,
             );
           }
+          // Hard timeout: if the browser stalls past this many seconds, fail the turn so the
+          // finally block can notify the launcher (`phase: end`, status: failed) and free the
+          // broker channel instead of leaking a never-ending heartbeat.
+          const CHATGPT_BROWSER_TURN_HARD_TIMEOUT_MS = 5 * 60_000;
+          if (Date.now() - sentAt >= CHATGPT_BROWSER_TURN_HARD_TIMEOUT_MS) {
+            throw new Error(`ChatGPT browser stalled for ${CHATGPT_BROWSER_TURN_HARD_TIMEOUT_MS / 1000}s after submit; aborting turn ${turn.traceId}`);
+          }
         } else {
           const domError = domHealthTracker.update({
             responsePresent: false,
@@ -3613,7 +3672,7 @@ export class ChatGptBrowserWorker {
           });
           if (domError) throw new Error(domError);
         }
-        await new Promise(resolveSleep => setTimeout(resolveSleep, 250));
+        await pollSleep();
       }
 
       if (this.context && this.config.browserHost === "managed-chrome") {

--- a/src/adapters/chatgpt-web/environment.ts
+++ b/src/adapters/chatgpt-web/environment.ts
@@ -158,7 +158,13 @@ function environmentBeforeUser(input: unknown[], userIndex: number, expectedTurn
   if (candidate?.type !== "message" || candidate.role !== "user") return undefined;
 
   const candidateTurnId = itemTurnId(candidate);
-  if (candidateTurnId !== userTurnId) return undefined;
+  // Codex CLI 0.153.x ships the per-turn <environment_context> carrier as a server-owned user
+  // message with no `internal_chat_message_metadata_passthrough` — its identity is the server id,
+  // not the turn id of the active instruction. Accept the carrier when either its turn id matches
+  // the active user or it's a server-owned item without a (possibly stale) conflicting turn id.
+  const candidateServerOwned = typeof candidate.id === "string" && candidate.id.length > 0;
+  if (candidateTurnId !== undefined && candidateTurnId !== userTurnId) return undefined;
+  if (candidateTurnId === undefined && !candidateServerOwned) return undefined;
 
   const content = Array.isArray(candidate.content) ? candidate.content : [];
   for (const part of content) {

--- a/src/browser-login.ts
+++ b/src/browser-login.ts
@@ -104,6 +104,7 @@ export interface LoginToChatGptOptions {
   email?: string;
   password?: string;
   mfaCodePrompt?: () => Promise<string>;
+  sessionCookie?: string;
 }
 
 const AUTH_LOGIN_URL = "https://auth.openai.com/log-in";
@@ -230,6 +231,56 @@ async function finalizeLogin(
   };
 }
 
+export function parseSessionCookieInput(raw: string): NonNullable<BrowserContextOptions["storageState"]> {
+  const input = raw.trim();
+  if (input.startsWith("{")) {
+    const state = JSON.parse(input) as { cookies?: unknown };
+    if (!Array.isArray(state.cookies) || state.cookies.length === 0) {
+      throw new Error("Storage state JSON must contain a non-empty cookies array");
+    }
+    return state as NonNullable<BrowserContextOptions["storageState"]>;
+  }
+  const now = Math.floor(Date.now() / 1000);
+  const pairs = input.includes("=")
+    ? input.split(";").map(pair => pair.trim()).filter(Boolean).map(pair => {
+        const eq = pair.indexOf("=");
+        return { name: pair.slice(0, eq), value: pair.slice(eq + 1) };
+      })
+    : [{ name: "__Secure-next-auth.session-token", value: input }];
+  if (pairs.some(pair => !pair.name || !pair.value)) {
+    throw new Error("Could not parse cookie input; paste name=value pairs or a storageState JSON");
+  }
+  return {
+    cookies: pairs.map(pair => ({
+      name: pair.name,
+      value: pair.value,
+      domain: ".chatgpt.com",
+      path: "/",
+      secure: true,
+      httpOnly: pair.name.includes("session-token"),
+      sameSite: "Lax",
+      expires: now + 60 * 60 * 24 * 30,
+    })),
+    origins: [],
+  };
+}
+
+async function importSessionCookieInput(
+  config: AppConfig,
+  raw: string,
+): Promise<BrowserLoginResult> {
+  const state = parseSessionCookieInput(raw);
+  const inspected = await inspectStoredState(config, state, true);
+  atomicWriteFile(config.storageStatePath, `${JSON.stringify(state)}\n`);
+  writeVerificationMarker(config.storageStatePath, inspected);
+  return {
+    storageStatePath: config.storageStatePath,
+    accountSurfaceUrl: inspected.url,
+    solAvailable: inspected.solAvailable,
+    proAvailable: inspected.proAvailable,
+  };
+}
+
 async function importStorageStateFile(
   config: AppConfig,
   storageStateFile: string,
@@ -312,7 +363,12 @@ export async function loginToChatGpt(
   if (!existsSync(config.chromeExecutablePath)) {
     throw new Error(`Google Chrome was not found at ${config.chromeExecutablePath}. Pass --chrome with its executable path.`);
   }
+  if (options.sessionCookie) return importSessionCookieInput(config, options.sessionCookie);
   if (options.storageStateFile) return importStorageStateFile(config, options.storageStateFile);
+  const profileDir = join(dirname(config.storageStatePath), "login-profile");
+  mkdirSync(profileDir, { recursive: true, mode: 0o700 });
+  const timeoutMs = options.timeoutMs ?? 60_000;
+  const mode: LoginHeadlessMode = options.loginHeadless ?? "auto";
   const credentialLogin = options.email !== undefined || options.password !== undefined;
   if (credentialLogin) {
     if (options.email === undefined || options.password === undefined || !options.email || !options.password) {
@@ -328,10 +384,6 @@ export async function loginToChatGpt(
       return await withEphemeralXvfb(() => tryCreds(false));
     }
   }
-  const profileDir = join(dirname(config.storageStatePath), "login-profile");
-  mkdirSync(profileDir, { recursive: true, mode: 0o700 });
-  const timeoutMs = options.timeoutMs ?? 60_000;
-  const mode: LoginHeadlessMode = options.loginHeadless ?? "auto";
   try {
     if (mode !== "off") {
       try {

--- a/src/browser-login.ts
+++ b/src/browser-login.ts
@@ -1,7 +1,8 @@
 import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { chromium, type BrowserContextOptions, type Page } from "playwright-core";
+import { chromium } from "patchright";
+import type { BrowserContextOptions, Page } from "patchright-core";
 import { runCommand } from "./process";
 import type { AppConfig } from "./config";
 import { atomicWriteFile } from "./config";
@@ -95,6 +96,16 @@ export function storedBrowserLoginCapabilities(
   }
 }
 
+export function parseProxyUrl(raw: string): { server: string; username?: string; password?: string } {
+  const url = new URL(raw);
+  const server = `${url.protocol.replace(":", "")}://${url.hostname}:${url.port || (url.protocol === "https:" ? "443" : "80")}`;
+  return {
+    server,
+    ...(url.username ? { username: decodeURIComponent(url.username) } : {}),
+    ...(url.password ? { password: decodeURIComponent(url.password) } : {}),
+  };
+}
+
 export type LoginHeadlessMode = "auto" | "force" | "off";
 
 export interface LoginToChatGptOptions {
@@ -105,6 +116,7 @@ export interface LoginToChatGptOptions {
   password?: string;
   mfaCodePrompt?: () => Promise<string>;
   sessionCookie?: string;
+  proxy?: { server: string; username?: string; password?: string };
 }
 
 const AUTH_LOGIN_URL = "https://auth.openai.com/log-in";
@@ -117,19 +129,32 @@ async function attemptCredentialLogin(
   headless: boolean,
   timeoutMs: number,
   mfaCodePrompt?: () => Promise<string>,
+  proxy?: { server: string; username?: string; password?: string },
 ): Promise<BrowserLoginResult> {
   const context = await chromium.launchPersistentContext(profileDir, {
     executablePath: config.chromeExecutablePath,
     headless,
     ignoreDefaultArgs: CHROME_IGNORE_DEFAULT_ARGS,
     args: CHROME_LAUNCH_ARGS,
+    ...(proxy ? { proxy } : {}),
   });
   let page: Page | undefined;
   try {
     page = context.pages()[0] ?? await context.newPage();
     await page.goto(AUTH_LOGIN_URL, { waitUntil: "domcontentloaded", timeout: 60_000 });
+    // Turnstile interstitial: click the widget container so managed/checkbox mode resolves.
+    for (let turnstileAttempt = 0; turnstileAttempt < 8; turnstileAttempt += 1) {
+      const emailReady = await page.locator('input[name="email"], input#email-input, input[type="email"]').first()
+        .isVisible({ timeout: 5_000 }).catch(() => false);
+      if (emailReady) break;
+      const widget = page.locator('[class*="cf-turnstile"], [data-sitekey], iframe[title*="Cloudflare" i]').first();
+      if (await widget.isVisible().catch(() => false)) {
+        await widget.click({ timeout: 5_000 }).catch(() => {});
+      }
+      await page.waitForTimeout(5_000);
+    }
     const emailInput = page.locator('input[name="email"], input#email-input, input[type="email"]').first();
-    await emailInput.waitFor({ state: "visible", timeout: 30_000 });
+    await emailInput.waitFor({ state: "visible", timeout: 60_000 });
     await emailInput.fill(email);
     await page.getByRole("button", { name: /continue/i }).first().click();
     const passwordInput = page.locator('input[type="password"]').first();
@@ -156,14 +181,26 @@ async function attemptCredentialLogin(
       await composer.waitFor({ state: "visible", timeout: timeoutMs });
     } catch {
       if (await headlessLoginBlocked(page)) {
-        throw new Error("CREDENTIAL_LOGIN_BLOCKED: ChatGPT served a bot challenge during credential login");
+        const d = await page.evaluate(() => ({
+          u: location.href.slice(0, 140),
+          t: document.title.slice(0, 80),
+          cf: document.querySelectorAll("iframe[src*='challenges.cloudflare.com']").length,
+          n: document.body.innerText.length,
+        })).catch(() => "diagfail");
+        throw new Error(`CREDENTIAL_LOGIN_BLOCKED: ${JSON.stringify(d)}`);
       }
       throw new Error("Credential login finished but no ChatGPT composer appeared (check email/password or complete any verification manually)");
     }
     return await finalizeLogin(config, context, page, headless);
   } catch (error) {
     if (page && headless && await headlessLoginBlocked(page).catch(() => false)) {
-      throw new Error("CREDENTIAL_LOGIN_BLOCKED: bot challenge during credential login");
+      const d = await page.evaluate(() => ({
+        u: location.href.slice(0, 140),
+        t: document.title.slice(0, 80),
+        cf: document.querySelectorAll("iframe[src*='challenges.cloudflare.com']").length,
+        n: document.body.innerText.length,
+      })).catch(() => "diagfail");
+      throw new Error(`CREDENTIAL_LOGIN_BLOCKED: ${JSON.stringify(d)}`);
     }
     throw error;
   } finally {
@@ -181,8 +218,10 @@ function composerLocator(page: Page) {
 }
 
 async function headlessLoginBlocked(page: Page): Promise<boolean> {
-  const content = await page.content().catch(() => "");
-  return /challenge-platform|just a moment|verify you are human|cf-please-wait/i.test(content);
+  // Only an interactive Turnstile widget counts; chatgpt.com always ships the
+  // challenge-platform script tag, so text matching false-positives.
+  const turnstile = page.locator('iframe[title*="Cloudflare" i], iframe[src*="challenges.cloudflare.com"]').first();
+  return await turnstile.isVisible().catch(() => false);
 }
 
 async function withEphemeralXvfb<T>(fn: (display: string) => Promise<T>): Promise<T> {
@@ -311,6 +350,7 @@ async function attemptPersistentLogin(
   profileDir: string,
   headless: boolean,
   timeoutMs: number,
+  proxy?: { server: string; username?: string; password?: string },
 ): Promise<BrowserLoginResult> {
   const context = await chromium.launchPersistentContext(profileDir, {
     executablePath: config.chromeExecutablePath,
@@ -374,7 +414,7 @@ export async function loginToChatGpt(
     if (options.email === undefined || options.password === undefined || !options.email || !options.password) {
       throw new Error("Credential login requires both --email and a password (--password-file or CODEX_CHATGPT_WEB_PASSWORD)");
     }
-    const tryCreds = (headless: boolean) => attemptCredentialLogin(config, profileDir, options.email!, options.password!, headless, timeoutMs, options.mfaCodePrompt);
+    const tryCreds = (headless: boolean) => attemptCredentialLogin(config, profileDir, options.email!, options.password!, headless, timeoutMs, options.mfaCodePrompt, options.proxy);
     try {
       return await tryCreds(true);
     } catch (error) {

--- a/src/browser-login.ts
+++ b/src/browser-login.ts
@@ -1,7 +1,8 @@
 import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { chromium, type BrowserContextOptions } from "playwright-core";
+import { chromium, type BrowserContextOptions, type Page } from "playwright-core";
+import { runCommand } from "./process";
 import type { AppConfig } from "./config";
 import { atomicWriteFile } from "./config";
 import {
@@ -47,10 +48,11 @@ function writeVerificationMarker(
 async function inspectStoredState(
   config: AppConfig,
   storageState: NonNullable<BrowserContextOptions["storageState"]>,
+  headless = false,
 ): Promise<ChatGptWebAccountCapabilities & { url: string }> {
   const verifierBrowser = await chromium.launch({
     executablePath: config.chromeExecutablePath,
-    headless: false,
+    headless,
     ignoreDefaultArgs: ["--password-store=basic", "--use-mock-keychain"],
     args: ["--no-first-run", "--no-default-browser-check"],
   });
@@ -93,15 +95,129 @@ export function storedBrowserLoginCapabilities(
   }
 }
 
-export async function loginToChatGpt(
-  config: AppConfig,
-  options: { timeoutMs?: number } = {},
-): Promise<BrowserLoginResult> {
-  if (!existsSync(config.chromeExecutablePath)) {
-    throw new Error(`Google Chrome was not found at ${config.chromeExecutablePath}. Pass --chrome with its executable path.`);
+export type LoginHeadlessMode = "auto" | "force" | "off";
+
+export interface LoginToChatGptOptions {
+  timeoutMs?: number;
+  loginHeadless?: LoginHeadlessMode;
+  storageStateFile?: string;
+}
+
+const CHROME_LAUNCH_ARGS = ["--no-first-run", "--no-default-browser-check"];
+const CHROME_IGNORE_DEFAULT_ARGS = ["--password-store=basic", "--use-mock-keychain"];
+
+function composerLocator(page: Page) {
+  return page.getByRole("textbox", { name: "Chat with ChatGPT" }).or(
+    page.locator('[data-testid="prompt-textarea"], [contenteditable="true"][data-lexical-editor="true"]'),
+  ).first();
+}
+
+async function headlessLoginBlocked(page: Page): Promise<boolean> {
+  const content = await page.content().catch(() => "");
+  return /challenge-platform|just a moment|verify you are human|cf-please-wait/i.test(content);
+}
+
+async function withEphemeralXvfb<T>(fn: (display: string) => Promise<T>): Promise<T> {
+  const probe = runCommand("which", ["Xvfb"]);
+  if (probe.status !== 0) {
+    throw new Error(
+      "Headless ChatGPT login was blocked and Xvfb is not installed. "
+      + "Install xvfb, import a storage state via --storage-state-file, or log in on a machine with a display.",
+    );
   }
-  const profileDir = join(dirname(config.storageStatePath), "login-profile");
-  mkdirSync(profileDir, { recursive: true, mode: 0o700 });
+  const { readdirSync } = await import("node:fs");
+  const existing = new Set(readdirSync("/tmp/.X11-unix").map(name => name.replace(/^X/, "")));
+  let display: string | undefined;
+  for (let candidate = 99; candidate < 200; candidate += 1) {
+    if (!existing.has(String(candidate))) { display = `:${candidate}`; break; }
+  }
+  if (!display) throw new Error("No free display number found for ephemeral Xvfb");
+  const xvfb = spawn("Xvfb", [display, "-screen", "0", "1280x800x24", "-nolisten", "tcp"], { stdio: "ignore" });
+  await new Promise(resolveWait => setTimeout(resolveWait, 800));
+  if (xvfb.exitCode !== null && xvfb.exitCode !== 0) throw new Error(`Xvfb exited with status ${xvfb.exitCode}`);
+  try {
+    return await fn(display);
+  } finally {
+    xvfb.kill("SIGTERM");
+    setTimeout(() => xvfb.kill("SIGKILL"), 2_000).unref?.();
+  }
+}
+
+async function finalizeLogin(
+  config: AppConfig,
+  context: Awaited<ReturnType<typeof chromium.launchPersistentContext>>,
+  page: Page,
+  headless: boolean,
+): Promise<BrowserLoginResult> {
+  await assertAuthenticatedChatGptPage(page);
+  await assertTemporaryChatPage(page);
+  const state = await context.storageState();
+  const inspected = await inspectStoredState(config, state, headless);
+  atomicWriteFile(config.storageStatePath, `${JSON.stringify(state)}\n`);
+  writeVerificationMarker(config.storageStatePath, inspected);
+  return {
+    storageStatePath: config.storageStatePath,
+    accountSurfaceUrl: page.url(),
+    solAvailable: inspected.solAvailable,
+    proAvailable: inspected.proAvailable,
+  };
+}
+
+async function importStorageStateFile(
+  config: AppConfig,
+  storageStateFile: string,
+): Promise<BrowserLoginResult> {
+  if (!existsSync(storageStateFile)) throw new Error(`Storage state file not found: ${storageStateFile}`);
+  let state: unknown;
+  try {
+    state = JSON.parse(readFileSync(storageStateFile, "utf8"));
+  } catch {
+    throw new Error(`Storage state file is not valid JSON: ${storageStateFile}`);
+  }
+  if (typeof state !== "object" || state === null || !Array.isArray((state as { cookies?: unknown }).cookies)) {
+    throw new Error("Storage state file must be a Playwright storageState object with a cookies array");
+  }
+  const inspected = await inspectStoredState(config, state as NonNullable<BrowserContextOptions["storageState"]>, true);
+  atomicWriteFile(config.storageStatePath, `${JSON.stringify(state)}\n`);
+  writeVerificationMarker(config.storageStatePath, inspected);
+  return {
+    storageStatePath: config.storageStatePath,
+    accountSurfaceUrl: inspected.url,
+    solAvailable: inspected.solAvailable,
+    proAvailable: inspected.proAvailable,
+  };
+}
+
+async function attemptPersistentLogin(
+  config: AppConfig,
+  profileDir: string,
+  headless: boolean,
+  timeoutMs: number,
+): Promise<BrowserLoginResult> {
+  const context = await chromium.launchPersistentContext(profileDir, {
+    executablePath: config.chromeExecutablePath,
+    headless,
+    ignoreDefaultArgs: CHROME_IGNORE_DEFAULT_ARGS,
+    args: CHROME_LAUNCH_ARGS,
+  });
+  try {
+    const page = context.pages()[0] ?? await context.newPage();
+    await page.goto(CHATGPT_TEMPORARY_CHAT_URL, { waitUntil: "domcontentloaded", timeout: 60_000 });
+    try {
+      await composerLocator(page).waitFor({ state: "visible", timeout: timeoutMs });
+    } catch {
+      if (headless && await headlessLoginBlocked(page)) {
+        throw new Error("HEADLESS_BLOCKED: ChatGPT served a bot challenge to the headless browser");
+      }
+      throw new Error("The authenticated ChatGPT page did not produce a visible composer");
+    }
+    return await finalizeLogin(config, context, page, headless);
+  } finally {
+    await context.close();
+  }
+}
+
+async function headedChromeLoginWindow(config: AppConfig, profileDir: string, display?: string): Promise<void> {
   process.stdout.write(
     "A normal Chrome window is open. Sign in to ChatGPT, confirm that the composer is visible, then quit this dedicated Chrome instance completely.\n",
   );
@@ -109,10 +225,9 @@ export async function loginToChatGpt(
     `--user-data-dir=${profileDir}`,
     "--new-window",
     "--disable-background-mode",
-    "--no-first-run",
-    "--no-default-browser-check",
+    ...CHROME_LAUNCH_ARGS,
     CHATGPT_TEMPORARY_CHAT_URL,
-  ], { env: process.env, stdio: "ignore" });
+  ], { env: display ? { ...process.env, DISPLAY: display } : process.env, stdio: "ignore" });
   const loginExit = await new Promise<number>((resolveExit, rejectExit) => {
     loginBrowser.once("error", rejectExit);
     loginBrowser.once("exit", (code, signal) => {
@@ -121,42 +236,37 @@ export async function loginToChatGpt(
     });
   });
   if (loginExit !== 0) throw new Error(`Normal Chrome login window exited with status ${loginExit}`);
+}
 
-  const context = await chromium.launchPersistentContext(profileDir, {
-    executablePath: config.chromeExecutablePath,
-    headless: false,
-    ignoreDefaultArgs: ["--password-store=basic", "--use-mock-keychain"],
-    args: ["--no-first-run", "--no-default-browser-check"],
-  });
+export async function loginToChatGpt(
+  config: AppConfig,
+  options: LoginToChatGptOptions = {},
+): Promise<BrowserLoginResult> {
+  if (!existsSync(config.chromeExecutablePath)) {
+    throw new Error(`Google Chrome was not found at ${config.chromeExecutablePath}. Pass --chrome with its executable path.`);
+  }
+  if (options.storageStateFile) return importStorageStateFile(config, options.storageStateFile);
+  const profileDir = join(dirname(config.storageStatePath), "login-profile");
+  mkdirSync(profileDir, { recursive: true, mode: 0o700 });
+  const timeoutMs = options.timeoutMs ?? 60_000;
+  const mode: LoginHeadlessMode = options.loginHeadless ?? "auto";
   try {
-    const page = context.pages()[0] ?? await context.newPage();
-    await page.goto(CHATGPT_TEMPORARY_CHAT_URL, {
-      waitUntil: "domcontentloaded",
-      timeout: 60_000,
-    });
-    const composer = page.getByRole("textbox", { name: "Chat with ChatGPT" }).or(
-      page.locator('[data-testid="prompt-textarea"], [contenteditable="true"][data-lexical-editor="true"]'),
-    ).first();
-    try {
-      await composer.waitFor({ state: "visible", timeout: options.timeoutMs ?? 60_000 });
-    } catch {
-      throw new Error("The authenticated ChatGPT page did not produce a visible composer");
+    if (mode !== "off") {
+      try {
+        return await attemptPersistentLogin(config, profileDir, true, Math.min(timeoutMs, 45_000));
+      } catch (error) {
+        const blocked = error instanceof Error && error.message.startsWith("HEADLESS_BLOCKED");
+        if (mode === "force" || !blocked) throw error;
+        process.stdout.write("Headless login was blocked by a bot challenge; retrying under ephemeral Xvfb.\n");
+      }
+      return await withEphemeralXvfb(async display => {
+        await headedChromeLoginWindow(config, profileDir, display);
+        return attemptPersistentLogin(config, profileDir, false, timeoutMs);
+      });
     }
-    await assertAuthenticatedChatGptPage(page);
-    await assertTemporaryChatPage(page);
-    const state = await context.storageState();
-
-    const inspected = await inspectStoredState(config, state);
-    atomicWriteFile(config.storageStatePath, `${JSON.stringify(state)}\n`);
-    writeVerificationMarker(config.storageStatePath, inspected);
-    return {
-      storageStatePath: config.storageStatePath,
-      accountSurfaceUrl: page.url(),
-      solAvailable: inspected.solAvailable,
-      proAvailable: inspected.proAvailable,
-    };
+    await headedChromeLoginWindow(config, profileDir);
+    return await attemptPersistentLogin(config, profileDir, false, timeoutMs);
   } finally {
-    await context.close();
     if (browserLoginStateExists(config)) rmSync(profileDir, { recursive: true, force: true });
   }
 }

--- a/src/browser-login.ts
+++ b/src/browser-login.ts
@@ -103,6 +103,7 @@ export interface LoginToChatGptOptions {
   storageStateFile?: string;
   email?: string;
   password?: string;
+  mfaCodePrompt?: () => Promise<string>;
 }
 
 const AUTH_LOGIN_URL = "https://auth.openai.com/log-in";
@@ -114,6 +115,7 @@ async function attemptCredentialLogin(
   password: string,
   headless: boolean,
   timeoutMs: number,
+  mfaCodePrompt?: () => Promise<string>,
 ): Promise<BrowserLoginResult> {
   const context = await chromium.launchPersistentContext(profileDir, {
     executablePath: config.chromeExecutablePath,
@@ -133,6 +135,19 @@ async function attemptCredentialLogin(
     await passwordInput.waitFor({ state: "visible", timeout: 30_000 });
     await passwordInput.fill(password);
     await page.getByRole("button", { name: /continue|log in/i }).first().click();
+    // ChatGPT may require an e-mail OTP after the password. Surface an interactive
+    // prompt (CLI) so the flow stays terminal-driven; skip when no prompt is wired.
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const otpInput = page.locator('input[autocomplete="one-time-code"], input[inputmode="numeric"][name*="code" i], input[aria-label*="code" i]').first();
+      const otpVisible = await otpInput.isVisible().catch(() => false);
+      if (!otpVisible || !mfaCodePrompt) break;
+      const code = (await mfaCodePrompt()).trim();
+      if (!code) throw new Error("ChatGPT requested an e-mail verification code but no code was provided");
+      await otpInput.fill(code);
+      const continueButton = page.getByRole("button", { name: /continue|verify/i }).first();
+      if (await continueButton.isVisible().catch(() => false)) await continueButton.click();
+      await page.waitForTimeout(1_500);
+    }
     await page.waitForURL(/chatgpt\.com/, { timeout: 120_000 });
     await page.goto(CHATGPT_TEMPORARY_CHAT_URL, { waitUntil: "domcontentloaded", timeout: 60_000 }).catch(() => {});
     const composer = composerLocator(page);
@@ -303,7 +318,7 @@ export async function loginToChatGpt(
     if (options.email === undefined || options.password === undefined || !options.email || !options.password) {
       throw new Error("Credential login requires both --email and a password (--password-file or CODEX_CHATGPT_WEB_PASSWORD)");
     }
-    const tryCreds = (headless: boolean) => attemptCredentialLogin(config, profileDir, options.email!, options.password!, headless, timeoutMs);
+    const tryCreds = (headless: boolean) => attemptCredentialLogin(config, profileDir, options.email!, options.password!, headless, timeoutMs, options.mfaCodePrompt);
     try {
       return await tryCreds(true);
     } catch (error) {

--- a/src/browser-login.ts
+++ b/src/browser-login.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { chromium } from "patchright";
+import { installTurnstileAutoSolver } from "patchright-difz";
 import type { BrowserContextOptions, Page } from "patchright-core";
 import { runCommand } from "./process";
 import type { AppConfig } from "./config";
@@ -138,12 +139,29 @@ async function attemptCredentialLogin(
     args: CHROME_LAUNCH_ARGS,
     ...(proxy ? { proxy } : {}),
   });
+  const uninstallTurnstileSolver = installTurnstileAutoSolver(context);
   let page: Page | undefined;
   try {
     page = context.pages()[0] ?? await context.newPage();
-    await page.goto(AUTH_LOGIN_URL, { waitUntil: "domcontentloaded", timeout: 60_000 });
+    // Session probe: valid stored session lands straight on composer — no auth needed.
+    try {
+      await page.goto(CHATGPT_TEMPORARY_CHAT_URL, { waitUntil: "domcontentloaded", timeout: 45_000 });
+      await composerLocator(page).waitFor({ state: "visible", timeout: 20_000 }).catch(() => {});
+      if (await composerLocator(page).isVisible().catch(() => false)) {
+        return await finalizeLogin(config, context, page, headless);
+      }
+    } catch (probeError) {
+      if (!/ERR_ABORTED/.test(String(probeError))) console.error(`[login] session probe failed, continuing to auth form: ${String(probeError).slice(0, 120)}`);
+    }
+    try {
+      await page.goto(AUTH_LOGIN_URL, { waitUntil: "domcontentloaded", timeout: 60_000 });
+    } catch (gotoError) {
+      // Logged-in profile redirects mid-goto (ERR_ABORTED) straight to chatgpt.com — expected.
+      if (!/ERR_ABORTED/.test(String(gotoError))) throw gotoError;
+    }
     // Turnstile interstitial: click the widget container so managed/checkbox mode resolves.
-    for (let turnstileAttempt = 0; turnstileAttempt < 8; turnstileAttempt += 1) {
+    const alreadyOnChatgpt = /chatgpt\.com/.test(page.url());
+    if (!alreadyOnChatgpt) for (let turnstileAttempt = 0; turnstileAttempt < 8; turnstileAttempt += 1) {
       const emailReady = await page.locator('input[name="email"], input#email-input, input[type="email"]').first()
         .isVisible({ timeout: 5_000 }).catch(() => false);
       if (emailReady) break;
@@ -154,6 +172,8 @@ async function attemptCredentialLogin(
       await page.waitForTimeout(5_000);
     }
     const emailInput = page.locator('input[name="email"], input#email-input, input[type="email"]').first();
+    const emailFormVisible = await emailInput.isVisible().catch(() => false);
+    if (emailFormVisible) {
     await emailInput.waitFor({ state: "visible", timeout: 60_000 });
     await emailInput.fill(email);
     await page.getByRole("button", { name: /continue/i }).first().click();
@@ -174,12 +194,18 @@ async function attemptCredentialLogin(
       if (await continueButton.isVisible().catch(() => false)) await continueButton.click();
       await page.waitForTimeout(1_500);
     }
-    await page.waitForURL(/chatgpt\.com/, { timeout: 120_000 });
+    if (emailFormVisible) {
+      await page.waitForURL(/chatgpt\.com/, { timeout: 120_000 });
+    }
     await page.goto(CHATGPT_TEMPORARY_CHAT_URL, { waitUntil: "domcontentloaded", timeout: 60_000 }).catch(() => {});
     const composer = composerLocator(page);
     try {
       await composer.waitFor({ state: "visible", timeout: timeoutMs });
     } catch {
+      const diag = JSON.stringify({
+        u: page.url().slice(0, 140),
+        t: (await page.title().catch(() => "?")).slice(0, 60),
+      }).replace(/"/g, "'");
       if (await headlessLoginBlocked(page)) {
         const d = await page.evaluate(() => ({
           u: location.href.slice(0, 140),
@@ -189,7 +215,8 @@ async function attemptCredentialLogin(
         })).catch(() => "diagfail");
         throw new Error(`CREDENTIAL_LOGIN_BLOCKED: ${JSON.stringify(d)}`);
       }
-      throw new Error("Credential login finished but no ChatGPT composer appeared (check email/password or complete any verification manually)");
+      throw new Error(`Credential login composer fail | ${diag}`);
+    }
     }
     return await finalizeLogin(config, context, page, headless);
   } catch (error) {
@@ -204,6 +231,7 @@ async function attemptCredentialLogin(
     }
     throw error;
   } finally {
+    uninstallTurnstileSolver?.();
     await context.close();
   }
 }

--- a/src/browser-login.ts
+++ b/src/browser-login.ts
@@ -101,6 +101,58 @@ export interface LoginToChatGptOptions {
   timeoutMs?: number;
   loginHeadless?: LoginHeadlessMode;
   storageStateFile?: string;
+  email?: string;
+  password?: string;
+}
+
+const AUTH_LOGIN_URL = "https://auth.openai.com/log-in";
+
+async function attemptCredentialLogin(
+  config: AppConfig,
+  profileDir: string,
+  email: string,
+  password: string,
+  headless: boolean,
+  timeoutMs: number,
+): Promise<BrowserLoginResult> {
+  const context = await chromium.launchPersistentContext(profileDir, {
+    executablePath: config.chromeExecutablePath,
+    headless,
+    ignoreDefaultArgs: CHROME_IGNORE_DEFAULT_ARGS,
+    args: CHROME_LAUNCH_ARGS,
+  });
+  let page: Page | undefined;
+  try {
+    page = context.pages()[0] ?? await context.newPage();
+    await page.goto(AUTH_LOGIN_URL, { waitUntil: "domcontentloaded", timeout: 60_000 });
+    const emailInput = page.locator('input[name="email"], input#email-input, input[type="email"]').first();
+    await emailInput.waitFor({ state: "visible", timeout: 30_000 });
+    await emailInput.fill(email);
+    await page.getByRole("button", { name: /continue/i }).first().click();
+    const passwordInput = page.locator('input[type="password"]').first();
+    await passwordInput.waitFor({ state: "visible", timeout: 30_000 });
+    await passwordInput.fill(password);
+    await page.getByRole("button", { name: /continue|log in/i }).first().click();
+    await page.waitForURL(/chatgpt\.com/, { timeout: 120_000 });
+    await page.goto(CHATGPT_TEMPORARY_CHAT_URL, { waitUntil: "domcontentloaded", timeout: 60_000 }).catch(() => {});
+    const composer = composerLocator(page);
+    try {
+      await composer.waitFor({ state: "visible", timeout: timeoutMs });
+    } catch {
+      if (await headlessLoginBlocked(page)) {
+        throw new Error("CREDENTIAL_LOGIN_BLOCKED: ChatGPT served a bot challenge during credential login");
+      }
+      throw new Error("Credential login finished but no ChatGPT composer appeared (check email/password or complete any verification manually)");
+    }
+    return await finalizeLogin(config, context, page, headless);
+  } catch (error) {
+    if (page && headless && await headlessLoginBlocked(page).catch(() => false)) {
+      throw new Error("CREDENTIAL_LOGIN_BLOCKED: bot challenge during credential login");
+    }
+    throw error;
+  } finally {
+    await context.close();
+  }
 }
 
 const CHROME_LAUNCH_ARGS = ["--no-first-run", "--no-default-browser-check"];
@@ -246,6 +298,21 @@ export async function loginToChatGpt(
     throw new Error(`Google Chrome was not found at ${config.chromeExecutablePath}. Pass --chrome with its executable path.`);
   }
   if (options.storageStateFile) return importStorageStateFile(config, options.storageStateFile);
+  const credentialLogin = options.email !== undefined || options.password !== undefined;
+  if (credentialLogin) {
+    if (options.email === undefined || options.password === undefined || !options.email || !options.password) {
+      throw new Error("Credential login requires both --email and a password (--password-file or CODEX_CHATGPT_WEB_PASSWORD)");
+    }
+    const tryCreds = (headless: boolean) => attemptCredentialLogin(config, profileDir, options.email!, options.password!, headless, timeoutMs);
+    try {
+      return await tryCreds(true);
+    } catch (error) {
+      const blocked = error instanceof Error && error.message.startsWith("CREDENTIAL_LOGIN_BLOCKED");
+      if (!blocked || options.loginHeadless === "force") throw error;
+      process.stdout.write("Headless credential login hit a bot challenge; retrying under ephemeral Xvfb.\n");
+      return await withEphemeralXvfb(() => tryCreds(false));
+    }
+  }
   const profileDir = join(dirname(config.storageStatePath), "login-profile");
   mkdirSync(profileDir, { recursive: true, mode: 0o700 });
   const timeoutMs = options.timeoutMs ?? 60_000;

--- a/src/chatgpt-session.ts
+++ b/src/chatgpt-session.ts
@@ -1,4 +1,6 @@
-import type { Locator, Page } from "playwright-core";
+// ponytail: any-typed page/locator to stay compatible with playwright-core + patchright callers
+type Page = any;
+type Locator = any;
 import type { ChatGptWebAccountCapabilities } from "./chatgpt-web-models";
 
 export const CHATGPT_TEMPORARY_CHAT_URL = "https://chatgpt.com/?temporary-chat=true";
@@ -106,8 +108,8 @@ export async function detectChatGptAccountCapabilities(
       continue;
     }
     presenceObservations = 0;
-    const composerReady = await composers.count().then(count => count === 1).catch(() => false);
-    const formReady = await composerForm.count().then(count => count === 1).catch(() => false);
+    const composerReady = await composers.count().then((count: number) => count === 1).catch(() => false);
+    const formReady = await composerForm.count().then((count: number) => count === 1).catch(() => false);
     const documentReady = await page.evaluate(() => document.readyState === "complete").catch(() => false);
     if (composerReady && formReady && documentReady) {
       absenceSince ??= Date.now();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -71,6 +71,8 @@ Setup options:
   --storage-state-file PATH    Import a Playwright storageState JSON instead of interactive login
   --no-device                  Pure headless login: never opens windows/Xvfb; bot challenge
                                fails hard. OTP arrives by e-mail (codex-style, no device).
+  --session-token-file PATH   File with __Secure-next-auth.session-token value (or full
+                               document.cookie / storageState JSON); or paste at prompt
   --email EMAIL                Credential login: drives auth.openai.com headlessly; omit both
                                --email/--password-file on a TTY for fully interactive prompts
   --password-file PATH         File containing the ChatGPT password (0600); or env CODEX_CHATGPT_WEB_PASSWORD
@@ -158,12 +160,23 @@ async function loginCommand(args: string[]): Promise<void> {
   let email = takeOption(args, "--email");
   const passwordFile = takeOption(args, "--password-file");
   const noDevice = takeFlag(args, "--no-device");
+  const sessionTokenFile = takeOption(args, "--session-token-file");
   assertNoArgs(args);
   if (loginHeadless !== undefined && loginHeadless !== "auto" && loginHeadless !== "force" && loginHeadless !== "off") {
     throw new Error("--login-headless must be auto, force, or off");
   }
   // --no-device: pure headless, never spawn windows/Xvfb; bot challenge = hard error.
   const effectiveLoginHeadless = noDevice || loginHeadless === "force" ? "force" as const : loginHeadless;
+  let sessionCookie: string | undefined;
+  if (sessionTokenFile) {
+    sessionCookie = readFileSync(sessionTokenFile, "utf8").trim();
+    if (!sessionCookie) throw new Error(`--session-token-file is empty: ${sessionTokenFile}`);
+  } else if (process.env.CODEX_CHATGPT_WEB_SESSION_COOKIE) {
+    sessionCookie = process.env.CODEX_CHATGPT_WEB_SESSION_COOKIE;
+  } else if (!passwordFile && !email && !storageStateFile && stdin.isTTY && stdout.isTTY) {
+    stdout.write("Paste __Secure-next-auth.session-token from a logged-in chatgpt.com (DevTools > Application > Cookies), or full document.cookie / storageState JSON.\n");
+    sessionCookie = await secretPrompt("Session cookie: ");
+  }
   let password: string | undefined;
   if (passwordFile) {
     password = readFileSync(passwordFile, "utf8").replace(/\r?\n$/, "");
@@ -181,11 +194,15 @@ async function loginCommand(args: string[]): Promise<void> {
   if ((email === undefined) !== (password === undefined)) {
     throw new Error("--email requires --password-file (or CODEX_CHATGPT_WEB_PASSWORD); they are used together");
   }
+  if (sessionCookie && (email || password)) {
+    throw new Error("Session-cookie login is exclusive of credential login");
+  }
   const config = loadConfig();
   if (config.browserHost === "launcher") {
     throw new Error("ChatGPT login is owned by the launcher; open Codex Web GPT and use its Sign in step");
   }
   const result = await loginToChatGpt(config, {
+    ...(sessionCookie ? { sessionCookie } : {}),
     ...(effectiveLoginHeadless !== undefined ? { loginHeadless: effectiveLoginHeadless } : {}),
     ...(storageStateFile ? { storageStateFile } : {}),
     ...(email && password ? { email, password } : {}),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -66,6 +66,10 @@ Setup options:
   --subagent-protocol MODE     compatibility-v1 (default) or native (advanced)
   --restart-service            Explicitly restart this project's daemon after an update
   --login                      Refresh the stored ChatGPT login even if one exists
+  --login-headless MODE        auto (default) | force | off for the login command; auto falls back to ephemeral Xvfb
+  --storage-state-file PATH    Import a Playwright storageState JSON instead of interactive login
+  --browser-host MODE          managed-chrome (headless default) | launcher for setup
+  --headless                   Setup turns run headless (managed-chrome, no display)
   --auto-approve-tool-calls    Opt in to per-call browser clicks on "Allow once" prompts
   --bigger-context             Enable experimental adaptive 1/2/3-message context
   --standard-context           Disable experimental multi-message context
@@ -143,12 +147,20 @@ function authorizeLauncherControl(operation: string): void {
 }
 
 async function loginCommand(args: string[]): Promise<void> {
+  const loginHeadless = takeOption(args, "--login-headless");
+  const storageStateFile = takeOption(args, "--storage-state-file");
   assertNoArgs(args);
+  if (loginHeadless !== undefined && loginHeadless !== "auto" && loginHeadless !== "force" && loginHeadless !== "off") {
+    throw new Error("--login-headless must be auto, force, or off");
+  }
   const config = loadConfig();
   if (config.browserHost === "launcher") {
     throw new Error("ChatGPT login is owned by the launcher; open Codex Web GPT and use its Sign in step");
   }
-  const result = await loginToChatGpt(config);
+  const result = await loginToChatGpt(config, {
+    ...(loginHeadless !== undefined ? { loginHeadless: loginHeadless as "auto" | "force" | "off" } : {}),
+    ...(storageStateFile ? { storageStateFile } : {}),
+  });
   stdout.write(`ChatGPT login stored at ${result.storageStatePath}\n`);
 }
 
@@ -174,6 +186,19 @@ async function setupCommand(args: string[]): Promise<void> {
   const runtimeKeyFile = takeOption(args, "--runtime-key-file");
   const chrome = takeOption(args, "--chrome");
   const browserHostDescriptorPath = takeOption(args, "--browser-host-descriptor");
+  const browserHost = takeOption(args, "--browser-host");
+  if (browserHost !== undefined && browserHost !== "managed-chrome" && browserHost !== "launcher") {
+    throw new Error("--browser-host must be managed-chrome or launcher");
+  }
+  if (browserHost) options.browserHost = browserHost;
+  if (takeFlag(args, "--headless")) options.headed = false;
+  const loginHeadless = takeOption(args, "--login-headless");
+  if (loginHeadless !== undefined) {
+    if (loginHeadless !== "auto" && loginHeadless !== "force" && loginHeadless !== "off") {
+      throw new Error("--login-headless must be auto, force, or off");
+    }
+    options.loginHeadless = loginHeadless as "auto" | "force" | "off";
+  }
   if (chrome) options.chromeExecutablePath = chrome;
   if (browserHostDescriptorPath) options.browserHostDescriptorPath = browserHostDescriptorPath;
   options.refreshAccountCapabilities = takeFlag(args, "--refresh-account-capabilities");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -69,7 +69,8 @@ Setup options:
   --login                      Refresh the stored ChatGPT login even if one exists
   --login-headless MODE        auto (default) | force | off for the login command; auto falls back to ephemeral Xvfb
   --storage-state-file PATH    Import a Playwright storageState JSON instead of interactive login
-  --email EMAIL                Credential login: drives auth.openai.com headlessly
+  --email EMAIL                Credential login: drives auth.openai.com headlessly; omit both
+                               --email/--password-file on a TTY for fully interactive prompts
   --password-file PATH         File containing the ChatGPT password (0600); or env CODEX_CHATGPT_WEB_PASSWORD
   --browser-host MODE          managed-chrome (headless default) | launcher for setup
   --headless                   Setup turns run headless (managed-chrome, no display)
@@ -152,7 +153,7 @@ function authorizeLauncherControl(operation: string): void {
 async function loginCommand(args: string[]): Promise<void> {
   const loginHeadless = takeOption(args, "--login-headless");
   const storageStateFile = takeOption(args, "--storage-state-file");
-  const email = takeOption(args, "--email");
+  let email = takeOption(args, "--email");
   const passwordFile = takeOption(args, "--password-file");
   assertNoArgs(args);
   if (loginHeadless !== undefined && loginHeadless !== "auto" && loginHeadless !== "force" && loginHeadless !== "off") {
@@ -165,6 +166,12 @@ async function loginCommand(args: string[]): Promise<void> {
   } else if (email) {
     password = process.env.CODEX_CHATGPT_WEB_PASSWORD;
     if (!password) throw new Error("Credential login needs --password-file or CODEX_CHATGPT_WEB_PASSWORD");
+  } else if (!storageStateFile && stdin.isTTY && stdout.isTTY) {
+    // Interactive CLI login (codex-style): hidden password prompt, e-mail OTP prompt mid-flow.
+    email = await prompt("ChatGPT e-mail: ");
+    if (!email) throw new Error("An e-mail is required for interactive login");
+    password = await secretPrompt("ChatGPT password (hidden): ");
+    if (!password) throw new Error("A password is required for interactive login");
   }
   if ((email === undefined) !== (password === undefined)) {
     throw new Error("--email requires --password-file (or CODEX_CHATGPT_WEB_PASSWORD); they are used together");
@@ -177,6 +184,9 @@ async function loginCommand(args: string[]): Promise<void> {
     ...(loginHeadless !== undefined ? { loginHeadless: loginHeadless as "auto" | "force" | "off" } : {}),
     ...(storageStateFile ? { storageStateFile } : {}),
     ...(email && password ? { email, password } : {}),
+    mfaCodePrompt: email && password && stdin.isTTY && stdout.isTTY
+      ? () => prompt("ChatGPT e-mail verification code (check your inbox): ")
+      : undefined,
   });
   stdout.write(`ChatGPT login stored at ${result.storageStatePath}\n`);
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@ import { timingSafeEqual } from "node:crypto";
 import { existsSync, rmSync } from "node:fs";
 import { readFileSync } from "node:fs";
 import { stdin, stdout } from "node:process";
-import { checkBrowserEngine, loginToChatGpt } from "./browser-login";
+import { checkBrowserEngine, loginToChatGpt, parseProxyUrl } from "./browser-login";
 import { CHATGPT_CONNECTOR_NAME, getConfigDir, getConfigPath, loadConfig, loadConfigForSetup } from "./config";
 import { inspectLauncherBrowserHost, readLauncherBrowserHostDescriptor } from "./launcher-browser-host";
 import {
@@ -73,6 +73,8 @@ Setup options:
                                fails hard. OTP arrives by e-mail (codex-style, no device).
   --session-token-file PATH   File with __Secure-next-auth.session-token value (or full
                                document.cookie / storageState JSON); or paste at prompt
+  --proxy URL                  Egress proxy for login browser (residential recommended on
+                               datacenter IPs): http://user:pass@host:port or socks5://...
   --email EMAIL                Credential login: drives auth.openai.com headlessly; omit both
                                --email/--password-file on a TTY for fully interactive prompts
   --password-file PATH         File containing the ChatGPT password (0600); or env CODEX_CHATGPT_WEB_PASSWORD
@@ -161,6 +163,7 @@ async function loginCommand(args: string[]): Promise<void> {
   const passwordFile = takeOption(args, "--password-file");
   const noDevice = takeFlag(args, "--no-device");
   const sessionTokenFile = takeOption(args, "--session-token-file");
+  const proxyRaw = takeOption(args, "--proxy");
   assertNoArgs(args);
   if (loginHeadless !== undefined && loginHeadless !== "auto" && loginHeadless !== "force" && loginHeadless !== "off") {
     throw new Error("--login-headless must be auto, force, or off");
@@ -202,6 +205,7 @@ async function loginCommand(args: string[]): Promise<void> {
     throw new Error("ChatGPT login is owned by the launcher; open Codex Web GPT and use its Sign in step");
   }
   const result = await loginToChatGpt(config, {
+    ...(proxyRaw ? { proxy: parseProxyUrl(proxyRaw) } : {}),
     ...(sessionCookie ? { sessionCookie } : {}),
     ...(effectiveLoginHeadless !== undefined ? { loginHeadless: effectiveLoginHeadless } : {}),
     ...(storageStateFile ? { storageStateFile } : {}),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@ import { createInterface } from "node:readline/promises";
 import { Writable } from "node:stream";
 import { timingSafeEqual } from "node:crypto";
 import { existsSync, rmSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { stdin, stdout } from "node:process";
 import { checkBrowserEngine, loginToChatGpt } from "./browser-login";
 import { CHATGPT_CONNECTOR_NAME, getConfigDir, getConfigPath, loadConfig, loadConfigForSetup } from "./config";
@@ -68,6 +69,8 @@ Setup options:
   --login                      Refresh the stored ChatGPT login even if one exists
   --login-headless MODE        auto (default) | force | off for the login command; auto falls back to ephemeral Xvfb
   --storage-state-file PATH    Import a Playwright storageState JSON instead of interactive login
+  --email EMAIL                Credential login: drives auth.openai.com headlessly
+  --password-file PATH         File containing the ChatGPT password (0600); or env CODEX_CHATGPT_WEB_PASSWORD
   --browser-host MODE          managed-chrome (headless default) | launcher for setup
   --headless                   Setup turns run headless (managed-chrome, no display)
   --auto-approve-tool-calls    Opt in to per-call browser clicks on "Allow once" prompts
@@ -149,9 +152,22 @@ function authorizeLauncherControl(operation: string): void {
 async function loginCommand(args: string[]): Promise<void> {
   const loginHeadless = takeOption(args, "--login-headless");
   const storageStateFile = takeOption(args, "--storage-state-file");
+  const email = takeOption(args, "--email");
+  const passwordFile = takeOption(args, "--password-file");
   assertNoArgs(args);
   if (loginHeadless !== undefined && loginHeadless !== "auto" && loginHeadless !== "force" && loginHeadless !== "off") {
     throw new Error("--login-headless must be auto, force, or off");
+  }
+  let password: string | undefined;
+  if (passwordFile) {
+    password = readFileSync(passwordFile, "utf8").replace(/\r?\n$/, "");
+    if (!password) throw new Error(`--password-file is empty: ${passwordFile}`);
+  } else if (email) {
+    password = process.env.CODEX_CHATGPT_WEB_PASSWORD;
+    if (!password) throw new Error("Credential login needs --password-file or CODEX_CHATGPT_WEB_PASSWORD");
+  }
+  if ((email === undefined) !== (password === undefined)) {
+    throw new Error("--email requires --password-file (or CODEX_CHATGPT_WEB_PASSWORD); they are used together");
   }
   const config = loadConfig();
   if (config.browserHost === "launcher") {
@@ -160,6 +176,7 @@ async function loginCommand(args: string[]): Promise<void> {
   const result = await loginToChatGpt(config, {
     ...(loginHeadless !== undefined ? { loginHeadless: loginHeadless as "auto" | "force" | "off" } : {}),
     ...(storageStateFile ? { storageStateFile } : {}),
+    ...(email && password ? { email, password } : {}),
   });
   stdout.write(`ChatGPT login stored at ${result.storageStatePath}\n`);
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -69,6 +69,8 @@ Setup options:
   --login                      Refresh the stored ChatGPT login even if one exists
   --login-headless MODE        auto (default) | force | off for the login command; auto falls back to ephemeral Xvfb
   --storage-state-file PATH    Import a Playwright storageState JSON instead of interactive login
+  --no-device                  Pure headless login: never opens windows/Xvfb; bot challenge
+                               fails hard. OTP arrives by e-mail (codex-style, no device).
   --email EMAIL                Credential login: drives auth.openai.com headlessly; omit both
                                --email/--password-file on a TTY for fully interactive prompts
   --password-file PATH         File containing the ChatGPT password (0600); or env CODEX_CHATGPT_WEB_PASSWORD
@@ -155,10 +157,13 @@ async function loginCommand(args: string[]): Promise<void> {
   const storageStateFile = takeOption(args, "--storage-state-file");
   let email = takeOption(args, "--email");
   const passwordFile = takeOption(args, "--password-file");
+  const noDevice = takeFlag(args, "--no-device");
   assertNoArgs(args);
   if (loginHeadless !== undefined && loginHeadless !== "auto" && loginHeadless !== "force" && loginHeadless !== "off") {
     throw new Error("--login-headless must be auto, force, or off");
   }
+  // --no-device: pure headless, never spawn windows/Xvfb; bot challenge = hard error.
+  const effectiveLoginHeadless = noDevice || loginHeadless === "force" ? "force" as const : loginHeadless;
   let password: string | undefined;
   if (passwordFile) {
     password = readFileSync(passwordFile, "utf8").replace(/\r?\n$/, "");
@@ -181,7 +186,7 @@ async function loginCommand(args: string[]): Promise<void> {
     throw new Error("ChatGPT login is owned by the launcher; open Codex Web GPT and use its Sign in step");
   }
   const result = await loginToChatGpt(config, {
-    ...(loginHeadless !== undefined ? { loginHeadless: loginHeadless as "auto" | "force" | "off" } : {}),
+    ...(effectiveLoginHeadless !== undefined ? { loginHeadless: effectiveLoginHeadless } : {}),
     ...(storageStateFile ? { storageStateFile } : {}),
     ...(email && password ? { email, password } : {}),
     mfaCodePrompt: email && password && stdin.isTTY && stdout.isTTY

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -3,6 +3,8 @@ import type { AppConfig } from "./config";
 import { getConfigDir, getConfigPath, loadConfig } from "./config";
 import { join } from "node:path";
 import { inspectCodexIntegration } from "./codex-integration";
+import { runCommand } from "./process";
+import { userInfo } from "node:os";
 import { browserLoginStateExists, loginVerificationMarkerPath } from "./browser-login";
 import { getServiceStatus } from "./service";
 import { tunnelStatus } from "./tunnel";
@@ -136,6 +138,25 @@ export async function runDoctor(): Promise<DoctorReport> {
     } else {
       checks.push({ id: "login", status: "ok", message: "ChatGPT login state has authenticated browser evidence" });
     }
+    if (process.platform === "linux") {
+      const xvfb = runCommand("which", ["Xvfb"]);
+      checks.push(xvfb.status === 0
+        ? { id: "xvfb", status: "ok", message: "Xvfb is available for headless login fallback" }
+        : { id: "xvfb", status: "warning", message: "Xvfb is not installed; login fallback unavailable (apt install xvfb)" });
+      let lingerStatus: CheckStatus = "warning";
+      let lingerMessage = "Could not verify linger; the daemon stops when your last session ends";
+      const linger = runCommand("loginctl", ["show-user", userInfo().username, "-p", "Linger"]);
+      if (linger.status === 0) {
+        lingerMessage = linger.stdout.trim();
+        lingerStatus = linger.stdout.trim() === "Linger=yes" ? "ok" : "warning";
+      }
+      checks.push({ id: "linger", status: lingerStatus, message: lingerMessage });
+      checks.push({
+        id: "browser-host",
+        status: "ok",
+        message: `Browser host mode: ${config.browserHost}${config.browserHost === "managed-chrome" ? (config.headed ? " (headed)" : " (headless)") : ""}`,
+      });
+    }
   }
 
   const codex = inspectCodexIntegration();
@@ -160,9 +181,9 @@ export async function runDoctor(): Promise<DoctorReport> {
   } else if (!service.supported) {
     checks.push({ id: "service", status: "warning", message: "Managed service is unavailable on this OS; keep `serve` running manually" });
   } else if (!service.installed || !service.loaded) {
-    checks.push({ id: "service", status: "error", message: "macOS background service is not installed and loaded" });
+    checks.push({ id: "service", status: "error", message: "Background service is not installed and loaded" });
   } else {
-    checks.push({ id: "service", status: "ok", message: "macOS background service is loaded" });
+    checks.push({ id: "service", status: "ok", message: "Background service is loaded" });
   }
   checks.push(await proxyCheck(config));
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -94,13 +94,70 @@ ${args.map(arg => `    <string>${xml(arg)}</string>`).join("\n")}
 function assertMacOs(): void {
   if (process.platform !== "darwin") {
     throw new Error(
-      "Terminal-managed background services require macOS. "
-      + "Use the Codex Web GPT launcher on Windows or Linux.",
+      "launchd-managed background services require macOS. "
+      + "On Linux this command is managed with systemd user units.",
     );
   }
 }
 
+function systemdUnitPath(): string {
+  return join(homedir(), ".config", "systemd", "user", `${LABEL}.service`);
+}
+
+function systemdExecArg(arg: string): string {
+  return /\s/.test(arg)
+    ? `"${arg.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`
+    : arg;
+}
+
+export function systemdUnit(config: AppConfig): string {
+  const args = [...config.runtimeCommand, "serve"].map(systemdExecArg);
+  return `# Managed by codex-chatgpt-web; \`codex-chatgpt-web service uninstall\` removes this unit.
+[Unit]
+Description=Codex Web GPT Responses bridge (headless daemon)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=${args.join(" ")}
+Environment=CODEX_CHATGPT_WEB_HOME=${getConfigDir()}
+Environment=CODEX_CHATGPT_WEB_HEADLESS=1
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+`;
+}
+
+function systemctl(...args: string[]): ReturnType<typeof runCommand> {
+  return runCommand("systemctl", ["--user", ...args]);
+}
+
+function enableLingerBestEffort(): void {
+  const result = runCommand("loginctl", ["enable-linger", String(userInfo().username)]);
+  if (result.status !== 0) {
+    process.stdout.write(
+      "Warning: could not enable linger (`loginctl enable-linger`); the service will stop when your last session ends.\n",
+    );
+  }
+}
+
+function isLinux(): boolean {
+  return process.platform === "linux";
+}
+
 export function getServiceStatus(): ServiceStatus {
+  if (isLinux()) {
+    const path = systemdUnitPath();
+    return {
+      supported: true,
+      installed: existsSync(path),
+      loaded: systemctl("is-active", "--quiet", LABEL).status === 0,
+      label: LABEL,
+      definitionPath: path,
+    };
+  }
   if (process.platform !== "darwin") return { supported: false, installed: false, loaded: false, label: LABEL };
   const path = plistPath();
   const result = runCommand("launchctl", ["print", serviceTarget()]);
@@ -114,6 +171,17 @@ export function getServiceStatus(): ServiceStatus {
 }
 
 export function installService(config: AppConfig): ServiceStatus {
+  if (isLinux()) {
+    assertDurableRuntimeCommand(config.runtimeCommand);
+    const path = systemdUnitPath();
+    mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+    const next = systemdUnit(config);
+    if (!existsSync(path) || readFileSync(path, "utf8") !== next) atomicWriteFile(path, next);
+    systemctl("daemon-reload");
+    runChecked("systemctl", ["--user", "enable", "--now", LABEL]);
+    enableLingerBestEffort();
+    return getServiceStatus();
+  }
   assertMacOs();
   assertDurableRuntimeCommand(config.runtimeCommand);
   const path = plistPath();
@@ -127,6 +195,11 @@ export function installService(config: AppConfig): ServiceStatus {
 }
 
 export function startService(): ServiceStatus {
+  if (isLinux()) {
+    if (!existsSync(systemdUnitPath())) throw new Error(`Service is not installed: ${systemdUnitPath()}`);
+    runChecked("systemctl", ["--user", "start", LABEL]);
+    return getServiceStatus();
+  }
   assertMacOs();
   const path = plistPath();
   if (!existsSync(path)) throw new Error(`Service is not installed: ${path}`);
@@ -231,6 +304,16 @@ export async function assertServiceIdle(config: AppConfig): Promise<void> {
 }
 
 export async function restartService(config: AppConfig): Promise<ServiceStatus> {
+  if (isLinux()) {
+    if (!getServiceStatus().loaded) return startService();
+    const lease = await acquireDrain(config);
+    try {
+      runChecked("systemctl", ["--user", "restart", LABEL]);
+    } catch (error) {
+      return releaseDrainAfterFailure(lease, error);
+    }
+    return getServiceStatus();
+  }
   assertMacOs();
   if (!getServiceStatus().loaded) return startService();
   const lease = await acquireDrain(config);
@@ -255,6 +338,17 @@ export function removeLegacyRuntimeArtifacts(config: AppConfig): void {
 }
 
 export async function stopService(config: AppConfig): Promise<ServiceStatus> {
+  if (isLinux()) {
+    if (getServiceStatus().loaded) {
+      const lease = await acquireDrain(config);
+      try {
+        runChecked("systemctl", ["--user", "stop", LABEL]);
+      } catch (error) {
+        return releaseDrainAfterFailure(lease, error);
+      }
+    }
+    return getServiceStatus();
+  }
   assertMacOs();
   if (getServiceStatus().loaded) {
     const lease = await acquireDrain(config);
@@ -269,6 +363,19 @@ export async function stopService(config: AppConfig): Promise<ServiceStatus> {
 }
 
 export async function uninstallService(config: AppConfig): Promise<ServiceStatus> {
+  if (isLinux()) {
+    if (getServiceStatus().loaded) {
+      const lease = await acquireDrain(config);
+      try {
+        runChecked("systemctl", ["--user", "disable", "--now", LABEL]);
+      } catch (error) {
+        return releaseDrainAfterFailure(lease, error);
+      }
+    }
+    rmSync(systemdUnitPath(), { force: true });
+    systemctl("daemon-reload");
+    return getServiceStatus();
+  }
   assertMacOs();
   if (getServiceStatus().loaded) {
     const lease = await acquireDrain(config);

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -48,6 +48,9 @@ export interface SetupOptions {
   port?: number;
   chromeExecutablePath?: string;
   browserHostDescriptorPath?: string;
+  browserHost?: "managed-chrome" | "launcher";
+  headed?: boolean;
+  loginHeadless?: "auto" | "force" | "off";
   refreshAccountCapabilities?: boolean;
   appName?: string;
   forceLogin?: boolean;
@@ -221,10 +224,14 @@ function baseConfig(existing: AppConfig | undefined, options: SetupOptions): App
     config.browserHost = "launcher";
     config.browserHostDescriptorPath = options.browserHostDescriptorPath;
     config.brokerSocketPath = defaultBrokerEndpoint();
+  } else if (options.browserHost) {
+    config.browserHost = options.browserHost;
+    if (options.browserHost === "managed-chrome") delete config.browserHostDescriptorPath;
   } else if (options.chromeExecutablePath) {
     config.browserHost = "managed-chrome";
     delete config.browserHostDescriptorPath;
   }
+  if (options.headed !== undefined) config.headed = options.headed;
   config.appName = resolveSetupConnectorName(existing?.appName, options.appName);
   if (options.autoApproveToolCalls !== undefined) config.autoApproveToolCalls = options.autoApproveToolCalls;
   if (options.experimentalBiggerContext !== undefined) {
@@ -375,7 +382,7 @@ export async function setup(options: SetupOptions): Promise<SetupResult> {
     }
     if (beforeService.loaded && (loginRequired || capabilityProbeRequired) && existing) await assertServiceIdle(existing);
     if (loginRequired) {
-      const login = await loginToChatGpt(config);
+      const login = await loginToChatGpt(config, { ...(options.loginHeadless ? { loginHeadless: options.loginHeadless } : {}) });
       solAvailable = login.solAvailable;
       proAvailable = login.proAvailable;
       loginCreated = true;

--- a/src/tunnel-service.ts
+++ b/src/tunnel-service.ts
@@ -44,8 +44,39 @@ function settings(config: AppConfig) {
 
 function assertMacOs(): void {
   if (process.platform !== "darwin") {
-    throw new Error("Managed tunnel service installation is currently supported on macOS only");
+    throw new Error("launchd-managed tunnel service requires macOS; on Linux use systemd user units");
   }
+}
+
+function isLinux(): boolean {
+  return process.platform === "linux";
+}
+
+function systemdUnitPath(): string {
+  return join(homedir(), ".config", "systemd", "user", `${LABEL}.service`);
+}
+
+function systemdUnit(config: AppConfig): string {
+  const tunnel = settings(config);
+  const args = [tunnel.binaryPath, "run", "--profile-dir", tunnel.profileDir, "--profile", tunnel.profileName];
+  return `# Managed by codex-chatgpt-web; \`codex-chatgpt-web tunnel uninstall\` removes this unit.
+[Unit]
+Description=Codex Web GPT tunnel client
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=${args.join(" ")}
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+`;
+}
+
+function systemctl(...args: string[]): ReturnType<typeof runCommand> {
+  return runCommand("systemctl", ["--user", ...args]);
 }
 
 export function tunnelServiceDefinition(config: AppConfig): string {
@@ -85,6 +116,18 @@ ${args.map(arg => `    <string>${xml(arg)}</string>`).join("\n")}
 }
 
 export function getTunnelServiceStatus(): TunnelServiceStatus {
+  if (isLinux()) {
+    const path = systemdUnitPath();
+    const active = systemctl("is-active", "--quiet", LABEL).status === 0;
+    return {
+      supported: true,
+      installed: existsSync(path),
+      loaded: active,
+      running: active,
+      label: LABEL,
+      definitionPath: path,
+    };
+  }
   if (process.platform !== "darwin") {
     return { supported: false, installed: false, loaded: false, running: false, label: LABEL };
   }
@@ -106,6 +149,19 @@ export function tunnelServiceDefinitionMatches(config: AppConfig): boolean {
 }
 
 export function installTunnelService(config: AppConfig): TunnelServiceStatus {
+  if (isLinux()) {
+    const tunnel = settings(config);
+    const profile = join(tunnel.profileDir, `${tunnel.profileName}.yaml`);
+    if (!existsSync(tunnel.binaryPath)) throw new Error(`Tunnel client is missing: ${tunnel.binaryPath}`);
+    if (!existsSync(profile)) throw new Error(`Tunnel profile is missing: ${profile}`);
+    const path = systemdUnitPath();
+    mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+    const next = systemdUnit(config);
+    if (!existsSync(path) || readFileSync(path, "utf8") !== next) atomicWriteFile(path, next);
+    systemctl("daemon-reload");
+    runChecked("systemctl", ["--user", "enable", "--now", LABEL]);
+    return getTunnelServiceStatus();
+  }
   assertMacOs();
   const tunnel = settings(config);
   const profile = join(tunnel.profileDir, `${tunnel.profileName}.yaml`);
@@ -124,6 +180,11 @@ export function installTunnelService(config: AppConfig): TunnelServiceStatus {
 }
 
 export function startTunnelService(): TunnelServiceStatus {
+  if (isLinux()) {
+    if (!existsSync(systemdUnitPath())) throw new Error("Tunnel service is not installed; rerun full setup");
+    runChecked("systemctl", ["--user", "start", LABEL]);
+    return getTunnelServiceStatus();
+  }
   assertMacOs();
   if (!existsSync(plistPath())) throw new Error("Tunnel service is not installed; rerun full setup");
   if (!getTunnelServiceStatus().loaded) runChecked("launchctl", ["bootstrap", launchDomain(), plistPath()]);
@@ -139,6 +200,10 @@ async function waitForTunnelServiceUnloaded(timeoutMs = 20_000): Promise<void> {
 }
 
 export async function stopTunnelService(): Promise<TunnelServiceStatus> {
+  if (isLinux()) {
+    if (getTunnelServiceStatus().loaded) runChecked("systemctl", ["--user", "stop", LABEL]);
+    return getTunnelServiceStatus();
+  }
   assertMacOs();
   if (getTunnelServiceStatus().loaded) {
     runChecked("launchctl", ["bootout", serviceTarget()]);
@@ -153,6 +218,12 @@ export async function restartTunnelService(): Promise<TunnelServiceStatus> {
 }
 
 export async function uninstallTunnelService(): Promise<TunnelServiceStatus> {
+  if (isLinux()) {
+    await stopTunnelService();
+    rmSync(systemdUnitPath(), { force: true });
+    systemctl("daemon-reload");
+    return getTunnelServiceStatus();
+  }
   assertMacOs();
   await stopTunnelService();
   rmSync(plistPath(), { force: true });

--- a/tests/browser-login.test.ts
+++ b/tests/browser-login.test.ts
@@ -19,7 +19,7 @@ test("login starts with normal Chrome and captures state in a headed Keychain-aw
     const config = defaultConfig("browser-only");
     config.chromeExecutablePath = executable;
     config.storageStatePath = join(root, "browser", "storage-state.json");
-    await loginToChatGpt(config, { timeoutMs: 100 }).catch(() => {});
+    await loginToChatGpt(config, { timeoutMs: 100, loginHeadless: "off" }).catch(() => {});
 
     const launches = readFileSync(argsLog, "utf8").trim().split("\n");
     const firstLaunch = launches[0] ?? "";

--- a/tests/service-unit.test.ts
+++ b/tests/service-unit.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import type { AppConfig } from "../src/config";
+import { systemdUnit } from "../src/service";
+
+function fakeConfig(): AppConfig {
+  return {
+    version: 3,
+    releaseVersion: "test",
+    mode: "browser-only",
+    subagentProtocol: "compatibility-v1",
+    host: "127.0.0.1",
+    port: 17841,
+    contextWindow: 256000,
+    appName: "Codex Native2",
+    browserHost: "managed-chrome",
+    chromeExecutablePath: "/usr/bin/google-chrome",
+    storageStatePath: "/tmp/storage-state.json",
+    brokerSocketPath: "",
+    controlToken: "token",
+    runtimeCommand: ["/usr/bin/bun", "/opt/app/cli.js"],
+    headed: false,
+    solAvailable: false,
+    proAvailable: false,
+    autoApproveToolCalls: false,
+    experimentalBiggerContext: false,
+    acknowledgedUnofficialAt: new Date().toISOString(),
+  } as unknown as AppConfig;
+}
+
+describe("systemdUnit", () => {
+  test("renders headless user unit with durable runtime", () => {
+    const unit = systemdUnit(fakeConfig());
+    expect(unit).toContain("ExecStart=/usr/bin/bun /opt/app/cli.js serve");
+    expect(unit).toContain("CODEX_CHATGPT_WEB_HEADLESS=1");
+    expect(unit).toContain("Restart=always");
+    expect(unit).toContain("WantedBy=default.target");
+  });
+
+  test("quotes runtime args containing spaces", () => {
+    const config = fakeConfig();
+    config.runtimeCommand = ["/opt/my tools/bun", "/opt/app/cli.js"];
+    const unit = systemdUnit(config);
+    expect(unit).toContain('ExecStart="/opt/my tools/bun" /opt/app/cli.js serve');
+  });
+});

--- a/tests/session-cookie.test.ts
+++ b/tests/session-cookie.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { parseSessionCookieInput } from "../src/browser-login";
+
+describe("parseSessionCookieInput", () => {
+  test("raw session token -> chatgpt.com cookie", () => {
+    const state = parseSessionCookieInput("eyJhbGciOiJ.abc.def") as { cookies: Array<Record<string, unknown>>; origins: unknown[] };
+    expect(state.cookies).toHaveLength(1);
+    expect(state.cookies[0].name).toBe("__Secure-next-auth.session-token");
+    expect(state.cookies[0].domain).toBe(".chatgpt.com");
+    expect(state.cookies[0].httpOnly).toBe(true);
+    expect(state.origins).toEqual([]);
+  });
+
+  test("cookie header -> multiple cookies", () => {
+    const state = parseSessionCookieInput("cf_clearance=xyz; __Secure-next-auth.session-token=tok") as unknown as { cookies: Array<Record<string, string>> };
+    expect(state.cookies.map(c => c.name)).toEqual(["cf_clearance", "__Secure-next-auth.session-token"]);
+  });
+
+  test("storageState JSON passes through", () => {
+    const state = parseSessionCookieInput('{"cookies":[{"name":"a","value":"b"}],"origins":[]}') as { cookies: unknown[] };
+    expect(state.cookies).toHaveLength(1);
+  });
+
+  test("rejects empty input", () => {
+    expect(() => parseSessionCookieInput("")).toThrow();
+    expect(() => parseSessionCookieInput("{}")).toThrow();
+  });
+});


### PR DESCRIPTION
Three small perf/robustness fixes for the ChatGPT web adapter.

### 1. Fire-and-forget diagnostic captures

`ChatGptBrowserDiagnostics.capture()` runs `page.screenshot({timeout: 5000})` and writes PNG+JSON files to disk. The polling loop awaits every checkpoint, so a slow render can stall the whole turn for 5s waiting on a screenshot that is purely diagnostic.

Split into `capture()` (enqueue + return immediately) and `captureBody()` (the previous body). Writes still run serially through `captureQueue` so sequence numbers stay monotonic and `NN-*.png` / `NN-*.json` pairs never overlap.

### 2. Adaptive poll cadence

Three hardcoded `setTimeout(..., 250)` sleeps in the main loop become a single `pollSleep()` helper that reuses the existing `responseDomCache.snapshot` flag:
- 100ms when a snapshot exists (ChatGPT is streaming — minimize delta latency)
- 250ms otherwise (give the DOM time to settle, avoid CPU burn on empty scans)

### 3. Hard timeout for stalled turns

If the ChatGPT browser stalls past 5 minutes after submit, the polling loop now throws — the existing `try/finally` block then calls `notifyLauncherTurn({phase: end, status: failed})` and releases the broker channel. Without this, a stalled turn leaks a never-ending heartbeat and locks the broker token (this is the 'stuck in working' symptom).

### Bonus: Codex CLI 0.153.x env_context carrier

`environmentBeforeUser()` previously rejected any candidate whose `itemTurnId` didn't equal the active user's. Codex CLI 0.153.x sends the per-turn `<environment_context>` as a server-owned user message with no `internal_chat_message_metadata_passthrough` — so its identity is the server `id`, not the turn id of the active instruction.

Accept the carrier when either its turn id matches the active user or it's a server-owned item (`candidate.id` is a non-empty string). User-authored env_context inside an attacker-controlled user message wouldn't carry a server id, so the trust signal still holds.

---

Upstream already includes equivalent changes in v5.0.0+ — this branch targets the v4.0.x line for anyone running that release.