### PR TITLE
fix: stabilize Business web turns and compaction

### DIFF
--- a/launcher/electron/browser-host.cjs
+++ b/launcher/electron/browser-host.cjs
@@ -138,6 +138,30 @@ function allowedAuthUrl(value) {
   return AUTH_PROVIDER_HOSTS.has(parsed.hostname);
 }
 
+function isAuthenticatedChatGptSessionRefresh(value, authenticated) {
+  if (!authenticated) return false;
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return false;
+  }
+  return parsed.origin === CHATGPT_ORIGIN
+    && (parsed.pathname === "/auth" || parsed.pathname.startsWith("/auth/"));
+}
+
+function authenticationNavigationForLog(value) {
+  try {
+    const parsed = new URL(value);
+    return {
+      origin: parsed.origin,
+      ...(parsed.origin === CHATGPT_ORIGIN ? { pathname: parsed.pathname } : {}),
+    };
+  } catch {
+    return { origin: "invalid-url" };
+  }
+}
+
 function navigationOriginForLog(value) {
   try {
     const parsed = new URL(value);
@@ -761,9 +785,21 @@ class BrowserHost {
     });
     const blockAuthenticationNavigation = (event, url) => {
       if (!allowedAuthUrl(url)) return;
+      if (isAuthenticatedChatGptSessionRefresh(url, this.state.authenticated)) {
+        this.logger.info("browser.turn_session_refresh_allowed", {
+          tabId: tab.id,
+          traceId: tab.traceId,
+          ...authenticationNavigationForLog(url),
+        });
+        return;
+      }
       event.preventDefault();
       tab.message = "ChatGPT requires a fresh sign-in; finish this turn, then sign in from Setup";
-      this.logger.warn("browser.turn_authentication_blocked", { tabId: tab.id, traceId: tab.traceId });
+      this.logger.warn("browser.turn_authentication_blocked", {
+        tabId: tab.id,
+        traceId: tab.traceId,
+        ...authenticationNavigationForLog(url),
+      });
       this.publishState?.(this.snapshot());
     };
     contents.on("will-navigate", blockAuthenticationNavigation);
@@ -2788,7 +2824,12 @@ class BrowserHost {
       && (typeof inspected.solAvailable !== "boolean" || typeof inspected.proAvailable !== "boolean")) {
       throw new Error("Browser helper returned incomplete ChatGPT capability evidence");
     }
-    if (detectCapabilities && inspected.proAvailable && !inspected.solAvailable) {
+    if (detectCapabilities && typeof inspected.extraHighAvailable !== "boolean") {
+      inspected.extraHighAvailable = inspected.proAvailable === true;
+    }
+    if (detectCapabilities
+      && ((inspected.extraHighAvailable && !inspected.solAvailable)
+        || (inspected.proAvailable && !inspected.extraHighAvailable))) {
       throw new Error("Browser helper returned contradictory ChatGPT capability evidence");
     }
     if (startedIdle) await this.returnToIdle();
@@ -2887,6 +2928,7 @@ class BrowserHost {
 
 module.exports = {
   allowedAuthUrl,
+  isAuthenticatedChatGptSessionRefresh,
   BrowserHost,
   BrowserTurnCancelledError,
   CHATGPT_VIEWPORT_CSS,

--- a/launcher/electron/runtime-install.cjs
+++ b/launcher/electron/runtime-install.cjs
@@ -183,6 +183,14 @@ function validateRuntimeBundle(runtimeRoot, identity) {
   return inspectRuntimeBundle(runtimeRoot, identity).runtimeRoot;
 }
 
+function isWindowsRuntimeLock(error) {
+  return process.platform === "win32" && ["EBUSY", "EPERM", "EACCES"].includes(error?.code);
+}
+
+function sideBySideRuntimeDestination(destination, bundleId) {
+  return `${destination}.bundle-${bundleId.slice(0, 16)}`;
+}
+
 async function waitForPackagedRuntimeSource({
   app,
   resourcesPath,
@@ -230,12 +238,20 @@ function ensurePackagedRuntime({ app, coreHome, resourcesPath }) {
     versionsRoot,
     `${identity.version}-${identity.platform}-${identity.arch}`,
   );
+  const sideBySideDestination = sideBySideRuntimeDestination(destination, expectedIdentity.bundleId);
   if (fs.existsSync(destination)) {
     try {
       return validateRuntimeBundle(destination, expectedIdentity);
     } catch {
       // A terminated installer or external cleanup can leave a version directory present but
       // incomplete. Rebuild the launcher-owned bundle transactionally from the signed package.
+    }
+  }
+  if (fs.existsSync(sideBySideDestination)) {
+    try {
+      return validateRuntimeBundle(sideBySideDestination, expectedIdentity);
+    } catch {
+      // A prior interrupted side-by-side repair is replaced below.
     }
   }
 
@@ -252,8 +268,28 @@ function ensurePackagedRuntime({ app, coreHome, resourcesPath }) {
     });
     validateRuntimeBundle(temporary, expectedIdentity);
     if (fs.existsSync(destination)) {
-      renameAtomicFile(destination, previous);
-      previousMoved = true;
+      try {
+        renameAtomicFile(destination, previous);
+        previousMoved = true;
+      } catch (error) {
+        if (!isWindowsRuntimeLock(error)) throw error;
+
+        // Bun keeps its executable and imported JavaScript files open on Windows. A stale
+        // launcher-owned broker or worker can therefore make an in-place same-version repair
+        // impossible even though the signed replacement bundle is already valid. Install the
+        // new bundle beside the locked one; RuntimeSupervisor will recover the stale owner after
+        // startup and all new commands will use this content-addressed directory.
+        if (fs.existsSync(sideBySideDestination)) {
+          try {
+            return validateRuntimeBundle(sideBySideDestination, expectedIdentity);
+          } catch {
+            fs.rmSync(sideBySideDestination, { recursive: true, force: true });
+          }
+        }
+        renameAtomicFile(temporary, sideBySideDestination);
+        try { fs.chmodSync(sideBySideDestination, 0o700); } catch {}
+        return validateRuntimeBundle(sideBySideDestination, expectedIdentity);
+      }
     }
     try {
       renameAtomicFile(temporary, destination);

--- a/launcher/electron/runtime-supervisor.cjs
+++ b/launcher/electron/runtime-supervisor.cjs
@@ -251,6 +251,13 @@ function validateConfig(config, descriptorPath, platform = process.platform, lau
       throw new Error(`Runtime configuration has an invalid ${key}`);
     }
   }
+  if (config.extraHighAvailable === undefined) {
+    // Released configs before the capability split used proAvailable as the single extended-mode
+    // bit. Preserve that meaning until setup performs a fresh browser capability inspection.
+    config.extraHighAvailable = config.proAvailable === true;
+  } else if (typeof config.extraHighAvailable !== "boolean") {
+    throw new Error("Runtime configuration has an invalid extraHighAvailable");
+  }
   if (config.experimentalBiggerContext !== undefined
     && typeof config.experimentalBiggerContext !== "boolean") {
     throw new Error("Runtime configuration has an invalid experimentalBiggerContext");
@@ -261,6 +268,12 @@ function validateConfig(config, descriptorPath, platform = process.platform, lau
   }
   if (config.proAvailable && !config.solAvailable) {
     throw new Error("Runtime configuration cannot enable Pro without Sol");
+  }
+  if (config.extraHighAvailable && !config.solAvailable) {
+    throw new Error("Runtime configuration cannot enable Extra High without Sol");
+  }
+  if (config.proAvailable && !config.extraHighAvailable) {
+    throw new Error("Runtime configuration cannot enable Pro without Extra High");
   }
   if (!Array.isArray(config.runtimeCommand)
     || config.runtimeCommand.length === 0

--- a/launcher/tests/browser-host.test.cjs
+++ b/launcher/tests/browser-host.test.cjs
@@ -16,6 +16,7 @@ const {
   allowedAuthUrl,
   BrowserHost,
   IDLE_BROWSER_URL,
+  isAuthenticatedChatGptSessionRefresh,
   isChatGptCloudflareChallengeResponse,
   isTemporaryChatUrl,
   loadCommittedBrowserSurface,
@@ -24,6 +25,14 @@ const {
   navigationErrorForLog,
   navigationOriginForLog,
 } = require("../electron/browser-host.cjs");
+
+test("an authenticated turn may follow only ChatGPT's same-origin session refresh", () => {
+  assert.equal(isAuthenticatedChatGptSessionRefresh("https://chatgpt.com/auth/session", true), true);
+  assert.equal(isAuthenticatedChatGptSessionRefresh("https://chatgpt.com/auth/login", true), true);
+  assert.equal(isAuthenticatedChatGptSessionRefresh("https://chatgpt.com/auth/login", false), false);
+  assert.equal(isAuthenticatedChatGptSessionRefresh("https://auth.openai.com/authorize", true), false);
+  assert.equal(isAuthenticatedChatGptSessionRefresh("https://accounts.google.com/o/oauth2/v2/auth", true), false);
+});
 
 test("manual prompt handoff keeps ordinary turns at thirty seconds and compaction at two minutes", () => {
   assert.equal(MANUAL_SUBMIT_TIMEOUT_MS, 30_000);
@@ -393,6 +402,7 @@ test("session inspection delegates navigation and capability detection to the sh
     temporary: true,
     url: "https://chatgpt.com/?temporary-chat=true",
     solAvailable: true,
+    extraHighAvailable: true,
     proAvailable: true,
   });
   assert.equal(calls.length, 2);

--- a/launcher/tests/runtime-install.test.cjs
+++ b/launcher/tests/runtime-install.test.cjs
@@ -351,3 +351,38 @@ test("packaged runtime replaces stale files when a release is refreshed under th
     fs.rmSync(root, { recursive: true, force: true });
   }
 });
+
+test("packaged runtime repairs beside a Windows-locked same-version runtime", {
+  skip: process.platform !== "win32",
+}, () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-web-gpt-runtime-locked-refresh-"));
+  const resourcesPath = runtimeFixture(root, "0.2.0");
+  const coreHome = path.join(root, "core-home");
+  const app = { isPackaged: true, getVersion: () => "0.2.0" };
+  const originalRename = fs.renameSync;
+  try {
+    const installed = ensurePackagedRuntime({ app, coreHome, resourcesPath });
+    const source = path.join(resourcesPath, "runtime");
+    fs.writeFileSync(path.join(source, "app", "cli.js"), "new cli");
+    writeRuntimeManifest(source);
+
+    fs.renameSync = (from, to) => {
+      if (from === installed && to.includes(".previous-")) {
+        const error = new Error("runtime is in use");
+        error.code = "EPERM";
+        throw error;
+      }
+      return originalRename(from, to);
+    };
+
+    const repaired = ensurePackagedRuntime({ app, coreHome, resourcesPath });
+    assert.notEqual(repaired, installed);
+    assert.match(repaired, /\.bundle-[a-f0-9]{16}$/);
+    assert.equal(fs.readFileSync(path.join(installed, "app", "cli.js"), "utf8"), "cli");
+    assert.equal(fs.readFileSync(path.join(repaired, "app", "cli.js"), "utf8"), "new cli");
+    assert.equal(ensurePackagedRuntime({ app, coreHome, resourcesPath }), repaired);
+  } finally {
+    fs.renameSync = originalRename;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -942,6 +942,7 @@ export function assertChatGptWebMultipartInputWithinLimits(
 export function resolveChatGptWebMultipartStagingMode(
   modelId: string,
   capabilities: ChatGptWebCapabilities,
+  requestedEffort: ChatGptWebModelMode["effort"],
   maxStageMessageTokens: number,
   maxStageChars: number,
 ): ChatGptWebModelMode {
@@ -955,15 +956,19 @@ export function resolveChatGptWebMultipartStagingMode(
     throw new Error(`ChatGPT Bigger Context staging mode is not defined for model: ${modelId}`);
   }
   const efforts: readonly ChatGptWebModelMode["effort"][] = capabilities.proAvailable
-    ? ["low", "medium", "max"]
-    : ["low", "medium"];
+    ? ["medium", "max"]
+    : capabilities.extraHighAvailable
+      ? ["medium", "xhigh"]
+      : ["low", "medium"];
+  const requestedContextWindow = resolveChatGptWebContextLimits(
+    modelId,
+    requestedEffort,
+    capabilities,
+  ).contextWindow;
   for (const effort of efforts) {
     const mode = resolveChatGptWebModelMode(modelId, effort, capabilities);
-    const contextLimits = resolveChatGptWebContextLimits(
-      modelId,
-      effort,
-      { ...capabilities, experimentalBiggerContext: false },
-    );
+    const contextLimits = resolveChatGptWebContextLimits(modelId, effort, capabilities);
+    if (contextLimits.contextWindow < requestedContextWindow) continue;
     const limits = resolveChatGptWebTransportLimits(modelId, effort, capabilities);
     // Bigger Context multiplies the accumulated transaction ceiling, not the capacity of one
     // message. Plus does not expose a separate measured message-token boundary, so its ordinary
@@ -1228,10 +1233,13 @@ export function chatGptTurnIsComplete(state: {
   currentHtml?: string;
   completionActionVisible: boolean;
 }): boolean {
+  // The action row is useful positive evidence, but it is not a protocol boundary. ChatGPT has
+  // changed/virtualized that row independently of the assistant response DOM, including across
+  // multiple tabs at once. A stopped generator with a non-empty response becomes a completion
+  // candidate; ChatGptCompletionTracker then requires either the action row or a stable DOM window.
   return state.responsePresent
     && !state.running
-    && state.currentText.length > 0
-    && state.completionActionVisible;
+    && state.currentText.length > 0;
 }
 
 export type ChatGptSubmissionEvidence = "user_turn" | "assistant_turn" | "generation_running" | "mcp_tool_call";
@@ -1331,6 +1339,7 @@ export function chatGptReboundTurnIdentity(
 export class ChatGptCompletionTracker {
   private candidate?: { signature: string; since: number };
   private lastToolBatchRevision = 0;
+  private sawExternalToolCallsInFlight = false;
   private postToolAnswerBaselineText?: string;
   private missingPostToolAnswerSince?: number;
 
@@ -1368,6 +1377,7 @@ export class ChatGptCompletionTracker {
     // currently looks like. Completing here would return a truncated answer and retire the turn
     // while its own tool calls were still in flight.
     if (state.externalToolCallsInFlight) {
+      this.sawExternalToolCallsInFlight = true;
       this.candidate = undefined;
       this.missingPostToolAnswerSince = undefined;
       return false;
@@ -1389,6 +1399,15 @@ export class ChatGptCompletionTracker {
       this.candidate = undefined;
       return false;
     }
+    // A response-scoped completed-turn action is still the strongest UI signal and may commit
+    // immediately. When the action row is absent, fall back to a bounded text+HTML stability
+    // window. Outstanding Codex tool calls were rejected above, so this cannot truncate a tool loop.
+    if (state.completionActionVisible
+      && this.lastToolBatchRevision === 0
+      && !this.sawExternalToolCallsInFlight) {
+      this.candidate = undefined;
+      return true;
+    }
     if (this.candidate?.signature !== signature) {
       this.candidate = { signature, since: now };
       return false;
@@ -1401,12 +1420,13 @@ export class ChatGptTurnDomHealthTracker {
   private sawResponse = false;
   private missingResponseSince?: number;
   private emptyCompletionSince?: number;
-  private missingCompletionAction?: { text: string; since: number };
 
   constructor(
     private readonly missingResponseMs = CHATGPT_RESPONSE_DOM_GRACE_MS,
     private readonly emptyCompletionMs = CHATGPT_EMPTY_RESPONSE_GRACE_MS,
-    private readonly missingCompletionActionMs = CHATGPT_COMPLETION_ACTION_GRACE_MS,
+    // Retained as a third constructor parameter for compatibility with older tests/callers. A
+    // missing action row is no longer a DOM-health failure; completion uses stability instead.
+    _legacyMissingCompletionActionMs = CHATGPT_COMPLETION_ACTION_GRACE_MS,
   ) {}
 
   /**
@@ -1434,7 +1454,6 @@ export class ChatGptTurnDomHealthTracker {
       // no window may accrue while the model is provably working.
       this.missingResponseSince = undefined;
       this.emptyCompletionSince = undefined;
-      this.missingCompletionAction = undefined;
       return undefined;
     }
     if (state.responsePresent) {
@@ -1461,17 +1480,6 @@ export class ChatGptTurnDomHealthTracker {
       }
     }
 
-    const missingCompletionAction = state.responsePresent
-      && !state.running
-      && state.currentText.length > 0
-      && !state.completionActionVisible;
-    if (!missingCompletionAction) {
-      this.missingCompletionAction = undefined;
-    } else if (this.missingCompletionAction?.text !== state.currentText) {
-      this.missingCompletionAction = { text: state.currentText, since: now };
-    } else if (now - this.missingCompletionAction.since >= this.missingCompletionActionMs) {
-      return "ChatGPT stopped generating but did not expose its completed-turn action; the ChatGPT DOM may have changed";
-    }
     return undefined;
   }
 }
@@ -2105,6 +2113,7 @@ export class ChatGptBrowserWorker {
     temporary: true;
     url: string;
     solAvailable?: boolean;
+    extraHighAvailable?: boolean;
     proAvailable?: boolean;
   }> {
     return this.enqueueMaintenance("session inspection", () => this.inspectSessionExclusive(detectCapabilities));
@@ -3558,6 +3567,7 @@ export class ChatGptBrowserWorker {
     temporary: true;
     url: string;
     solAvailable?: boolean;
+    extraHighAvailable?: boolean;
     proAvailable?: boolean;
   }> {
     const page = await this.ensurePage();
@@ -4142,6 +4152,16 @@ export class ChatGptBrowserWorker {
     }
   }
 
+  private async refreshLauncherViewport(traceId: string): Promise<void> {
+    if (!this.config.browserHostDescriptorPath) return;
+    await notifyLauncherTurn(this.config.browserHostDescriptorPath, {
+      phase: "heartbeat",
+      traceId,
+      helperPid: process.pid,
+      refreshViewport: true,
+    });
+  }
+
   private async runBrowserTurn(
     turn: BrowserTurn,
     launcherSurfaceId?: string,
@@ -4202,6 +4222,7 @@ export class ChatGptBrowserWorker {
         ? resolveChatGptWebMultipartStagingMode(
           turn.modelId,
           browserCapabilities,
+          requestedMode.effort,
           maxStageMessageTokens!,
           maxStageChars!,
         )
@@ -4294,12 +4315,7 @@ export class ChatGptBrowserWorker {
                   : turn.abortSignal
                     ? AbortSignal.any([stageSignal, turn.abortSignal])
                     : stageSignal;
-                await notifyLauncherTurn(this.config.browserHostDescriptorPath!, {
-                  phase: "heartbeat",
-                  traceId: turn.traceId,
-                  helperPid: process.pid,
-                  refreshViewport: true,
-                });
+                await this.refreshLauncherViewport(turn.traceId);
                 const rebound = await connectLauncherBrowserHost(
                   this.config.browserHostDescriptorPath!,
                   browserStageTimeouts.browserPage,
@@ -4391,15 +4407,26 @@ export class ChatGptBrowserWorker {
         requestedMode.effort,
         stagingMode.effort,
       )) {
-        mode = await this.runStage(turn.traceId, "effort_selection", browserStageTimeouts.effortSelection, () => (
-          this.selectModelAndEffort(
+        mode = await this.runStage(turn.traceId, "effort_selection", browserStageTimeouts.effortSelection, async (stageSignal) => {
+          const signal = turn.abortSignal
+            ? AbortSignal.any([stageSignal, turn.abortSignal])
+            : stageSignal;
+          // Temporary Chat navigation can recreate the renderer after the initial launcher-page
+          // viewport check. Electron may then collapse the hidden WebContentsView back to 0x0 even
+          // though the page and model control remain present in the DOM. Reapply the launcher's
+          // background viewport contract immediately before the first coordinate-bearing UI action.
+          if (launcherSurfaceId && this.config.browserHostDescriptorPath) {
+            await this.refreshLauncherViewport(turn.traceId);
+          }
+          await waitForOperationalChatGptViewport(page, signal);
+          return this.selectModelAndEffort(
             page,
             turn.modelId,
             stagingMode.effort,
             browserCapabilities,
             checkpoint => diagnostics.capture(page, checkpoint),
-          )
-        ));
+          );
+        });
       }
       await diagnostics.capture(page, "effort-selection-complete");
 
@@ -4493,13 +4520,24 @@ export class ChatGptBrowserWorker {
             turn.traceId,
             "final_part_effort_selection",
             browserStageTimeouts.effortSelection,
-            () => this.selectModelAndEffort(
-              page,
-              turn.modelId,
-              requestedMode.effort,
-              browserCapabilities,
-              checkpoint => diagnostics.capture(page, `final-part-${checkpoint}`),
-            ),
+            async (stageSignal) => {
+              const signal = turn.abortSignal
+                ? AbortSignal.any([stageSignal, turn.abortSignal])
+                : stageSignal;
+              // Multipart acknowledgement can also leave a hidden launcher renderer with a stale
+              // 0x0 viewport. Refresh before restoring the user's final effort level as well.
+              if (launcherSurfaceId && this.config.browserHostDescriptorPath) {
+                await this.refreshLauncherViewport(turn.traceId);
+              }
+              await waitForOperationalChatGptViewport(page, signal);
+              return this.selectModelAndEffort(
+                page,
+                turn.modelId,
+                requestedMode.effort,
+                browserCapabilities,
+                checkpoint => diagnostics.capture(page, `final-part-${checkpoint}`),
+              );
+            },
           );
           await diagnostics.capture(page, "final-part-effort-selected");
         }
@@ -4795,6 +4833,14 @@ export class ChatGptBrowserWorker {
           });
           if (!completionReady) completionFenceRevision = undefined;
           if (completionReady) {
+            if (!snapshot.completionActionVisible) {
+              // The stability fallback is now itself final-completion evidence. Flush any mutable
+              // final commentary/status block exactly as the legacy action row used to do.
+              for (const trace of visibleTrace.observe(snapshot.traceBlocks, true)) {
+                if (trace.kind === "commentary") turn.onCommentary?.(trace.text, trace.continuation === true);
+                else turn.onReasoningSummary?.(trace.text, trace.continuation === true);
+              }
+            }
             if (turn.completionFence) {
               if (completionFenceRevision === undefined) {
                 const revision = await turn.completionFence.begin();

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -145,6 +145,7 @@ const CHATGPT_DOM_REVISION_ATTRIBUTES = [
   "data-streaming-response-status",
   "data-testid",
   "data-turn",
+  "data-turn-id",
   "disabled",
   "hidden",
   "inert",
@@ -1325,6 +1326,26 @@ export function chatGptNewTurnIdentity(
     throw new Error(`ChatGPT exposed ${added.length} new conversation turns for one submitted message`);
   }
   return added[0];
+}
+
+export function chatGptConversationTurnIdentity(
+  turnId: string | null | undefined,
+  testId: string | null | undefined,
+): string {
+  const stableTurnId = turnId?.trim();
+  if (stableTurnId) return stableTurnId;
+  const positionalTestId = testId?.trim();
+  if (positionalTestId?.startsWith("conversation-turn-")) return positionalTestId;
+  throw new Error("ChatGPT conversation turn has no stable data-turn-id or fallback data-testid identity");
+}
+
+function chatGptTurnLocator(page: Page, identity: string): Locator {
+  // `conversation-turn-N` is only a positional label and can be renumbered when ChatGPT
+  // virtualizes history or navigates temporary chat into /c/<id>. Prefer the immutable
+  // data-turn-id logical identity, while retaining data-testid as a compatibility fallback.
+  return page.locator(
+    `[data-turn-id=${JSON.stringify(identity)}], [data-testid=${JSON.stringify(identity)}]`,
+  );
 }
 
 export function chatGptReboundTurnIdentity(
@@ -2600,15 +2621,17 @@ export class ChatGptBrowserWorker {
       const observerKey = `${observerState.id}:${observerState.revision}`;
       if (options.knownKey === observerKey) return { key: observerKey };
       const identities = (selector: string): string[] => {
-        const values = [...document.querySelectorAll(selector)].map(element => element.getAttribute("data-testid"));
-        if (values.some(value => typeof value !== "string" || !value.startsWith("conversation-turn-"))) {
-          throw new Error("ChatGPT conversation turn has no stable data-testid identity");
-        }
-        const typed = values as string[];
-        if (new Set(typed).size !== typed.length) {
+        const values = [...document.querySelectorAll(selector)].map(element => {
+          const turnId = element.getAttribute("data-turn-id")?.trim();
+          if (turnId) return turnId;
+          const testId = element.getAttribute("data-testid")?.trim();
+          if (testId?.startsWith("conversation-turn-")) return testId;
+          throw new Error("ChatGPT conversation turn has no stable data-turn-id or fallback data-testid identity");
+        });
+        if (new Set(values).size !== values.length) {
           throw new Error("ChatGPT exposed duplicate conversation turn identities");
         }
-        return typed;
+        return values;
       };
       const visible = (element: Element): boolean => {
         const candidate = element as HTMLElement;
@@ -2677,7 +2700,7 @@ export class ChatGptBrowserWorker {
       state.responseIdentities,
     );
     if (!identity) return "";
-    const locator = page.locator(`[data-testid=${JSON.stringify(identity)}]`);
+    const locator = chatGptTurnLocator(page, identity);
     return (await this.responseDomSnapshot(locator, {})).visibleText;
   }
 
@@ -2783,7 +2806,7 @@ export class ChatGptBrowserWorker {
         && completionTracker?.needsToolBatchObservation(progress.lastToolBatchRevision)) {
         const boundaryText = identity
           ? (await this.responseDomSnapshot(
-            observationPage.locator(`[data-testid=${JSON.stringify(identity)}]`),
+            chatGptTurnLocator(observationPage, identity),
             {},
           )).visibleText
           : "";
@@ -2792,7 +2815,7 @@ export class ChatGptBrowserWorker {
       }
       if (identity) return {
         identity,
-        locator: observationPage.locator(`[data-testid=${JSON.stringify(identity)}]`),
+        locator: chatGptTurnLocator(observationPage, identity),
         acceptedUserTurnIdentities: state.userIdentities,
       };
       await this.waitForTurnDomOrExternalProgress(
@@ -2830,7 +2853,7 @@ export class ChatGptBrowserWorker {
     if (!identity || identity === binding.identity) return binding;
     return {
       identity,
-      locator: page.locator(`[data-testid=${JSON.stringify(identity)}]`),
+      locator: chatGptTurnLocator(page, identity),
       acceptedUserTurnIdentities: state.userIdentities,
     };
   }
@@ -4751,7 +4774,7 @@ export class ChatGptBrowserWorker {
             };
             responseTurn = {
               ...responseTurn,
-              locator: page.locator(`[data-testid=${JSON.stringify(responseTurn.identity)}]`),
+              locator: chatGptTurnLocator(page, responseTurn.identity),
             };
             responseDomCache.key = undefined;
             responseDomCache.snapshot = undefined;

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -1366,7 +1366,7 @@ export class ChatGptCompletionTracker {
 
   constructor(
     private readonly stableMs = CHATGPT_COMPLETION_SETTLE_MS,
-    private readonly missingPostToolAnswerMs = CHATGPT_COMPLETION_ACTION_GRACE_MS,
+    private readonly postToolCompletionGraceMs = CHATGPT_COMPLETION_ACTION_GRACE_MS,
   ) {}
 
   needsToolBatchObservation(revision: number): boolean {
@@ -1393,7 +1393,8 @@ export class ChatGptCompletionTracker {
     },
     now = Date.now(),
   ): boolean {
-    const signature = `${state.currentText}\0${state.currentHtml ?? state.currentText}`;
+    const signature = `${state.currentText}\0${state.currentHtml ?? state.currentText}`
+      + `\0${state.completionActionVisible ? "completion-action" : "no-completion-action"}`;
     // An outstanding tool call proves the model has more to say, whatever the rendered message
     // currently looks like. Completing here would return a truncated answer and retire the turn
     // while its own tool calls were still in flight.
@@ -1410,7 +1411,7 @@ export class ChatGptCompletionTracker {
         return false;
       }
       this.missingPostToolAnswerSince ??= now;
-      if (now - this.missingPostToolAnswerSince >= this.missingPostToolAnswerMs) {
+      if (now - this.missingPostToolAnswerSince >= this.postToolCompletionGraceMs) {
         throw new Error("ChatGPT completed without producing a final answer after its last Codex tool call");
       }
       return false;
@@ -1420,20 +1421,28 @@ export class ChatGptCompletionTracker {
       this.candidate = undefined;
       return false;
     }
-    // A response-scoped completed-turn action is still the strongest UI signal and may commit
-    // immediately. When the action row is absent, fall back to a bounded text+HTML stability
-    // window. Outstanding Codex tool calls were rejected above, so this cannot truncate a tool loop.
-    if (state.completionActionVisible
-      && this.lastToolBatchRevision === 0
-      && !this.sawExternalToolCallsInFlight) {
+    const sawToolActivity = this.lastToolBatchRevision > 0 || this.sawExternalToolCallsInFlight;
+    // A response-scoped completed-turn action is the strongest UI signal. A turn that never used
+    // Codex tools can commit immediately on it. After tool activity, keep the ordinary short settle
+    // window so a transient action-row render cannot race the final tool-result projection.
+    if (state.completionActionVisible && !sawToolActivity) {
       this.candidate = undefined;
       return true;
     }
+
     if (this.candidate?.signature !== signature) {
       this.candidate = { signature, since: now };
       return false;
     }
-    return now - this.candidate.since >= this.stableMs;
+    // Current ChatGPT builds sometimes virtualize the completed-turn action row, so retain a
+    // fallback instead of requiring Copy forever. For turns that never used Codex tools, the short
+    // DOM-stability window remains sufficient. After tool activity, however, the same short window
+    // with no action row is indistinguishable from an inter-tool idle gap; only release that weaker
+    // state after the much longer action grace. A visible action row returns to the short settle.
+    const settleMs = sawToolActivity && !state.completionActionVisible
+      ? this.postToolCompletionGraceMs
+      : this.stableMs;
+    return now - this.candidate.since >= settleMs;
   }
 }
 

--- a/src/adapters/chatgpt-web/index.ts
+++ b/src/adapters/chatgpt-web/index.ts
@@ -355,6 +355,8 @@ export function createChatGptWebAdapter(
   const configuredCapabilities: ChatGptWebCapabilities = {
     localToolsEnabled: provider.chatgptWeb?.localToolsEnabled === true,
     solAvailable: provider.chatgptWeb?.solAvailable !== false,
+    extraHighAvailable: provider.chatgptWeb?.proAvailable === true
+      || provider.chatgptWeb?.extraHighAvailable === true,
     proAvailable: provider.chatgptWeb?.proAvailable === true,
   };
   const manualInteraction = provider.chatgptWeb?.browserInteractionMode === "manual";
@@ -718,11 +720,6 @@ export function createChatGptWebAdapter(
         traceId,
       );
       activeToken = turnToken;
-      observeCapabilityRetirement(turnToken, externalProgress);
-      if (!tokenSettled) {
-        tokenSettled = true;
-        token.resolve(turnToken);
-      }
       try {
         const compiled = compileChatGptWebPrompt(
           input,
@@ -730,11 +727,25 @@ export function createChatGptWebAdapter(
           turnToken,
           compileOptionsFor(input),
         );
+        // The response observer must not receive a capability until the exact browser prompt has
+        // compiled successfully. Otherwise a preparation failure revokes the just-published token
+        // and the observer races into updateEnvironment(), masking the causal error as
+        // "turn token is invalid or expired".
+        observeCapabilityRetirement(turnToken, externalProgress);
+        if (!tokenSettled) {
+          tokenSettled = true;
+          token.resolve(turnToken);
+        }
         return { ...compiled, release: () => {} };
       } catch (error) {
         await broker.revoke(turnToken);
         activeToken = undefined;
-        throw error;
+        const normalized = error instanceof Error ? error : new Error(String(error));
+        if (!tokenSettled) {
+          tokenSettled = true;
+          token.reject(normalized);
+        }
+        throw normalized;
       }
     };
     const browserTurn = cancellableBrowserTurn(trackBrowserOwner(finalizeCheckpoint(worker.run({

--- a/src/adapters/chatgpt-web/index.ts
+++ b/src/adapters/chatgpt-web/index.ts
@@ -559,7 +559,7 @@ export function createChatGptWebAdapter(
           if (!parsed._compactionRequest) {
             trace.push({
               kind: "commentary",
-              text: "> **Action required in Zero Risk**\n>\n> Open the launcher, copy and paste the prompt into ChatGPT, add any images yourself because Zero Risk cannot transfer them, select the `Codex Zero Risk` plugin and the model you want, send the prompt, then confirm it was sent in the launcher.",
+              text: "> **Action required in Zero Risk**\n>\n> Open the launcher, copy and paste the prompt into ChatGPT, select the `Codex Zero Risk` plugin and the model you want, send the prompt, then confirm it was sent in the launcher. Images from the Codex context are intentionally omitted by this Web bridge.",
             });
           }
           await zeroRiskManualControl.start(retainedLauncherDescriptor, {

--- a/src/adapters/chatgpt-web/model.ts
+++ b/src/adapters/chatgpt-web/model.ts
@@ -9,6 +9,7 @@ export const CHATGPT_WEB_LUNA_MODEL_ID = CHATGPT_WEB_LUNA_BACKEND_MODEL;
 export interface ChatGptWebCapabilities {
   localToolsEnabled: boolean;
   solAvailable: boolean;
+  extraHighAvailable?: boolean;
   proAvailable: boolean;
 }
 
@@ -59,7 +60,9 @@ export function resolveChatGptWebModelMode(
     case "high":
       return { modelId, effort, displayLabel: "High", uiEffortIndex: 2, thinkEnabled: false, localTools: capabilities.localToolsEnabled };
     case "xhigh":
-      if (!capabilities.proAvailable) throw new Error("ChatGPT Extra High effort is not available for this account");
+      if (!(capabilities.proAvailable || capabilities.extraHighAvailable === true)) {
+        throw new Error("ChatGPT Extra High effort is not available for this account");
+      }
       return { modelId, effort, displayLabel: "Extra High", uiEffortIndex: 3, thinkEnabled: false, localTools: capabilities.localToolsEnabled };
     case "max":
       if (!capabilities.proAvailable) throw new Error("ChatGPT Pro effort is not available for this account");

--- a/src/adapters/chatgpt-web/prompt.ts
+++ b/src/adapters/chatgpt-web/prompt.ts
@@ -1,5 +1,12 @@
 import { createHash } from "node:crypto";
-import { isChatGptWebZeroRiskBackendModel } from "../../chatgpt-web-models";
+import {
+  isChatGptWebZeroRiskBackendModel,
+  resolveChatGptWebContextLimits,
+  resolveChatGptWebTransportLimits,
+  type ChatGptWebAdapterEffort,
+  type ChatGptWebBackendModel,
+} from "../../chatgpt-web-models";
+import { estimateTokens } from "../../lib/token-estimate";
 import type { CodexAssistantContentPart, CodexContentPart, CodexMessage, CodexParsedRequest } from "../../types";
 import { isOnePixelPngDataUrl, isReadableCompactionSummaryText } from "../../responses/compaction";
 import { CHATGPT_WEB_LUNA_MODEL_ID, resolveChatGptWebModelMode, type ChatGptWebCapabilities } from "./model";
@@ -52,6 +59,7 @@ export interface ChatGptWebMultipartStage {
 }
 
 const MULTIPART_TRANSACTION_ID = /^ctx_[a-f0-9]{32}$/;
+const COMPACTION_PREFLIGHT_TRANSACTION_ID = `ctx_${"0".repeat(32)}`;
 
 function assertMultipartTransactionId(transactionId: string): void {
   if (!MULTIPART_TRANSACTION_ID.test(transactionId)) {
@@ -390,6 +398,54 @@ function partitionMultipartContext(
   return [payloads[0]!, payloads[1]!, payloads[2]!];
 }
 
+function chatGptWebMessageFits(
+  text: string,
+  modelId: ChatGptWebBackendModel,
+  effort: ChatGptWebAdapterEffort,
+  capabilities: ChatGptWebCapabilities,
+): boolean {
+  const context = resolveChatGptWebContextLimits(modelId, effort, capabilities);
+  const transport = resolveChatGptWebTransportLimits(modelId, effort, capabilities);
+  const tokenLimit = transport.browserMessageTokenLimit ?? context.autoCompactTokenLimit;
+  return estimateTokens(text, modelId) <= tokenLimit
+    && (transport.browserComposerCharLimit === undefined
+      || text.length <= transport.browserComposerCharLimit);
+}
+
+/**
+ * A compaction turn must be transportable before its browser tab is opened. Browser preflight can
+ * choose any account-visible staging effort, while the final commit must fit the user's requested
+ * effort. Checking both here lets native-style oldest-first trimming repair a large checkpoint
+ * instead of publishing a turn token for a transaction that can only fail.
+ */
+function multipartCompactionFits(
+  compiled: CompiledChatGptWebPrompt,
+  modelId: ChatGptWebBackendModel,
+  requestedEffort: ChatGptWebAdapterEffort,
+  capabilities: ChatGptWebCapabilities,
+): boolean {
+  const multipart = compiled.multipart;
+  if (!multipart) return true;
+  const totalParts = multipart.parts.length as ChatGptWebMultipartPartCount;
+  const stagingEffort: ChatGptWebAdapterEffort = requestedEffort === "max" && capabilities.proAvailable
+    ? "max"
+    : "medium";
+  const stages = multipart.parts.slice(0, -1).map((payload, index) => (
+    formatChatGptWebMultipartStage(
+      payload,
+      COMPACTION_PREFLIGHT_TRANSACTION_ID,
+      index + 1,
+      totalParts,
+    ).text
+  ));
+  const finalCommit = formatChatGptWebMultipartCommit(
+    multipart,
+    COMPACTION_PREFLIGHT_TRANSACTION_ID,
+  );
+  return stages.every(stage => chatGptWebMessageFits(stage, modelId, stagingEffort, capabilities))
+    && chatGptWebMessageFits(finalCommit, modelId, requestedEffort, capabilities);
+}
+
 export function chatGptReadOnlyContextWarning(
   parsed: CodexParsedRequest,
   capabilities: ChatGptWebCapabilities,
@@ -421,6 +477,10 @@ export function compileChatGptWebPrompt(
   const mode = manualControl
     ? { localTools: true, effort: "low" as const, displayLabel: "Zero Risk" as const }
     : resolveChatGptWebModelMode(parsed.modelId, parsed.options.reasoning, capabilities);
+  // Non-manual prompt compilation has already rejected every model outside the two browser
+  // backends. Manual mode cannot enter multipart transport, so this narrowed identity is safe for
+  // the compaction preflight below.
+  const backendModelId = parsed.modelId as ChatGptWebBackendModel;
   const captureLunaCheckpoint = options?.captureLunaCheckpoint === true;
   const multipartParts = options?.experimentalMultipartParts;
   const multipartEnabled = multipartParts !== undefined;
@@ -624,12 +684,26 @@ export function compileChatGptWebPrompt(
   let compiled = build(sourceMessages);
   if (!parsed._compactionRequest) return compiled;
 
-  // The 110k edge budget was measured for the old single-message compaction envelope. Bigger
-  // Context stages are governed by the same model-specific per-message token and composer limits
-  // as ordinary multipart turns in browser-worker. Applying the legacy byte cap here silently
-  // discarded context that the staged transport can carry; preserve it and let browser preflight
-  // fail explicitly if any atomic record is genuinely too large for one stage.
-  if (compiled.multipart) return compiled;
+  // Bigger Context still has a hard per-message boundary. Trim oldest semantic history until every
+  // inert stage and the final commit fit an account-visible effort. This is intentionally separate
+  // from the legacy 110k JSON-byte budget: multipart preserves everything that actually fits, but
+  // it no longer sends an oversized atomic stage to fail after the capability has been published.
+  if (compiled.multipart) {
+    while (
+      !multipartCompactionFits(compiled, backendModelId, mode.effort, capabilities)
+      && sourceMessages.length > 1
+    ) {
+      sourceMessages = sourceMessages.slice(1);
+      compiled = build(sourceMessages);
+    }
+    if (!multipartCompactionFits(compiled, backendModelId, mode.effort, capabilities)) {
+      throw new Error(
+        "ChatGPT Web Bigger Context compaction still exceeds the browser message boundary after all older history was trimmed; the system context and final compaction instruction cannot fit one safe transaction",
+      );
+    }
+    const trimmedCompactionMessages = initialMessageCount - sourceMessages.length;
+    return trimmedCompactionMessages > 0 ? { ...compiled, trimmedCompactionMessages } : compiled;
+  }
 
   const exceedsCompactionBudget = (): boolean => (
     chatGptPromptJsonBytes(compiled.text) > CHATGPT_COMPACTION_PROMPT_JSON_BYTE_BUDGET

--- a/src/adapters/chatgpt-web/prompt.ts
+++ b/src/adapters/chatgpt-web/prompt.ts
@@ -155,8 +155,12 @@ export function withoutRetiredTurnHandles(contextJson: string): string {
   return contextJson.replace(RETIRED_TURN_HANDLE, (_handle, kind: string) => `[retired ${kind} handle]`);
 }
 
-/** ChatGPT accepts at most this many attachments on one message. */
-export const CHATGPT_MAX_INPUT_IMAGES = 10;
+/**
+ * The Web bridge intentionally forwards no context images. Replayed screenshots are noisy in
+ * long tasks and make every browser turn larger; visual work should remain on the native Codex
+ * side instead of being silently re-uploaded to ChatGPT Web.
+ */
+export const CHATGPT_MAX_INPUT_IMAGES = 0;
 
 /**
  * ChatGPT's current `/backend-api/f/conversation` edge rejects large inline JSON bodies before a
@@ -173,8 +177,7 @@ export function chatGptPromptJsonBytes(text: string): number {
   return Buffer.byteLength(JSON.stringify(text), "utf8");
 }
 
-const DROPPED_IMAGE_NOTE =
-  `[older image not attached: ChatGPT accepts at most ${CHATGPT_MAX_INPUT_IMAGES} per message]`;
+const DROPPED_IMAGE_NOTE = "[image omitted by ChatGPT Web bridge]";
 
 /**
  * A fresh compaction epoch receives the complete canonical context, so every still-relevant image
@@ -525,11 +528,7 @@ export function compileChatGptWebPrompt(
     multipartEnabled
       ? "Read and reconstruct every acknowledged staged JSON record before acting."
       : "Read the complete inline JSON task context before acting.",
-    manualControl
-      ? "Each image_attachment in the context refers, in order, to an image the user manually attached to this ChatGPT message. If its corresponding image is absent, say that it was not provided instead of guessing."
-      : multipartEnabled
-        ? "Each image_attachment in the staged context refers to the correspondingly named image attached to this commit message; inspect it directly."
-        : "Each image_attachment in the context refers to the correspondingly named image attached to this ChatGPT message; inspect it directly.",
+    "Images from the replayed Codex context are intentionally omitted by this Web bridge. Do not infer their contents; if the active task depends on an omitted image, say that the image content is unavailable through this bridge.",
     "If a ChatGPT-native capability renders a rich card, widget, chart, or other non-text result, also provide the relevant result as ordinary Markdown in the final answer. A private ChatGPT UI widget never replaces the Markdown answer returned to Codex.",
     "Never copy a ChatGPT widget's HTML, CSS, class names, or DOM markup into the answer unless the user explicitly requested that source markup.",
     "Do not mention this transport contract, context packaging, or capability routing in the user-facing answer unless the user explicitly asks how the bridge works.",

--- a/src/adapters/chatgpt-web/turn-broker.ts
+++ b/src/adapters/chatgpt-web/turn-broker.ts
@@ -865,12 +865,21 @@ export class TurnBroker implements TurnBrokerOwner {
   }
 
   private writeSocketResponse(socket: Socket, response: BrokerResponse): void {
-    const line = `${JSON.stringify(response)}\n`;
+    let line = `${JSON.stringify(response)}\n`;
+    let requiresForcedClose = response.error !== undefined;
     if (line.length > MAX_BROKER_LINE_CHARS) {
-      socket.end(`${JSON.stringify({ id: response.id, error: "turn broker response exceeds size limit" } satisfies BrokerResponse)}\n`);
-      return;
+      line = `${JSON.stringify({ id: response.id, error: "turn broker response exceeds size limit" } satisfies BrokerResponse)}\n`;
+      requiresForcedClose = true;
     }
-    socket.end(line);
+    // Bun on Windows can leave a rejected long-held named pipe half-open after end(), even though
+    // the complete error response was flushed. Successful calls retain the normal close barrier;
+    // rejected calls get a bounded fallback so cancellation cannot leave both processes occupied.
+    const forcedClose = requiresForcedClose ? setTimeout(() => socket.destroy(), 100) : undefined;
+    forcedClose?.unref();
+    socket.end(line, () => {
+      if (forcedClose) clearTimeout(forcedClose);
+      socket.destroy();
+    });
   }
 
   private validateRequest(request: BrokerRequest): void {
@@ -1257,6 +1266,12 @@ export async function callTurnBroker<T>(
     // The server owns response termination. Waiting for the pipe/socket to close before resolving
     // prevents callers from retiring the broker while Bun still has a named-pipe write in flight.
     socket.once("close", finishResponse);
+    // On Windows, Bun can deliver the complete named-pipe response and its EOF without following
+    // with a physical close while our writable side remains open. Close our half after that EOF so
+    // the existing close barrier can settle instead of leaving a revoked MCP invocation hanging.
+    socket.once("end", () => {
+      if (!settled && response) socket.destroy();
+    });
     socket.once("connect", () => socket.write(`${JSON.stringify({ id, ...wireRequest })}\n`));
     socket.on("data", chunk => {
       if (settled || response) return;

--- a/src/adapters/chatgpt-web/turn-execution.ts
+++ b/src/adapters/chatgpt-web/turn-execution.ts
@@ -540,7 +540,19 @@ export class ChatGptTurnSessions {
         ownedKey !== key && session.ownerKey === ownerKey && !session.isPhysicallySettled()
       ));
       if (activeOwner) {
-        const [, ownedSession] = activeOwner;
+        const [ownedKey, ownedSession] = activeOwner;
+        if (nativeTurnId !== undefined && ownedSession.nativeTurnId === nativeTurnId) {
+          // Mid-turn steering keeps Codex's native turn id but changes the user revision (and
+          // therefore the execution key). Waiting for the old browser owner here deadlocks when
+          // this very request also carries the result of its outstanding tool call: the old owner
+          // waits for that result while the new revision waits for the old owner. Retire the
+          // superseded revision first so its pending MCP call receives cancellation and the new
+          // instruction can start on a clean browser surface.
+          this.entries.delete(ownedKey);
+          this.forgetConversationHead(ownedSession);
+          await awaitWithAbort(this.beginRetirement(ownedKey, ownedSession), signal);
+          continue;
+        }
         // A different native message for the same thread is sequential work, not permission to
         // kill the response already using that retained conversation. Wait for its complete
         // browser/launcher settlement; explicit tab close and lifecycle cancellation remain the

--- a/src/browser-login.ts
+++ b/src/browser-login.ts
@@ -16,6 +16,7 @@ export interface BrowserLoginResult {
   storageStatePath: string;
   accountSurfaceUrl: string;
   solAvailable: boolean;
+  extraHighAvailable: boolean;
   proAvailable: boolean;
 }
 
@@ -43,6 +44,7 @@ interface LoginVerificationMarker {
   authenticated: true;
   verifiedAt: string;
   solAvailable?: boolean;
+  extraHighAvailable?: boolean;
   proAvailable?: boolean;
 }
 
@@ -181,7 +183,11 @@ export async function inspectBrowserLoginCapabilities(config: AppConfig): Promis
   if (!browserLoginStateExists(config)) throw new Error("ChatGPT login state is missing or unverified");
   const inspected = await inspectStoredState(config, config.storageStatePath);
   writeVerificationMarker(config.storageStatePath, inspected);
-  return { solAvailable: inspected.solAvailable, proAvailable: inspected.proAvailable };
+  return {
+    solAvailable: inspected.solAvailable,
+    extraHighAvailable: inspected.extraHighAvailable ?? inspected.proAvailable,
+    proAvailable: inspected.proAvailable,
+  };
 }
 
 export function storedBrowserLoginCapabilities(
@@ -192,6 +198,11 @@ export function storedBrowserLoginCapabilities(
     const marker = JSON.parse(readFileSync(loginVerificationMarkerPath(config.storageStatePath), "utf8")) as Partial<LoginVerificationMarker>;
     return {
       ...(typeof marker.solAvailable === "boolean" ? { solAvailable: marker.solAvailable } : {}),
+      ...(typeof marker.extraHighAvailable === "boolean"
+        ? { extraHighAvailable: marker.extraHighAvailable }
+        : typeof marker.proAvailable === "boolean"
+          ? { extraHighAvailable: marker.proAvailable }
+          : {}),
       ...(typeof marker.proAvailable === "boolean" ? { proAvailable: marker.proAvailable } : {}),
     };
   } catch {
@@ -426,6 +437,7 @@ export async function loginToChatGpt(
       storageStatePath: config.storageStatePath,
       accountSurfaceUrl: page.url(),
       solAvailable: inspected.solAvailable,
+      extraHighAvailable: inspected.extraHighAvailable ?? inspected.proAvailable,
       proAvailable: inspected.proAvailable,
     };
   } finally {

--- a/src/chatgpt-session.ts
+++ b/src/chatgpt-session.ts
@@ -21,7 +21,16 @@ export const CHATGPT_EFFORT_SLIDER_CONTAINER_SELECTOR = '[data-model-reasoning-e
 export const CHATGPT_EFFORT_SLIDER_SELECTOR = '[data-model-reasoning-effort-slider] [role="slider"]';
 export const CHATGPT_EFFORT_SLIDER_MAX_OPTIONS = 5;
 export const CHATGPT_STOP_BUTTON_SELECTOR = '[data-testid="stop-button"]';
-export const CHATGPT_COMPLETION_ACTION_SELECTOR = 'button[data-testid="copy-turn-action-button"]';
+export const CHATGPT_COMPLETION_ACTION_SELECTOR = [
+  'button[data-testid="copy-turn-action-button"]',
+  // ChatGPT's September 2026 action row removed the copy button's data-testid while
+  // retaining its accessible name. The browser worker still scopes this selector to a
+  // visible button that follows (and is not contained by) the final Markdown root, so
+  // code-block copy buttons inside the answer cannot be mistaken for turn completion.
+  'button[aria-label="Copy"]',
+  'button[aria-label="复制"]',
+  'button[aria-label="複製"]',
+].join(", ");
 export const CHATGPT_ASSISTANT_TURN_SELECTOR = [
   '[data-testid^="conversation-turn-"][data-turn="assistant"]',
   '[data-testid^="conversation-turn-"][data-message-author-role="assistant"]',
@@ -199,7 +208,7 @@ export async function detectChatGptAccountCapabilities(
     if (composerReady && formReady && documentReady) {
       absenceSince ??= Date.now();
       if (Date.now() - absenceSince >= stableAbsenceMs) {
-        return { solAvailable: false, proAvailable: false };
+        return { solAvailable: false, extraHighAvailable: false, proAvailable: false };
       }
     } else {
       absenceSince = undefined;
@@ -231,7 +240,12 @@ export async function detectChatGptAccountCapabilities(
         { cause: new Error("ChatGPT effort slider exposed an invalid ARIA range") },
       );
     }
-    return { solAvailable: true, proAvailable: state.max - state.min + 1 >= 5 };
+    const stepCount = state.max - state.min + 1;
+    return {
+      solAvailable: true,
+      extraHighAvailable: stepCount >= 4,
+      proAvailable: stepCount >= 5,
+    };
   } finally {
     await page.keyboard.press("Escape").catch(() => {});
   }

--- a/src/chatgpt-web-models.ts
+++ b/src/chatgpt-web-models.ts
@@ -128,6 +128,10 @@ export function resolveChatGptWebContextLimits(
     return contextLimits(CHATGPT_WEB_LUNA_CONTEXT_WINDOW, CHATGPT_WEB_LUNA_CONTEXT_WINDOW);
   }
 
+  if (effort === "xhigh" && !(capabilities.proAvailable || capabilities.extraHighAvailable === true)) {
+    throw new Error(`ChatGPT Plus context limit is not defined for unavailable effort: ${effort}`);
+  }
+
   let limits: ChatGptWebContextLimits;
   if (capabilities.proAvailable) {
     const contextWindow = effort === "low"
@@ -141,7 +145,7 @@ export function resolveChatGptWebContextLimits(
       CHATGPT_WEB_INSTANT_CONTEXT_WINDOW,
       CHATGPT_WEB_INSTANT_AUTO_COMPACT_TOKEN_LIMIT,
     );
-  } else if (effort === "medium" || effort === "high") {
+  } else if (effort === "medium" || effort === "high" || effort === "xhigh") {
     limits = contextLimits(
       CHATGPT_WEB_MEDIUM_HIGH_CONTEXT_WINDOW,
       CHATGPT_WEB_MEDIUM_HIGH_AUTO_COMPACT_TOKEN_LIMIT,
@@ -164,11 +168,14 @@ export function resolveChatGptWebTransportLimits(
 ): ChatGptWebTransportLimits {
   if (isChatGptWebZeroRiskBackendModel(backendModel)) return {};
   if (backendModel === CHATGPT_WEB_LUNA_BACKEND_MODEL) return {};
+  if (effort === "xhigh" && !(capabilities.proAvailable || capabilities.extraHighAvailable === true)) {
+    throw new Error(`ChatGPT Plus transport limit is not defined for unavailable effort: ${effort}`);
+  }
   if (!capabilities.proAvailable) {
     if (effort === "low") {
       return { browserComposerCharLimit: CHATGPT_WEB_INSTANT_COMPOSER_CHAR_LIMIT };
     }
-    if (effort === "medium" || effort === "high") {
+    if (effort === "medium" || effort === "high" || effort === "xhigh") {
       return { browserComposerCharLimit: CHATGPT_WEB_MEDIUM_HIGH_COMPOSER_CHAR_LIMIT };
     }
     throw new Error(`ChatGPT Plus transport limit is not defined for unavailable effort: ${effort}`);
@@ -196,6 +203,7 @@ interface ChatGptWebModelRouteBase {
   displayName: string;
   description: string;
   codexEffort: ChatGptWebCodexEffort;
+  requiresExtraHigh?: boolean;
   requiresPro: boolean;
 }
 
@@ -216,6 +224,8 @@ export type ChatGptWebModelRoute = ChatGptWebAutomaticModelRoute | ChatGptWebZer
 
 export interface ChatGptWebAccountCapabilities {
   solAvailable: boolean;
+  /** Missing on pre-5.0.3 persisted state; legacy state inherits this from proAvailable. */
+  extraHighAvailable?: boolean;
   proAvailable: boolean;
   experimentalBiggerContext?: boolean;
   browserInteractionMode?: "automatic" | "manual";
@@ -318,7 +328,8 @@ export const CHATGPT_WEB_MODEL_ROUTES: readonly ChatGptWebAutomaticModelRoute[] 
     backendModel: CHATGPT_WEB_BACKEND_MODEL,
     codexEffort: "xhigh",
     adapterEffort: "xhigh",
-    requiresPro: true,
+    requiresExtraHigh: true,
+    requiresPro: false,
   },
   {
     slug: "chatgpt-web/pro",
@@ -358,9 +369,11 @@ export function availableChatGptWebModelRoutes(
       : [CHATGPT_WEB_ZERO_RISK_MODEL_ROUTE];
   }
   if (!capabilities.solAvailable) return CHATGPT_WEB_LUNA_MODEL_ROUTES;
-  return capabilities.proAvailable
-    ? CHATGPT_WEB_MODEL_ROUTES
-    : CHATGPT_WEB_MODEL_ROUTES.filter(route => !route.requiresPro);
+  const extraHighAvailable = capabilities.proAvailable || capabilities.extraHighAvailable === true;
+  return CHATGPT_WEB_MODEL_ROUTES.filter(route => (
+    (!route.requiresExtraHigh || extraHighAvailable)
+    && (!route.requiresPro || capabilities.proAvailable)
+  ));
 }
 
 export function requireChatGptWebModelRoute(
@@ -392,6 +405,10 @@ export function requireChatGptWebModelRoute(
   }
   if (!capabilities.solAvailable) {
     throw new Error(`${route.displayName} is not available for this Luna-only account`);
+  }
+  const extraHighAvailable = capabilities.proAvailable || capabilities.extraHighAvailable === true;
+  if (route.requiresExtraHigh && !extraHighAvailable) {
+    throw new Error(`${route.displayName} is not available for this account`);
   }
   if (route.requiresPro && !capabilities.proAvailable) {
     throw new Error(`${route.displayName} is not available for this account`);

--- a/src/codex-interrupt-hook.ts
+++ b/src/codex-interrupt-hook.ts
@@ -69,6 +69,59 @@ function managedMarkerCount(text: string): number {
   return text.split(MANAGED_INTERRUPT_HOOK_START).length - 1;
 }
 
+function managedEndMarkerCount(text: string): number {
+  return text.split(MANAGED_INTERRUPT_HOOK_END).length - 1;
+}
+
+function managedHookOwnedPrefix(
+  installed: InstalledCodexInterruptHook,
+  ending: "\n" | "\r\n" | "\r",
+): string {
+  return [
+    MANAGED_INTERRUPT_HOOK_START,
+    "[[hooks.Interrupt]]",
+    "",
+    "[[hooks.Interrupt.hooks]]",
+    'type = "command"',
+    `command = ${JSON.stringify(installed.command)}`,
+    "timeout = 3",
+    "",
+    `[hooks.state.${JSON.stringify(installed.stateKey)}]`,
+    `trusted_hash = ${JSON.stringify(installed.trustedHash)}`,
+  ].join(ending);
+}
+
+function locateCodexInterruptHook(
+  text: string,
+  installed: InstalledCodexInterruptHook,
+): { start: number; ownedEnd: number; endMarkerStart: number; endMarkerEnd: number } {
+  if (managedMarkerCount(text) !== 1 || managedEndMarkerCount(text) !== 1) {
+    throw new Error("Codex interrupt lifecycle hook markers changed after setup; refusing to overwrite them");
+  }
+  const start = text.indexOf(MANAGED_INTERRUPT_HOOK_START);
+  const ownedPrefix = managedHookOwnedPrefix(installed, lineEnding(text));
+  if (start < 0 || !text.startsWith(ownedPrefix, start)) {
+    throw new Error("Codex interrupt lifecycle hook changed after setup; refusing to overwrite it");
+  }
+  if (interruptGroupCount(text.slice(0, start)) !== installed.groupIndex) {
+    throw new Error("Codex interrupt lifecycle hook order changed after setup; refusing to overwrite it");
+  }
+  const ownedEnd = start + ownedPrefix.length;
+  const endMarkerStart = text.indexOf(MANAGED_INTERRUPT_HOOK_END, ownedEnd);
+  if (endMarkerStart < ownedEnd) {
+    throw new Error("Codex interrupt lifecycle hook markers changed after setup; refusing to overwrite them");
+  }
+  if (codexInterruptHookHash(installed.command) !== installed.trustedHash) {
+    throw new Error("Codex interrupt lifecycle hook journal hash is invalid");
+  }
+  return {
+    start,
+    ownedEnd,
+    endMarkerStart,
+    endMarkerEnd: endMarkerStart + MANAGED_INTERRUPT_HOOK_END.length,
+  };
+}
+
 function canonicalConfigPath(configPath: string): string {
   const absolute = resolve(configPath);
   try {
@@ -131,24 +184,34 @@ export function installCodexInterruptHookCommand(
 }
 
 export function verifyCodexInterruptHook(text: string, installed: InstalledCodexInterruptHook): void {
-  const first = text.indexOf(installed.fragment);
-  if (first < 0 || text.indexOf(installed.fragment, first + installed.fragment.length) >= 0) {
-    throw new Error("Codex interrupt lifecycle hook changed after setup; refusing to overwrite it");
-  }
-  if (interruptGroupCount(text.slice(0, first)) !== installed.groupIndex) {
-    throw new Error("Codex interrupt lifecycle hook order changed after setup; refusing to overwrite it");
-  }
-  if (managedMarkerCount(text) !== 1 || !text.includes(MANAGED_INTERRUPT_HOOK_END)) {
-    throw new Error("Codex interrupt lifecycle hook markers changed after setup; refusing to overwrite them");
-  }
-  if (codexInterruptHookHash(installed.command) !== installed.trustedHash) {
-    throw new Error("Codex interrupt lifecycle hook journal hash is invalid");
-  }
+  locateCodexInterruptHook(text, installed);
 }
 
 export function restoreCodexInterruptHook(text: string, installed: InstalledCodexInterruptHook): string {
-  verifyCodexInterruptHook(text, installed);
-  return text.replace(installed.fragment, "");
+  const exact = text.indexOf(installed.fragment);
+  if (exact >= 0 && text.indexOf(installed.fragment, exact + installed.fragment.length) < 0) {
+    verifyCodexInterruptHook(text, installed);
+    return text.replace(installed.fragment, "");
+  }
+
+  const located = locateCodexInterruptHook(text, installed);
+  const fragmentStart = installed.fragment.indexOf(MANAGED_INTERRUPT_HOOK_START);
+  const fragmentEnd = installed.fragment.indexOf(MANAGED_INTERRUPT_HOOK_END, fragmentStart);
+  if (fragmentStart < 0 || fragmentEnd < fragmentStart) {
+    throw new Error("Codex interrupt lifecycle hook journal fragment is invalid");
+  }
+  const recordedLeading = installed.fragment.slice(0, fragmentStart);
+  const recordedTrailing = installed.fragment.slice(fragmentEnd + MANAGED_INTERRUPT_HOOK_END.length);
+  const removalStart = recordedLeading
+    && text.slice(Math.max(0, located.start - recordedLeading.length), located.start) === recordedLeading
+    ? located.start - recordedLeading.length
+    : located.start;
+  const removalEnd = recordedTrailing
+    && text.slice(located.endMarkerEnd, located.endMarkerEnd + recordedTrailing.length) === recordedTrailing
+    ? located.endMarkerEnd + recordedTrailing.length
+    : located.endMarkerEnd;
+  const appendedCodexConfig = text.slice(located.ownedEnd, located.endMarkerStart);
+  return `${text.slice(0, removalStart)}${appendedCodexConfig}${text.slice(removalEnd)}`;
 }
 
 export function verifyCodexInterruptHookRestored(text: string): void {

--- a/src/config.ts
+++ b/src/config.ts
@@ -118,6 +118,8 @@ export interface AppConfig {
   brokerSocketPath: string;
   headed: boolean;
   solAvailable: boolean;
+  /** Separate from Pro: current Business UI may expose Extra High without exposing Pro. */
+  extraHighAvailable?: boolean;
   proAvailable: boolean;
   experimentalBiggerContext: boolean;
   /** Explicitly install the additional Pro-sized model row while Zero Risk is active. */
@@ -240,6 +242,7 @@ export function defaultConfig(mode: RuntimeMode = "browser-only"): AppConfig {
     brokerSocketPath: defaultBrokerEndpoint(home),
     headed: true,
     solAvailable: true,
+    extraHighAvailable: false,
     proAvailable: false,
     experimentalBiggerContext: false,
     zeroRiskProEnabled: false,
@@ -513,6 +516,9 @@ function parseConfig(value: unknown, path: string): AppConfig {
   if (parsed.proAvailable !== undefined && typeof parsed.proAvailable !== "boolean") {
     throw new Error(`Invalid proAvailable in ${path}`);
   }
+  if (parsed.extraHighAvailable !== undefined && typeof parsed.extraHighAvailable !== "boolean") {
+    throw new Error(`Invalid extraHighAvailable in ${path}`);
+  }
   if (parsed.solAvailable !== undefined && typeof parsed.solAvailable !== "boolean") {
     throw new Error(`Invalid solAvailable in ${path}`);
   }
@@ -529,6 +535,11 @@ function parseConfig(value: unknown, path: string): AppConfig {
   }
   const solAvailable = parsed.solAvailable !== false;
   const proAvailable = parsed.proAvailable === true;
+  // Persisted 4.x/early-5.x configs predate the separate Extra High capability. Their Pro bit
+  // historically meant "the account exposes the extended picker", so inherit it on load.
+  const extraHighAvailable = parsed.extraHighAvailable === undefined
+    ? proAvailable
+    : parsed.extraHighAvailable === true;
   const experimentalBiggerContext = parsed.experimentalBiggerContext === true;
   const zeroRiskProEnabled = parsed.zeroRiskProEnabled === true;
   if (browserInteractionMode === "manual" && experimentalBiggerContext) {
@@ -536,6 +547,12 @@ function parseConfig(value: unknown, path: string): AppConfig {
   }
   if (proAvailable && !solAvailable) {
     throw new Error(`Invalid ChatGPT account capabilities in ${path}: Pro requires Sol`);
+  }
+  if (extraHighAvailable && !solAvailable) {
+    throw new Error(`Invalid ChatGPT account capabilities in ${path}: Extra High requires Sol`);
+  }
+  if (proAvailable && !extraHighAvailable) {
+    throw new Error(`Invalid ChatGPT account capabilities in ${path}: Pro requires Extra High`);
   }
   return {
     ...parsed,
@@ -545,6 +562,7 @@ function parseConfig(value: unknown, path: string): AppConfig {
     browserInteractionMode,
     subagentProtocol,
     solAvailable,
+    extraHighAvailable,
     proAvailable,
     experimentalBiggerContext,
     zeroRiskProEnabled,
@@ -559,6 +577,7 @@ export function saveConfig(config: AppConfig): void {
 
 export function providerConfig(config: AppConfig): CodexProviderConfig {
   const manual = config.browserInteractionMode === "manual";
+  const extraHighAvailable = config.proAvailable || config.extraHighAvailable === true;
   const model = manual
     ? CHATGPT_WEB_ZERO_RISK_BACKEND_MODEL
     : config.solAvailable ? "gpt-5.6-sol" : "gpt-5.6-luna";
@@ -571,7 +590,13 @@ export function providerConfig(config: AppConfig): CodexProviderConfig {
   const efforts = manual
     ? ["low"]
     : config.solAvailable
-    ? ["low", "medium", "high", "xhigh", ...(config.proAvailable ? ["max"] : [])]
+    ? [
+      "low",
+      "medium",
+      "high",
+      ...(extraHighAvailable ? ["xhigh"] : []),
+      ...(config.proAvailable ? ["max"] : []),
+    ]
     : ["low", "medium"];
   return {
     adapter: "chatgpt-web",
@@ -599,6 +624,7 @@ export function providerConfig(config: AppConfig): CodexProviderConfig {
       headed: config.headed,
       localToolsEnabled: config.mode === "full",
       solAvailable: manual ? false : config.solAvailable,
+      extraHighAvailable: manual ? false : extraHighAvailable,
       proAvailable: manual ? false : config.proAvailable,
       experimentalBiggerContext: manual ? false : config.experimentalBiggerContext,
       ...(config.stallTimeoutSec !== undefined ? { stallTimeoutSec: config.stallTimeoutSec } : {}),

--- a/src/config.ts
+++ b/src/config.ts
@@ -605,7 +605,9 @@ export function providerConfig(config: AppConfig): CodexProviderConfig {
     liveModels: false,
     defaultModel: model,
     contextWindow: config.contextWindow,
-    modelInputModalities: Object.fromEntries(models.map(model => [model, manual ? ["text"] : ["text", "image"]])),
+    // The ChatGPT Web bridge is deliberately text-only. Context screenshots are omitted before
+    // transport so the Web model cannot accumulate stale or irrelevant image attachments.
+    modelInputModalities: Object.fromEntries(models.map(model => [model, ["text"]])),
     modelReasoningEfforts: Object.fromEntries(models.map(modelId => [modelId, efforts])),
     modelDefaultReasoningEfforts: Object.fromEntries(
       models.map(modelId => [modelId, manual ? "low" : config.solAvailable ? "high" : "low"]),

--- a/src/dev-chat/profile.ts
+++ b/src/dev-chat/profile.ts
@@ -133,7 +133,9 @@ export function installedLauncherCandidates({
     );
   } else if (platform === "win32") {
     const registeredLocation = windowsInstallLocation?.trim()
-      || (process.platform === "win32" ? registeredWindowsLauncherInstallLocation() : undefined);
+      || (process.platform === "win32" && environment === process.env
+        ? registeredWindowsLauncherInstallLocation()
+        : undefined);
     if (registeredLocation && win32.isAbsolute(registeredLocation)) {
       candidates.push(win32.join(registeredLocation, "Codex Web GPT.exe"));
     } else {

--- a/src/launcher-browser-host.ts
+++ b/src/launcher-browser-host.ts
@@ -276,7 +276,7 @@ export async function inspectLauncherBrowserHost(
     expectedProfile?: LauncherBrowserHostProfile;
     timeoutMs?: number;
   } = {},
-): Promise<{ solAvailable?: boolean; proAvailable?: boolean; url: string }> {
+): Promise<{ solAvailable?: boolean; extraHighAvailable?: boolean; proAvailable?: boolean; url: string }> {
   const descriptor = readLauncherBrowserHostDescriptor(descriptorPath);
   if (options.expectedProfile && descriptor.profile !== options.expectedProfile) {
     throw new Error(
@@ -311,13 +311,19 @@ export async function inspectLauncherBrowserHost(
       && (typeof body.solAvailable !== "boolean" || typeof body.proAvailable !== "boolean")) {
       throw new Error("Launcher did not return complete ChatGPT account capability evidence");
     }
-    if (options.detectCapabilities && body.proAvailable === true && body.solAvailable !== true) {
+    const extraHighAvailable = options.detectCapabilities
+      ? (typeof body.extraHighAvailable === "boolean" ? body.extraHighAvailable : body.proAvailable === true)
+      : undefined;
+    if (options.detectCapabilities
+      && ((extraHighAvailable === true && body.solAvailable !== true)
+        || (body.proAvailable === true && extraHighAvailable !== true))) {
       throw new Error("Launcher returned contradictory ChatGPT account capability evidence");
     }
     return {
       url: body.url,
       ...(options.detectCapabilities ? {
         solAvailable: body.solAvailable as boolean,
+        extraHighAvailable: extraHighAvailable as boolean,
         proAvailable: body.proAvailable as boolean,
       } : {}),
     };

--- a/src/model-catalog.ts
+++ b/src/model-catalog.ts
@@ -112,7 +112,9 @@ export function buildChatGptWebModel(
     slug: route.slug,
     display_name: route.displayName,
     description: route.description,
-    input_modalities: route.interactionMode === "manual" ? ["text"] : ["text", "image"],
+    // ChatGPT Web receives text-only context; image blocks are intentionally omitted by the
+    // prompt compiler to prevent screenshot accumulation across long tasks.
+    input_modalities: ["text"],
     visibility: "list",
     // These slugs are implemented by this local Responses-compatible bridge. Marking them false
     // makes Codex drop them from spawn_agent whenever openai_base_url points at the bridge.

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -142,6 +142,7 @@ function meaningfulRuntimeChange(before: AppConfig, after: AppConfig): boolean {
     brokerSocketPath: before.brokerSocketPath,
     headed: before.headed,
     solAvailable: before.solAvailable,
+    extraHighAvailable: before.extraHighAvailable ?? before.proAvailable,
     proAvailable: before.proAvailable,
     experimentalBiggerContext: before.experimentalBiggerContext,
     zeroRiskProEnabled: before.zeroRiskProEnabled,
@@ -169,6 +170,7 @@ function meaningfulRuntimeChange(before: AppConfig, after: AppConfig): boolean {
     brokerSocketPath: after.brokerSocketPath,
     headed: after.headed,
     solAvailable: after.solAvailable,
+    extraHighAvailable: after.extraHighAvailable ?? after.proAvailable,
     proAvailable: after.proAvailable,
     experimentalBiggerContext: after.experimentalBiggerContext,
     zeroRiskProEnabled: after.zeroRiskProEnabled,
@@ -302,7 +304,7 @@ async function inspectLauncherCapabilities(
   existing: AppConfig | undefined,
   refreshAccountCapabilities: boolean,
   expectedProfile: "production" | "development",
-): Promise<{ solAvailable: boolean; proAvailable: boolean }> {
+): Promise<{ solAvailable: boolean; extraHighAvailable: boolean; proAvailable: boolean }> {
   const detectCapabilities = launcherCapabilityProbeRequired(
     existing,
     refreshAccountCapabilities,
@@ -314,6 +316,9 @@ async function inspectLauncherCapabilities(
   });
   return {
     solAvailable: detectCapabilities ? inspected.solAvailable === true : existing!.solAvailable,
+    extraHighAvailable: detectCapabilities
+      ? inspected.extraHighAvailable === true
+      : (existing!.extraHighAvailable ?? existing!.proAvailable),
     proAvailable: detectCapabilities ? inspected.proAvailable === true : existing!.proAvailable,
   };
 }
@@ -488,6 +493,7 @@ export async function setup(options: SetupOptions): Promise<SetupResult> {
 
   let loginCreated = false;
   let solAvailable: boolean | undefined = config.solAvailable;
+  let extraHighAvailable: boolean | undefined = config.extraHighAvailable ?? config.proAvailable;
   let proAvailable: boolean | undefined = config.proAvailable;
   if (config.browserInteractionMode === "manual") {
     // The generic manual route is independent of account capabilities. The launcher may open the
@@ -501,16 +507,19 @@ export async function setup(options: SetupOptions): Promise<SetupResult> {
       "production",
     );
     solAvailable = capabilities.solAvailable;
+    extraHighAvailable = capabilities.extraHighAvailable;
     proAvailable = capabilities.proAvailable;
   } else {
     const stored = storedBrowserLoginCapabilities(config);
     solAvailable = stored.solAvailable;
+    extraHighAvailable = stored.extraHighAvailable ?? stored.proAvailable;
     proAvailable = stored.proAvailable;
     const loginRequired = options.forceLogin || !browserLoginStateExists(config);
     const capabilityProbeRequired = !loginRequired
       && (options.refreshAccountCapabilities === true
         || existing?.browserInteractionMode === "manual"
         || solAvailable === undefined
+        || extraHighAvailable === undefined
         || proAvailable === undefined);
     if (beforeService.loaded && (loginRequired || capabilityProbeRequired) && !options.restartService) {
       throw new Error(
@@ -522,16 +531,20 @@ export async function setup(options: SetupOptions): Promise<SetupResult> {
     if (loginRequired) {
       const login = await loginToChatGpt(config);
       solAvailable = login.solAvailable;
+      extraHighAvailable = login.extraHighAvailable;
       proAvailable = login.proAvailable;
       loginCreated = true;
     } else if (capabilityProbeRequired) {
       const inspected = await inspectBrowserLoginCapabilities(config);
       solAvailable = inspected.solAvailable;
+      extraHighAvailable = inspected.extraHighAvailable ?? inspected.proAvailable;
       proAvailable = inspected.proAvailable;
     }
   }
   config.solAvailable = solAvailable === true;
+  config.extraHighAvailable = config.solAvailable && extraHighAvailable === true;
   config.proAvailable = config.solAvailable && proAvailable === true;
+  if (config.proAvailable) config.extraHighAvailable = true;
   const explicitTunnelChange = Boolean(options.tunnelId || options.runtimeKeyFile || options.runtimeKeyValue);
   const preliminaryChange = Boolean(existing && (meaningfulRuntimeChange(existing, config) || explicitTunnelChange || options.forceLogin));
   if (beforeService.loaded && preliminaryChange && !options.restartService) {
@@ -645,7 +658,9 @@ export async function setupDevProfile(options: SetupOptions): Promise<DevProfile
       DEV_LAUNCHER_PROFILE,
     );
     config.solAvailable = capabilities.solAvailable;
+    config.extraHighAvailable = capabilities.solAvailable && capabilities.extraHighAvailable;
     config.proAvailable = capabilities.solAvailable && capabilities.proAvailable;
+    if (config.proAvailable) config.extraHighAvailable = true;
   }
 
   const explicitTunnelChange = Boolean(options.tunnelId || options.runtimeKeyFile || options.runtimeKeyValue);

--- a/src/types.ts
+++ b/src/types.ts
@@ -298,6 +298,8 @@ export interface CodexProviderConfig {
     /** Account capability proven by the authenticated browser probe. */
     solAvailable?: boolean;
     /** Account capability proven by the authenticated browser probe. */
+    extraHighAvailable?: boolean;
+    /** Account capability proven by the authenticated browser probe. */
     proAvailable?: boolean;
     /** Authorize per-call "Allow once" confirmation clicks for this connector. */
     autoApproveToolCalls?: boolean;

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -364,6 +364,31 @@ test("launcher page acquisition proves a nonzero operational viewport before DOM
   expect(workerSource).toContain("innerWidth >= width && innerHeight >= height");
 });
 
+test("launcher effort selection refreshes the hidden viewport after navigation and before both effort pickers", () => {
+  const workerSource = readFileSync(new URL("../src/adapters/chatgpt-web/browser-worker.ts", import.meta.url), "utf8");
+  const refreshHelper = workerSource.indexOf("private async refreshLauncherViewport(");
+  const refreshRequest = workerSource.indexOf("refreshViewport: true", refreshHelper);
+  const firstStage = workerSource.indexOf('"effort_selection", browserStageTimeouts.effortSelection');
+  const firstRefresh = workerSource.indexOf("await this.refreshLauncherViewport(turn.traceId);", firstStage);
+  const firstViewport = workerSource.indexOf("await waitForOperationalChatGptViewport(page, signal);", firstRefresh);
+  const firstPicker = workerSource.indexOf("return this.selectModelAndEffort(", firstViewport);
+  const finalStage = workerSource.indexOf('"final_part_effort_selection",', firstPicker);
+  const finalRefresh = workerSource.indexOf("await this.refreshLauncherViewport(turn.traceId);", finalStage);
+  const finalViewport = workerSource.indexOf("await waitForOperationalChatGptViewport(page, signal);", finalRefresh);
+  const finalPicker = workerSource.indexOf("return this.selectModelAndEffort(", finalViewport);
+
+  expect(refreshHelper).toBeGreaterThan(-1);
+  expect(refreshRequest).toBeGreaterThan(refreshHelper);
+  expect(firstStage).toBeGreaterThan(-1);
+  expect(firstRefresh).toBeGreaterThan(firstStage);
+  expect(firstViewport).toBeGreaterThan(firstRefresh);
+  expect(firstPicker).toBeGreaterThan(firstViewport);
+  expect(finalStage).toBeGreaterThan(firstPicker);
+  expect(finalRefresh).toBeGreaterThan(finalStage);
+  expect(finalViewport).toBeGreaterThan(finalRefresh);
+  expect(finalPicker).toBeGreaterThan(finalViewport);
+});
+
 test("Luna turns without a retained conversation never send connector identity alone", () => {
   const workerSource = readFileSync(new URL("../src/adapters/chatgpt-web/browser-worker.ts", import.meta.url), "utf8");
   const runExclusive = workerSource.slice(workerSource.indexOf("  private async runExclusive("));
@@ -2778,22 +2803,33 @@ test("Bigger Context preflight expands only the total context ceiling and keeps 
 
 test("Bigger Context stages use the lowest account mode that can carry the stage", () => {
   const plus = { localToolsEnabled: false, solAvailable: true, proAvailable: false };
+  const business = { localToolsEnabled: false, solAvailable: true, extraHighAvailable: true, proAvailable: false };
   const pro = { localToolsEnabled: false, solAvailable: true, proAvailable: true };
-  expect(resolveChatGptWebMultipartStagingMode("gpt-5.6-sol", plus, 30_000, 200_000).effort).toBe("low");
-  expect(resolveChatGptWebMultipartStagingMode("gpt-5.6-sol", plus, 30_000, 300_000).effort).toBe("medium");
-  expect(resolveChatGptWebMultipartStagingMode("gpt-5.6-sol", plus, 80_000, 300_000).effort).toBe("medium");
+  expect(resolveChatGptWebMultipartStagingMode("gpt-5.6-sol", plus, "low", 30_000, 200_000).effort).toBe("low");
+  expect(resolveChatGptWebMultipartStagingMode("gpt-5.6-sol", plus, "medium", 30_000, 300_000).effort).toBe("medium");
+  expect(resolveChatGptWebMultipartStagingMode("gpt-5.6-sol", plus, "high", 80_000, 300_000).effort).toBe("medium");
   expect(() => resolveChatGptWebMultipartStagingMode(
     "gpt-5.6-sol",
     plus,
+    "high",
     80_001,
     300_000,
   )).toThrow("No ChatGPT effort");
-  expect(resolveChatGptWebMultipartStagingMode("gpt-5.6-sol", pro, 100_000, 500_000).effort).toBe("low");
-  expect(resolveChatGptWebMultipartStagingMode("gpt-5.6-sol", pro, 100_000, 600_000).effort).toBe("medium");
-  expect(resolveChatGptWebMultipartStagingMode("gpt-5.6-sol", pro, 104_000, 1_200_000).effort).toBe("max");
+  expect(resolveChatGptWebMultipartStagingMode("gpt-5.6-sol", business, "xhigh", 80_000, 300_000).effort).toBe("medium");
+  expect(() => resolveChatGptWebMultipartStagingMode(
+    "gpt-5.6-sol",
+    business,
+    "xhigh",
+    80_001,
+    300_000,
+  )).toThrow("No ChatGPT effort");
+  expect(resolveChatGptWebMultipartStagingMode("gpt-5.6-sol", pro, "medium", 100_000, 500_000).effort).toBe("medium");
+  expect(resolveChatGptWebMultipartStagingMode("gpt-5.6-sol", pro, "medium", 100_000, 600_000).effort).toBe("medium");
+  expect(resolveChatGptWebMultipartStagingMode("gpt-5.6-sol", pro, "max", 104_000, 1_200_000).effort).toBe("max");
   expect(() => resolveChatGptWebMultipartStagingMode(
     "gpt-5.6-luna",
     { localToolsEnabled: false, solAvailable: false, proAvailable: false },
+    "low",
     10_000,
     20_000,
   )).toThrow("Luna-only");
@@ -3075,7 +3111,7 @@ test("browser DOM health fails closed on a vanished or empty ChatGPT response", 
   };
   expect(missingCompletionAction.update(completedWithoutMarker, 1_000)).toBeUndefined();
   expect(missingCompletionAction.update(completedWithoutMarker, 1_749)).toBeUndefined();
-  expect(missingCompletionAction.update(completedWithoutMarker, 1_750)).toContain("DOM may have changed");
+  expect(missingCompletionAction.update(completedWithoutMarker, 1_750)).toBeUndefined();
 });
 
 test("stalled-turn diagnostics record DOM metrics without response or overlay content", () => {
@@ -3091,11 +3127,15 @@ test("stalled-turn diagnostics record DOM metrics without response or overlay co
   expect(diagnosticSource).not.toMatch(/\bariaLabel:\s*candidate\.getAttribute/);
 });
 
-test("browser completion requires ChatGPT's response-scoped copy action", () => {
+test("browser completion treats ChatGPT's response-scoped copy action as optional strong evidence", () => {
   const workerSource = readFileSync(new URL("../src/adapters/chatgpt-web/browser-worker.ts", import.meta.url), "utf8");
   const sessionSource = readFileSync(new URL("../src/chatgpt-session.ts", import.meta.url), "utf8");
   expect(sessionSource).toContain('button[data-testid="copy-turn-action-button"]');
+  expect(sessionSource).toContain('button[aria-label="Copy"]');
+  expect(sessionSource).toContain('button[aria-label="复制"]');
+  expect(sessionSource).toContain('button[aria-label="複製"]');
   expect(workerSource).toContain("CHATGPT_COMPLETION_ACTION_SELECTOR");
+  expect(workerSource).toContain("fall back to a bounded text+HTML stability");
   expect(workerSource).not.toContain('root.querySelectorAll<HTMLElement>("button")');
 });
 
@@ -3185,9 +3225,9 @@ test("turn cancellation heuristics defer to proven MCP progress in both wait loo
   expect((worker.match(/domHealthTracker\.clearMissingResponse\(\)/g) ?? []).length).toBe(2);
 });
 
-test("proven MCP progress vetoes every terminal DOM conclusion, not just a missing response", () => {
-  // Tool activity remains authoritative when the response DOM is present but its completion action
-  // has not appeared yet.
+test("proven MCP progress vetoes terminal DOM conclusions while missing actions remain non-terminal", () => {
+  // Tool activity remains authoritative when the response DOM is present. A missing completed-turn
+  // action is no longer itself an error because ChatGPT can virtualize that shared action row.
   const stalled = new ChatGptTurnDomHealthTracker(1_000, 500, 750);
   const answeredWithoutCompletionAction = {
     responsePresent: true,
@@ -3202,7 +3242,7 @@ test("proven MCP progress vetoes every terminal DOM conclusion, not just a missi
   // Once the model genuinely stops, the window starts fresh rather than charging the live stretch.
   expect(stalled.update(answeredWithoutCompletionAction, 10_100)).toBeUndefined();
   expect(stalled.update(answeredWithoutCompletionAction, 10_849)).toBeUndefined();
-  expect(stalled.update(answeredWithoutCompletionAction, 10_850)).toContain("did not expose its completed-turn action");
+  expect(stalled.update(answeredWithoutCompletionAction, 10_850)).toBeUndefined();
 
   const empty = new ChatGptTurnDomHealthTracker(1_000, 500, 750);
   const completedEmpty = {

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Page } from "playwright-core";
-import { CHATGPT_BROWSER_OBSERVATION_PROBE_TIMEOUT_MS, CHATGPT_COMPLETION_SETTLE_MS, CHATGPT_EXTERNAL_PROGRESS_CLOCK_SKEW_MS, CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS, ChatGptCompletionTracker, chatGptExternalProgressSuppressesDomHealth, CHATGPT_RESPONSE_DOM_GRACE_MS, MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS, CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_COMPOSER_SELECT_ALL_KEY, CHATGPT_STOPPED_THINKING_GRACE_MS, ChatGptBrowserObservationTimeoutError, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_PAGE_REBINDS, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, assertChatGptWebMultipartInputWithinLimits, browserDiagnosticCheckpoint, chatGptConnectorAttachmentMode, chatGptEffortSelectionRequired, chatGptNewTurnIdentity, chatGptReboundTurnIdentity, chatGptSubmissionEvidence, connectAfterClosingBrowserConnection, dismissChatGptTemporaryChatOnboarding, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, resolveChatGptWebMultipartStagingMode, sanitizeChatGptBrowserDiagnosticState, setChatGptThinkMode, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert, withChatGptBrowserObservationTimeout, CHATGPT_MULTIPART_RESPONSE_DOM_GRACE_MS, browserStageTimeouts, ChatGptSuspensionClock, remainingStageBudgetMs } from "../src/adapters/chatgpt-web/browser-worker";
+import { CHATGPT_BROWSER_OBSERVATION_PROBE_TIMEOUT_MS, CHATGPT_COMPLETION_SETTLE_MS, CHATGPT_EXTERNAL_PROGRESS_CLOCK_SKEW_MS, CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS, ChatGptCompletionTracker, chatGptExternalProgressSuppressesDomHealth, CHATGPT_RESPONSE_DOM_GRACE_MS, MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS, CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_COMPOSER_SELECT_ALL_KEY, CHATGPT_STOPPED_THINKING_GRACE_MS, ChatGptBrowserObservationTimeoutError, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_PAGE_REBINDS, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, assertChatGptWebMultipartInputWithinLimits, browserDiagnosticCheckpoint, chatGptConnectorAttachmentMode, chatGptConversationTurnIdentity, chatGptEffortSelectionRequired, chatGptNewTurnIdentity, chatGptReboundTurnIdentity, chatGptSubmissionEvidence, connectAfterClosingBrowserConnection, dismissChatGptTemporaryChatOnboarding, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, resolveChatGptWebMultipartStagingMode, sanitizeChatGptBrowserDiagnosticState, setChatGptThinkMode, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert, withChatGptBrowserObservationTimeout, CHATGPT_MULTIPART_RESPONSE_DOM_GRACE_MS, browserStageTimeouts, ChatGptSuspensionClock, remainingStageBudgetMs } from "../src/adapters/chatgpt-web/browser-worker";
 import { ensureChatGptPersonalizedConnectorAccess } from "../src/adapters/chatgpt-web/browser-worker";
 import { chatGptStoppedThinkingError } from "../src/adapters/chatgpt-web/adapter-error";
 import { CHATGPT_WEB_MODEL_ID } from "../src/adapters/chatgpt-web/model";
@@ -25,10 +25,21 @@ function personalizedTemporaryChatRole(
 }
 
 test("conversation turn identity survives ChatGPT DOM virtualization", () => {
+  const initial = [
+    chatGptConversationTurnIdentity("user-a", "conversation-turn-1"),
+    chatGptConversationTurnIdentity("assistant-a", "conversation-turn-2"),
+    chatGptConversationTurnIdentity("user-b", "conversation-turn-3"),
+  ];
+  const renumbered = [
+    chatGptConversationTurnIdentity("user-a", "conversation-turn-21"),
+    chatGptConversationTurnIdentity("assistant-a", "conversation-turn-22"),
+    chatGptConversationTurnIdentity("user-b", "conversation-turn-23"),
+  ];
+  expect(chatGptNewTurnIdentity(initial, renumbered)).toBeUndefined();
   expect(chatGptNewTurnIdentity(
-    ["conversation-turn-1", "conversation-turn-2", "conversation-turn-3"],
-    ["conversation-turn-2", "conversation-turn-3", "conversation-turn-4"],
-  )).toBe("conversation-turn-4");
+    initial,
+    [...renumbered, chatGptConversationTurnIdentity("assistant-b", "conversation-turn-24")],
+  )).toBe("assistant-b");
   expect(chatGptNewTurnIdentity(
     ["conversation-turn-1"],
     ["conversation-turn-1"],
@@ -37,14 +48,17 @@ test("conversation turn identity survives ChatGPT DOM virtualization", () => {
     ["conversation-turn-1"],
     ["conversation-turn-1", "conversation-turn-2", "conversation-turn-3"],
   )).toThrow("2 new conversation turns");
+  expect(chatGptConversationTurnIdentity(null, "conversation-turn-9")).toBe("conversation-turn-9");
+  expect(() => chatGptConversationTurnIdentity(null, "other-node")).toThrow("no stable data-turn-id");
 });
 
 test("assistant tracking rebinds only one proven replacement after React detaches its node", () => {
+  const stableAssistant = chatGptConversationTurnIdentity("request-WEB:stable-assistant", "conversation-turn-2");
   expect(chatGptReboundTurnIdentity(
-    ["conversation-turn-1"],
-    "conversation-turn-2",
-    ["conversation-turn-1", "conversation-turn-2"],
-  )).toBe("conversation-turn-2");
+    ["user-a"],
+    stableAssistant,
+    ["user-a", chatGptConversationTurnIdentity("request-WEB:stable-assistant", "conversation-turn-200")],
+  )).toBe(stableAssistant);
   expect(chatGptReboundTurnIdentity(
     ["conversation-turn-1"],
     "conversation-turn-2",
@@ -736,7 +750,7 @@ test("an accepted turn rebinds the missing assistant observation and acknowledge
   const makePage = (name: string) => ({
     name,
     isClosed: () => false,
-    locator: (selector: string) => selector.startsWith("[data-testid=")
+    locator: (selector: string) => selector.includes("[data-turn-id=") || selector.includes("[data-testid=")
       ? assistantLocator
       : hiddenLocator,
   }) as unknown as Page;

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -1971,7 +1971,7 @@ test("retained tool turns insert into the connector-bound composer without selec
   expect(calls).toEqual(["fill", "focus", "insert", "assert"]);
 });
 
-test("image attachment readiness uses exact file tiles and not localized remove-button text", async () => {
+test("image attachment readiness is disabled for the text-only Web bridge", async () => {
   const imageUrl = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
   const calls: Array<[string, string?]> = [];
   const send = {
@@ -2024,16 +2024,10 @@ test("image attachment readiness uses exact file tiles and not localized remove-
     attachFiles(page: unknown, prompt: unknown): Promise<void>;
   }).attachFiles;
 
-  await attachFiles.call({ activeComposer: async () => composer }, page, {
+  await expect(attachFiles.call({ activeComposer: async () => composer }, page, {
     images: [{ ref: "codex-input-image-1", imageUrl }],
-  });
-
-  expect(calls).toEqual([
-    ["inputReady"],
-    ["setFiles", "codex-input-image-1.png"],
-    ["fileTile", "codex-input-image-1.png"],
-    ["sendEnabled"],
-  ]);
+  })).rejects.toThrow("at most 0 input images per Codex turn");
+  expect(calls).toEqual([]);
 });
 
 test("effort slider ARIA state fails closed on malformed and unsupported ranges", () => {
@@ -3149,7 +3143,7 @@ test("browser completion treats ChatGPT's response-scoped copy action as optiona
   expect(sessionSource).toContain('button[aria-label="复制"]');
   expect(sessionSource).toContain('button[aria-label="複製"]');
   expect(workerSource).toContain("CHATGPT_COMPLETION_ACTION_SELECTOR");
-  expect(workerSource).toContain("fall back to a bounded text+HTML stability");
+  expect(workerSource).toContain("fallback instead of requiring Copy forever");
   expect(workerSource).not.toContain('root.querySelectorAll<HTMLElement>("button")');
 });
 
@@ -3471,6 +3465,46 @@ test("proven MCP progress vetoes completion, not only the health verdicts", () =
   expect(tracker.update(finishedLooking, 5_100)).toBeFalse();
   expect(tracker.update(finishedLooking, 5_599)).toBeFalse();
   expect(tracker.update(finishedLooking, 5_600)).toBeTrue();
+});
+
+test("a post-tool idle gap cannot terminate a turn before the next tool call", () => {
+  const tracker = new ChatGptCompletionTracker(500, 5_000);
+  const beforeFirstTool = {
+    responsePresent: true,
+    running: false,
+    currentText: "I will inspect the first thing.",
+    currentHtml: "<p>I will inspect the first thing.</p>",
+    completionActionVisible: false,
+  };
+
+  expect(tracker.observeToolBatch(1, beforeFirstTool.currentText)).toBeTrue();
+  expect(tracker.update({ ...beforeFirstTool, externalToolCallsInFlight: true }, 1_000)).toBeFalse();
+
+  // ChatGPT often drops the Stop button between Codex tool calls. It may also add a small amount
+  // of prose before deciding to call the next tool. That is an inter-tool idle gap, not a final
+  // assistant answer, even if the DOM is completely static for the ordinary settle window.
+  const betweenTools = {
+    ...beforeFirstTool,
+    currentText: "I inspected the first thing; now I will check the next one.",
+    currentHtml: "<p>I inspected the first thing; now I will check the next one.</p>",
+  };
+  expect(tracker.update({ ...betweenTools, externalToolCallsInFlight: false }, 2_000)).toBeFalse();
+  expect(tracker.update({ ...betweenTools, externalToolCallsInFlight: false }, 2_500)).toBeFalse();
+
+  // A second tool call can arrive after that quiet gap and must remain part of the same turn.
+  expect(tracker.observeToolBatch(2, betweenTools.currentText)).toBeTrue();
+  expect(tracker.update({ ...betweenTools, externalToolCallsInFlight: true }, 3_000)).toBeFalse();
+
+  // The response-scoped completed-turn action is terminal evidence after the last tool result.
+  const finalAnswer = {
+    ...betweenTools,
+    currentText: "All checks are complete. Here is the final answer.",
+    currentHtml: "<p>All checks are complete. Here is the final answer.</p>",
+    completionActionVisible: true,
+  };
+  expect(tracker.update({ ...finalAnswer, externalToolCallsInFlight: false }, 4_000)).toBeFalse();
+  expect(tracker.update({ ...finalAnswer, externalToolCallsInFlight: false }, 4_499)).toBeFalse();
+  expect(tracker.update({ ...finalAnswer, externalToolCallsInFlight: false }, 4_500)).toBeTrue();
 });
 
 test("Full mode has no fixed post-tool final-answer deadline", () => {

--- a/tests/chatgpt-session.test.ts
+++ b/tests/chatgpt-session.test.ts
@@ -156,7 +156,7 @@ test("a complete authenticated composer with no effort selector is Luna-only", a
   await expect(detectChatGptAccountCapabilities(page as never, {
     selectorTimeoutMs: 100,
     stableAbsenceMs: 0,
-  })).resolves.toEqual({ solAvailable: false, proAvailable: false });
+  })).resolves.toEqual({ solAvailable: false, extraHighAvailable: false, proAvailable: false });
 });
 
 test("a transient effort control does not turn a Luna-only account into Sol", async () => {
@@ -186,7 +186,7 @@ test("a transient effort control does not turn a Luna-only account into Sol", as
   await expect(detectChatGptAccountCapabilities(page as never, {
     selectorTimeoutMs: 100,
     stableAbsenceMs: 0,
-  })).resolves.toEqual({ solAvailable: false, proAvailable: false });
+  })).resolves.toEqual({ solAvailable: false, extraHighAvailable: false, proAvailable: false });
   expect(visibilityReads).toBe(2);
 });
 
@@ -239,7 +239,11 @@ function reasoningPicker(options: { max?: string; delay?: number; missing?: bool
 
 test.each([0, 50])("capabilities wait for the visible container and read its hidden semantic input (delay=%s)", async delay => {
   const fixture = reasoningPicker({ delay });
-  await expect(detectChatGptAccountCapabilities(fixture.page as never)).resolves.toEqual({ solAvailable: true, proAvailable: true });
+  await expect(detectChatGptAccountCapabilities(fixture.page as never)).resolves.toEqual({
+    solAvailable: true,
+    extraHighAvailable: true,
+    proAvailable: true,
+  });
 });
 
 test("an absent effort slider cannot turn three model rows into a saved non-Pro capability", async () => {
@@ -248,8 +252,20 @@ test("an absent effort slider cannot turn three model rows into a saved non-Pro 
 });
 
 test("the authoritative three-step range is non-Pro; a malformed range fails closed", async () => {
-  await expect(detectChatGptAccountCapabilities(reasoningPicker({ max: "2" }).page as never)).resolves.toEqual({ solAvailable: true, proAvailable: false });
+  await expect(detectChatGptAccountCapabilities(reasoningPicker({ max: "2" }).page as never)).resolves.toEqual({
+    solAvailable: true,
+    extraHighAvailable: false,
+    proAvailable: false,
+  });
   await expect(detectChatGptAccountCapabilities(reasoningPicker({ max: "bad" }).page as never)).rejects.toThrow("model controls are unavailable");
+});
+
+test("the authoritative four-step range enables Extra High without enabling Pro", async () => {
+  await expect(detectChatGptAccountCapabilities(reasoningPicker({ max: "3" }).page as never)).resolves.toEqual({
+    solAvailable: true,
+    extraHighAvailable: true,
+    proAvailable: false,
+  });
 });
 
 test("Pro selection changes the hidden slider through its visible owner, never through model rows", async () => {

--- a/tests/chatgpt-web-harness.test.ts
+++ b/tests/chatgpt-web-harness.test.ts
@@ -900,6 +900,52 @@ describe("ChatGPT outer-native harness v4", () => {
     sessions.clear();
   });
 
+  test("mid-turn steering retires the superseded revision instead of deadlocking on its tool result", async () => {
+    const sessions = new ChatGptTurnSessions();
+    let settlePhysical!: () => void;
+    const physicalSettlement = new Promise<void>(resolve => { settlePhysical = resolve; });
+    let cancellations = 0;
+    sessions.getOrCreate("old-revision", () => ({
+      mode: "tools",
+      token: new Promise<string>(() => {}),
+      externalProgress: new ChatGptExternalTurnProgress(),
+      browser: new Promise<string>(() => {}),
+      physicalSettlement,
+      trace: new ChatGptTraceFeed(),
+      text: new ChatGptTextFeed(),
+      cancel: () => {
+        cancellations += 1;
+        settlePhysical();
+      },
+    }), "old-trace", "shared-thread", "turn-steered");
+
+    let replacements = 0;
+    const replacement = await sessions.getOrCreateAfterOwnerRetirement(
+      "new-revision",
+      "shared-thread",
+      () => {
+        replacements += 1;
+        return {
+          mode: "read-only" as const,
+          browser: Promise.resolve("replacement"),
+          physicalSettlement: Promise.resolve(),
+          trace: new ChatGptTraceFeed(),
+          text: new ChatGptTextFeed(),
+          cancel: () => {},
+        };
+      },
+      "new-trace",
+      undefined,
+      "turn-steered",
+    );
+
+    expect(replacement.traceId).toBe("new-trace");
+    expect(sessions.find("old-revision")).toBeUndefined();
+    expect(replacements).toBe(1);
+    expect(cancellations).toBe(1);
+    sessions.clear();
+  });
+
   test("retires only the exact active native turn that Codex marked aborted", () => {
     const sessions = new ChatGptTurnSessions();
     const cancelled: string[] = [];
@@ -1554,7 +1600,7 @@ describe("ChatGPT outer-native harness v4", () => {
     expect(response.usage.total_tokens).toBe(usage.totalTokens!);
   });
 
-  test("accepts completion only from the response-scoped final answer action", () => {
+  test("accepts a stopped non-empty response without requiring the final answer action", () => {
     const state = {
       responsePresent: true,
       running: false,
@@ -1563,25 +1609,31 @@ describe("ChatGPT outer-native harness v4", () => {
     };
     expect(chatGptTurnIsComplete(state)).toBe(true);
     expect(chatGptTurnIsComplete({ ...state, responsePresent: false })).toBe(false);
-    expect(chatGptTurnIsComplete({ ...state, completionActionVisible: false })).toBe(false);
+    expect(chatGptTurnIsComplete({ ...state, completionActionVisible: false })).toBe(true);
+    expect(chatGptTurnIsComplete({ ...state, running: true })).toBe(false);
+    expect(chatGptTurnIsComplete({ ...state, currentText: "" })).toBe(false);
   });
 
-  test("requires completed-turn evidence to remain unchanged before accepting it", () => {
+  test("accepts the final answer action immediately and otherwise requires stable stopped output", () => {
     const state = {
       responsePresent: true,
       running: false,
       currentText: "final answer",
       completionActionVisible: true,
     };
+    const actionTracker = new ChatGptCompletionTracker(2_000);
+    expect(actionTracker.update(state, 1_000)).toBe(true);
+
     const tracker = new ChatGptCompletionTracker(2_000);
-    expect(tracker.update(state, 1_000)).toBe(false);
-    expect(tracker.update(state, 2_999)).toBe(false);
-    expect(tracker.update(state, 3_000)).toBe(true);
-    expect(tracker.update({ ...state, currentText: "final answer updated" }, 3_100)).toBe(false);
-    expect(tracker.update({ ...state, currentHtml: "<p>final answer</p>" }, 4_000)).toBe(false);
-    expect(tracker.update({ ...state, currentHtml: "<p>final answer</p><p>hydrated</p>" }, 6_000)).toBe(false);
-    expect(tracker.update({ ...state, currentHtml: "<p>final answer</p><p>hydrated</p>" }, 8_000)).toBe(true);
-    expect(tracker.update({ ...state, running: true }, 8_100)).toBe(false);
+    const withoutAction = { ...state, completionActionVisible: false };
+    expect(tracker.update(withoutAction, 1_000)).toBe(false);
+    expect(tracker.update(withoutAction, 2_999)).toBe(false);
+    expect(tracker.update(withoutAction, 3_000)).toBe(true);
+    expect(tracker.update({ ...withoutAction, currentText: "final answer updated" }, 3_100)).toBe(false);
+    expect(tracker.update({ ...withoutAction, currentHtml: "<p>final answer</p>" }, 4_000)).toBe(false);
+    expect(tracker.update({ ...withoutAction, currentHtml: "<p>final answer</p><p>hydrated</p>" }, 6_000)).toBe(false);
+    expect(tracker.update({ ...withoutAction, currentHtml: "<p>final answer</p><p>hydrated</p>" }, 8_000)).toBe(true);
+    expect(tracker.update({ ...withoutAction, running: true }, 8_100)).toBe(false);
   });
 
   test("preserves GFM formatting while streaming only completed stable DOM blocks", () => {

--- a/tests/chatgpt-web-harness.test.ts
+++ b/tests/chatgpt-web-harness.test.ts
@@ -1387,7 +1387,7 @@ describe("ChatGPT outer-native harness v4", () => {
     sessions.clear();
   });
 
-  test("keeps inline images out of the context JSON and prepares native browser attachments", () => {
+  test("omits inline images from the Web context and prepares no browser attachments", () => {
     const imageUrl = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAE0lEQVR4nGP4z8DwHwwZGP6DAQBJyAn3FGMynQAAAABJRU5ErkJggg==";
     const request = parsed();
     request.context.messages[0]!.content = [
@@ -1396,7 +1396,8 @@ describe("ChatGPT outer-native harness v4", () => {
     ];
     const compiled = compileChatGptWebPrompt(request, toolCapabilities, "turn_123456789012345678901234");
     expect(compiled.text).not.toContain(imageUrl);
-    expect(compiled.text).toContain('"attachment_ref":"codex-input-image-1"');
+    expect(compiled.text).not.toContain('"attachment_ref":"codex-input-image-1"');
+    expect(compiled.text).toContain("image omitted by ChatGPT Web bridge");
     expect(compiled.text).toContain('"version":3');
     expect(compiled.text).toContain("use the attached Codex Native tools directly according to their declared descriptions and schemas");
     expect(compiled.text).toContain("Use actual Codex Native results as evidence");
@@ -1404,10 +1405,8 @@ describe("ChatGPT outer-native harness v4", () => {
     expect(compiled.text.match(/turn_123456789012345678901234/g)).toHaveLength(1);
     expect(compiled.text).not.toContain("codex_bind_turn");
     expect(compiled.text).not.toContain("binding_id");
-    const files = chatGptImageFilePayloads(compiled.images);
-    expect(files[0]?.name).toBe("codex-input-image-1.png");
-    expect(files[0]?.mimeType).toBe("image/png");
-    expect(files[0]?.buffer.length).toBeGreaterThan(0);
+    expect(compiled.images).toEqual([]);
+    expect(chatGptImageFilePayloads(compiled.images)).toEqual([]);
   });
 
   test("keeps only the newest complete Codex model-switch contract", () => {
@@ -1434,7 +1433,7 @@ describe("ChatGPT outer-native harness v4", () => {
     expect(serialized).toContain("current request");
   });
 
-  test("keeps a large context inline and uploads only its referenced images", () => {
+  test("keeps a large context inline without uploading referenced images", () => {
     const imageUrl = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAE0lEQVR4nGP4z8DwHwwZGP6DAQBJyAn3FGMynQAAAABJRU5ErkJggg==";
     const request = parsed();
     request.context.systemPrompt = ["d".repeat(70_000)];
@@ -1447,8 +1446,7 @@ describe("ChatGPT outer-native harness v4", () => {
 
     expect(compiled.text).toContain("d".repeat(70_000));
     expect(compiled.text).toContain("<codex_context_json>");
-    expect(files.map(file => file.name)).toEqual(["codex-input-image-1.png"]);
-    expect(files[0]!.mimeType).toBe("image/png");
+    expect(files).toEqual([]);
   });
 
   test("keeps browser-only Pro context complete without creating a local-tool capability", () => {
@@ -1479,8 +1477,9 @@ describe("ChatGPT outer-native harness v4", () => {
     expect(compiled.text).toContain("web search, browsing, research");
     expect(compiled.text).toContain("prepared workspace evidence");
     expect(compiled.text).toContain('"system":["system-rule","repo-rule"]');
-    expect(compiled.text).toContain('"attachment_ref":"codex-input-image-1"');
-    expect(compiled.images).toHaveLength(1);
+    expect(compiled.text).not.toContain('"attachment_ref":"codex-input-image-1"');
+    expect(compiled.text).toContain("image content is unavailable through this bridge");
+    expect(compiled.images).toHaveLength(0);
     expect(compiled.text).not.toContain("codex_bind_turn");
     expect(compiled.text).not.toContain("turn_token");
     expect(compiled.text).not.toContain("Use the attached Codex Native plugin");
@@ -1515,7 +1514,7 @@ describe("ChatGPT outer-native harness v4", () => {
       { type: "image", imageUrl: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAE0lEQVR4nGP4z8DwHwwZGP6DAQBJyAn3FGMynQAAAABJRU5ErkJggg==", detail: "high" },
     ];
     const imageUsage = estimateChatGptWebUsage(imageRequest, { answer: "done" }, toolCapabilities);
-    expect(imageUsage.inputTokens).toBeGreaterThanOrEqual(textUsage.inputTokens + 3_500);
+    expect(imageUsage.inputTokens - textUsage.inputTokens).toBeLessThan(1_000);
   });
 
   test("keeps the ChatGPT rate-limit dialog distinct from model capacity and UI failures", () => {
@@ -1939,7 +1938,7 @@ describe("ChatGPT outer-native harness v4", () => {
     expect(() => chatGptImageFilePayloads([{
       ref: "codex-input-image-1",
       imageUrl: "https://example.com/image.png",
-    }])).toThrow("inline base64 data URL");
+    }])).toThrow("at most 0 input images per Codex turn");
   });
 
   test("holds an MCP invocation until the outer Codex result arrives", async () => {

--- a/tests/chatgpt-web-models.test.ts
+++ b/tests/chatgpt-web-models.test.ts
@@ -61,6 +61,23 @@ describe("fixed ChatGPT Web model routes", () => {
       .toThrow("Pro is not available for this account");
   });
 
+  test("exposes Extra High independently when a four-step Business picker has no Pro row", () => {
+    const business = {
+      solAvailable: true,
+      extraHighAvailable: true,
+      proAvailable: false,
+    };
+    expect(availableChatGptWebModelRoutes(business).map(route => route.slug)).toEqual([
+      "chatgpt-web/light",
+      "chatgpt-web/medium",
+      "chatgpt-web/high",
+      "chatgpt-web/extra-high",
+    ]);
+    expect(requireChatGptWebModelRoute("chatgpt-web/extra-high", business).adapterEffort).toBe("xhigh");
+    expect(() => requireChatGptWebModelRoute("chatgpt-web/pro", business))
+      .toThrow("Pro is not available for this account");
+  });
+
   test("exposes Luna and Think when the authenticated account has no Sol selector", () => {
     const free = { solAvailable: false, proAvailable: false };
     expect(availableChatGptWebModelRoutes(free)).toEqual(CHATGPT_WEB_LUNA_MODEL_ROUTES);

--- a/tests/codex-interrupt-hook.test.ts
+++ b/tests/codex-interrupt-hook.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import {
+  MANAGED_INTERRUPT_HOOK_END,
   codexInterruptHookCommand,
   codexInterruptHookHash,
   installCodexInterruptHook,
@@ -93,4 +94,27 @@ test("refuses to remove a modified or duplicated managed hook", () => {
   expect(() => restoreCodexInterruptHook(reordered, installed.installed)).toThrow("order changed after setup");
   expect(() => installCodexInterruptHook(installed.text, "/Users/test/.codex/config.toml", { runtimeCommand: ["/opt/runtime"] }))
     .toThrow("already contains");
+});
+
+test("preserves Codex-owned tables appended before the managed hook end marker", () => {
+  const original = 'model = "gpt-5.6-sol"\n';
+  const installed = installCodexInterruptHook(
+    original,
+    "/Users/test/.codex/config.toml",
+    { runtimeCommand: ["/opt/runtime"] },
+  );
+  const codexOwnedTable = [
+    "[tui.model_availability_nux]",
+    "gpt-6-astra = 1",
+    "",
+  ].join("\n");
+  const updatedByCodex = installed.text.replace(
+    MANAGED_INTERRUPT_HOOK_END,
+    `${codexOwnedTable}${MANAGED_INTERRUPT_HOOK_END}`,
+  );
+
+  verifyCodexInterruptHook(updatedByCodex, installed.installed);
+  expect(restoreCodexInterruptHook(updatedByCodex, installed.installed)).toBe(
+    `${original}\n${codexOwnedTable}`,
+  );
 });

--- a/tests/compaction-browser-recovery.test.ts
+++ b/tests/compaction-browser-recovery.test.ts
@@ -16,9 +16,14 @@ test.each([[true, false, true], [false, false, true], [true, true, true], [true,
   const sendBudgets: number[] = [];
   let stage = "";
   let released = false;
-  const page = { evaluate: async () => ({}), isClosed: () => false };
+  const page = {
+    evaluate: async () => ({}),
+    isClosed: () => false,
+    waitForFunction: async () => true,
+  };
   const worker = Object.assign(Object.create(ChatGptBrowserWorker.prototype), {
     config: { appName: "Codex Native2", browserDiagnosticsPath: diagnostics, ...(owned ? { browserHostDescriptorPath: "owned-descriptor" } : {}) },
+    refreshLauncherViewport: async () => {},
     runStage: async (_trace: string, name: string, timeout: number, action: (signal: AbortSignal) => Promise<unknown>) => {
       stage = name;
       if (name === "send" || name.endsWith("_send")) sendBudgets.push(timeout);
@@ -75,7 +80,7 @@ test.each([[true, false, true], [false, false, true], [true, true, true], [true,
     );
     expect(actions).toEqual([
       ...(multipart ? [
-        "effort:low",
+        "effort:medium",
         "attach:plain", "send", "observe", "ack",
         "attach:plain", "send", "observe", "ack",
       ] : []),

--- a/tests/launcher-browser-host.test.ts
+++ b/tests/launcher-browser-host.test.ts
@@ -268,6 +268,7 @@ test("launcher session verification uses the authenticated control channel inste
     const path = descriptorFile(`http://127.0.0.1:${address.port}`);
     expect(await inspectLauncherBrowserHost(path, { detectCapabilities: true })).toEqual({
       solAvailable: true,
+      extraHighAvailable: true,
       proAvailable: true,
       url: "https://chatgpt.com/?temporary-chat=true",
     });

--- a/tests/model-catalog.test.ts
+++ b/tests/model-catalog.test.ts
@@ -7,6 +7,7 @@ import {
   CHATGPT_WEB_ZERO_RISK_MODEL_ROUTE,
   CHATGPT_WEB_ZERO_RISK_PRO_MODEL_ROUTE,
   CHATGPT_WEB_MODEL_ROUTES,
+  availableChatGptWebModelRoutes,
   resolveChatGptWebContextLimits,
 } from "../src/chatgpt-web-models";
 import { augmentNativeModelCatalog } from "../src/model-catalog";
@@ -164,7 +165,7 @@ describe("native /models augmentation", () => {
     const models = second.models as Array<Record<string, unknown>>;
     const web = models.filter(model => String(model.slug).startsWith("chatgpt-web/"));
     expect(web.map(model => model.slug)).toEqual(
-      CHATGPT_WEB_MODEL_ROUTES.filter(route => !route.requiresPro).map(route => route.slug),
+      availableChatGptWebModelRoutes(config).map(route => route.slug),
     );
     expect(web.every(model => model.tool_mode === null)).toBe(true);
     expect(web.every(model => model.multi_agent_version === "v2")).toBe(true);

--- a/tests/prompt-contract.test.ts
+++ b/tests/prompt-contract.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../src/adapters/chatgpt-web/prompt";
 import { CHATGPT_WEB_LUNA_MODEL_ID, CHATGPT_WEB_MODEL_ID } from "../src/adapters/chatgpt-web/model";
 import { biggerContextPartCount } from "../src/adapters/chatgpt-web/usage";
+import { estimateTokens } from "../src/lib/token-estimate";
 import type { CodexParsedRequest } from "../src/types";
 
 function request(reasoning: "low" | "medium" | "high" | "xhigh" | "max"): CodexParsedRequest {
@@ -282,6 +283,39 @@ test("Bigger Context compaction preserves history above the retired inline byte 
   for (let index = 1; index <= 6; index += 1) {
     expect(staged).toContain(`multipart-history-${index}-`);
   }
+});
+
+test("Business Bigger Context trims an oldest record that would exceed one Extra High stage", () => {
+  const compact = request("xhigh");
+  compact._compactionRequest = true;
+  compact.context.systemPrompt = [];
+  const denseHistory = Array.from(
+    { length: 100_000 },
+    (_unused, index) => String.fromCharCode(0x4e00 + (index % 20_000)),
+  ).join("");
+  compact.context.messages = [
+    { role: "user", content: `oversized-oldest-${denseHistory}`, timestamp: 1 },
+    { role: "user", content: "preserve-latest-checkpoint", timestamp: 2 },
+  ];
+
+  const multipart = compileChatGptWebPrompt(
+    compact,
+    { localToolsEnabled: false, solAvailable: true, extraHighAvailable: true, proAvailable: false },
+    undefined,
+    { experimentalMultipartParts: CHATGPT_BIGGER_CONTEXT_PARTS },
+  );
+
+  expect(multipart.trimmedCompactionMessages).toBe(1);
+  expect(multipart.multipart?.parts.join("\n")).not.toContain("oversized-oldest");
+  expect(multipart.multipart?.parts.join("\n")).toContain("preserve-latest-checkpoint");
+  const transactionId = `ctx_${"1".repeat(32)}`;
+  const browserMessages = [
+    ...multipart.multipart!.parts.slice(0, -1).map((payload, index) => (
+      formatChatGptWebMultipartStage(payload, transactionId, index + 1).text
+    )),
+    formatChatGptWebMultipartCommit(multipart.multipart!, transactionId),
+  ];
+  expect(Math.max(...browserMessages.map(message => estimateTokens(message)))).toBeLessThanOrEqual(80_000);
 });
 
 test("Bigger Context minimizes the largest ordered stage instead of overfilling a middle part", () => {

--- a/tests/prompt-contract.test.ts
+++ b/tests/prompt-contract.test.ts
@@ -426,7 +426,7 @@ test("assigns prior assistant output to the model and never attributes Codex con
   expect(compiled.text).toContain("do not attribute, quote, summarize, or otherwise mention them");
 });
 
-test("a long task keeps the newest images and drops the overflow instead of failing", () => {
+test("a long task omits every replayed image instead of uploading screenshots", () => {
   const image = (marker: string) => ({
     type: "image" as const,
     imageUrl: `data:image/png;base64,${marker}`,
@@ -452,15 +452,14 @@ test("a long task keeps the newest images and drops the overflow instead of fail
     "turn_12345678901234567890123456789012",
   );
 
-  expect(compiled.images.map(entry => entry.imageUrl)).toEqual(
-    markers.slice(-10).map(marker => `data:image/png;base64,${marker}`),
-  );
-  expect(compiled.text).toContain("older image not attached");
+  expect(compiled.images).toEqual([]);
+  expect(compiled.text.match(/image omitted by ChatGPT Web bridge/g)).toHaveLength(markers.length);
+  expect(compiled.text).not.toContain("image_attachment");
   expect(compiled.text).toContain("step 1");
   expect(compiled.text).toContain("step 13");
 });
 
-test("Web compaction attaches the newest ten images as files and never embeds their base64 in prompt text", () => {
+test("Web compaction omits every image and never embeds screenshot data in prompt text", () => {
   const imagePayloads = Array.from({ length: 13 }, (_unused, index) =>
     Buffer.from(`compaction-image-${index + 1}`).toString("base64"));
   const parsed: CodexParsedRequest = {
@@ -486,13 +485,11 @@ test("Web compaction attaches the newest ten images as files and never embeds th
     { localToolsEnabled: false, solAvailable: true, proAvailable: true },
   );
 
-  expect(compiled.images.map(image => image.imageUrl)).toEqual(
-    imagePayloads.slice(-10).map(payload => `data:image/png;base64,${payload}`),
-  );
+  expect(compiled.images).toEqual([]);
   expect(compiled.text).not.toContain("data:image");
   for (const payload of imagePayloads) expect(compiled.text).not.toContain(payload);
-  expect(compiled.text.match(/"type":"image_attachment"/g)).toHaveLength(10);
-  expect(compiled.text.match(/older image not attached/g)).toHaveLength(3);
+  expect(compiled.text).not.toContain('"type":"image_attachment"');
+  expect(compiled.text.match(/image omitted by ChatGPT Web bridge/g)).toHaveLength(imagePayloads.length);
 });
 
 test("persisted one-pixel image sentinels are not attached to ChatGPT", () => {
@@ -516,9 +513,9 @@ test("persisted one-pixel image sentinels are not attached to ChatGPT", () => {
 
   const compiled = compileChatGptWebPrompt(parsed, { localToolsEnabled: false, solAvailable: true, proAvailable: true });
 
-  expect(compiled.images.map(image => image.imageUrl)).toEqual(["data:image/png;base64,real-image"]);
-  expect(compiled.text.match(/"type":"image_attachment"/g)).toHaveLength(1);
-  expect(compiled.text).not.toContain("older image not attached");
+  expect(compiled.images).toEqual([]);
+  expect(compiled.text).not.toContain('"type":"image_attachment"');
+  expect(compiled.text).toContain("image omitted by ChatGPT Web bridge");
 });
 
 test("the replayed context never carries a finished turn's broker handles", () => {

--- a/tests/zero-risk-adapter.test.ts
+++ b/tests/zero-risk-adapter.test.ts
@@ -356,11 +356,11 @@ test("Zero Risk keeps image handoff manual and says so in the paste instruction"
       { headers: new Headers() },
       event => events.push(event),
     );
-    expect(manualPrompt).toContain('"type":"image_attachment"');
-    expect(manualPrompt).toContain("image the user manually attached to this ChatGPT message");
+    expect(manualPrompt).not.toContain('"type":"image_attachment"');
+    expect(manualPrompt).toContain("Images from the replayed Codex context are intentionally omitted");
     expect(events.some(event => event.type === "text_delta"
       && event.phase === "commentary"
-      && event.text.includes("add any images yourself because Zero Risk cannot transfer them"))).toBeTrue();
+      && event.text.includes("Images from the Codex context are intentionally omitted"))).toBeTrue();
     expect(events.filter((event): event is Extract<AdapterEvent, { type: "text_delta" }> => (
       event.type === "text_delta" && event.phase === "final_answer"
     )).map(event => event.text).join(""))


### PR DESCRIPTION
## Summary

- separate Business Extra High capability from Pro and migrate existing configurations safely
- keep authenticated same-origin ChatGPT session refreshes and hidden launcher viewports operational
- make completion tolerant of ChatGPT action-row changes without truncating tool loops
- prevent preparation failures from publishing immediately revoked turn tokens
- trim oversized multipart compaction history before browser submission
- retire superseded same-turn revisions without deadlocking outstanding tools
- force rejected long-held Windows broker pipes to close after their response is flushed
- recover a refreshed same-version Windows runtime beside a locked Bun bundle, then let the supervisor retire the stale owner
- preserve Codex-owned configuration tables appended inside the managed interrupt-hook markers while still rejecting changed, duplicated, or reordered hook data

## Verification

- `node ./node_modules/typescript/bin/tsc --noEmit`
- `bun test --only-failures ./tests` (657 passed, 0 failed)
- `bun run --cwd launcher test` (283 passed, 0 failed, 2 platform skips)
- `bun run --cwd launcher build`
- `bun run build && bun run smoke` (`RELOCATABLE_RUNTIME_SMOKE_OK`)
- Windows packaged launcher smoke (`PACKAGED_LAUNCHER_SMOKE_OK win32/x64`)
- installed, durable, and source runtime hashes match after deployment
- installed route reports active with no errors; both `127.0.0.1:18417` and the managed `127.0.0.1:17841` bridge are healthy
- a deliberately incomplete `/v1/responses` request traverses the unified route and returns the bridge's expected validation error
- launcher connector verification confirms `Codex Native2` is available in the authenticated ChatGPT workspace without submitting a model turn