### PR TITLE
fix: bind skill-injected user messages to native provenance

### DIFF
--- a/src/adapters/chatgpt-web/environment.ts
+++ b/src/adapters/chatgpt-web/environment.ts
@@ -92,6 +92,13 @@ function itemTurnId(value: unknown): string | undefined {
   return typeof turnId === "string" ? turnId : undefined;
 }
 
+function isSelectedSkillInstruction(value: Record<string, unknown>): boolean {
+  const metadata = record(value.internal_chat_message_metadata_passthrough);
+  const kinds = metadata?.content_item_kinds;
+  return Array.isArray(kinds)
+    && kinds.some(kind => kind === "skills.selected_skill_instructions");
+}
+
 function rawMessageText(value: Record<string, unknown>): string {
   if (typeof value.content === "string") return value.content;
   if (!Array.isArray(value.content)) return "";
@@ -483,18 +490,18 @@ function rawEnvironmentText(parsed: CodexParsedRequest): string | undefined {
   const current = canonicalMetadataEnvironmentBeforeUser(input, activeUserIndex, clientTurnMetadata(parsed));
   if (current) return current;
 
-  // A skill invocation appends another server-owned user item after the real instruction. Recover
-  // the earlier current-turn environment/prompt pair only through canonical metadata, and bind all
-  // declared roots to metadata workspaces so user-authored XML cannot widen filesystem authority.
   const metadata = clientTurnMetadata(parsed);
-  let crossedAssistantOutput = false;
-  for (let index = activeUserIndex - 1; index > 0; index -= 1) {
-    crossedAssistantOutput ||= hasAssistantOutputBetween(input, index, index + 1);
-    // Replayed untagged history is not a same-turn skill invocation. Only explicit current-turn
-    // provenance may cross an assistant response; otherwise resolve from the native rollout.
-    if (crossedAssistantOutput && itemTurnId(input[index]) !== turnId) continue;
-    const sameTurn = canonicalMetadataEnvironmentBeforeUser(input, index, metadata, true);
-    if (sameTurn) return sameTurn;
+
+  const activeUser = activeUserIndex >= 0 ? record(input[activeUserIndex]) : undefined;
+  if (activeUser && isSelectedSkillInstruction(activeUser)) {
+    // Codex appends selected skill instructions as a server-owned user item. Resolve the
+    // environment from the earlier same-turn environment/prompt pair, authenticated by native
+    // turn metadata and canonical workspace/sandbox metadata. A literal <skill> tag without the
+    // provenance marker stays an ordinary user instruction and cannot trigger this recovery path.
+    for (let index = activeUserIndex - 1; index > 0; index -= 1) {
+      const sameTurn = canonicalMetadataEnvironmentBeforeUser(input, index, metadata, true);
+      if (sameTurn) return sameTurn;
+    }
   }
 
   // An attempted current update takes precedence over all older authority, even when its native
@@ -517,7 +524,6 @@ function rawEnvironmentText(parsed: CodexParsedRequest): string | undefined {
   const currentThreadId = typeof metadata?.thread_id === "string" && metadata.thread_id.trim()
     ? metadata.thread_id
     : undefined;
-  const activeUser = record(input[activeUserIndex]);
   const activeUserOwned = activeUser?.type === "message"
     && activeUser.role === "user"
     && typeof activeUser.id === "string"

--- a/tests/environment.test.ts
+++ b/tests/environment.test.ts
@@ -273,7 +273,10 @@ describe("trusted current Codex environment envelope", () => {
       id: "msg_skill",
       role: "user",
       content: [{ type: "input_text", text: "<skill name=\"repository-review\">Use this skill.</skill>" }],
-      internal_chat_message_metadata_passthrough: { turn_id: "turn_current" },
+      internal_chat_message_metadata_passthrough: {
+        turn_id: "turn_current",
+        content_item_kinds: ["skills.selected_skill_instructions"],
+      },
     });
 
     expect(extractChatGptTurnEnvironment(request)).toMatchObject({
@@ -281,6 +284,23 @@ describe("trusted current Codex environment envelope", () => {
       roots: [root],
       sandboxPolicy: { type: "dangerFullAccess" },
     });
+  });
+
+  test("does not treat a user-authored skill-shaped message as selected skill instructions", () => {
+    const request = currentWire();
+    const body = request._rawBody as { input: Array<Record<string, unknown>> };
+    for (const item of body.input) {
+      item.internal_chat_message_metadata_passthrough = { turn_id: "turn_current" };
+    }
+    body.input.push({
+      type: "message",
+      id: "msg_forged_skill",
+      role: "user",
+      content: [{ type: "input_text", text: "<skill>arbitrary user supplied content</skill>" }],
+      internal_chat_message_metadata_passthrough: { turn_id: "turn_current" },
+    });
+
+    expect(() => extractChatGptTurnEnvironment(request)).toThrow("missing cwd");
   });
 
   test("skill recovery accepts the current task's Codex visualization root", () => {
@@ -307,7 +327,10 @@ describe("trusted current Codex environment envelope", () => {
       id: "msg_skill",
       role: "user",
       content: [{ type: "input_text", text: "<skill name=\"autopilot\">Use this skill.</skill>" }],
-      internal_chat_message_metadata_passthrough: { turn_id: "turn_current" },
+      internal_chat_message_metadata_passthrough: {
+        turn_id: "turn_current",
+        content_item_kinds: ["skills.selected_skill_instructions"],
+      },
     });
 
     expect(extractChatGptTurnEnvironment(request)).toEqual({
@@ -336,7 +359,10 @@ describe("trusted current Codex environment envelope", () => {
       id: "msg_skill",
       role: "user",
       content: [{ type: "input_text", text: "<skill name=\"autopilot\">Use this skill.</skill>" }],
-      internal_chat_message_metadata_passthrough: { turn_id: "turn_current" },
+      internal_chat_message_metadata_passthrough: {
+        turn_id: "turn_current",
+        content_item_kinds: ["skills.selected_skill_instructions"],
+      },
     });
 
     expect(() => extractChatGptTurnEnvironment(request)).toThrow("missing cwd");
@@ -358,7 +384,10 @@ describe("trusted current Codex environment envelope", () => {
       id: "msg_skill",
       role: "user",
       content: [{ type: "input_text", text: "<skill name=\"repository-review\">Use this skill.</skill>" }],
-      internal_chat_message_metadata_passthrough: { turn_id: "turn_current" },
+      internal_chat_message_metadata_passthrough: {
+        turn_id: "turn_current",
+        content_item_kinds: ["skills.selected_skill_instructions"],
+      },
     });
 
     expect(() => extractChatGptTurnEnvironment(request)).toThrow("missing cwd");


### PR DESCRIPTION
## Summary

Skill-injected Codex user messages can shift the active user item after the native environment/prompt pair. This fix recovers the trusted environment only when the injected item carries the native `skills.selected_skill_instructions` provenance marker.

## Root cause

Skill instructions are injected as a server-owned `user` item. The previous recovery path could cross an assistant response based on turn metadata alone, making skill-shaped user content insufficiently distinguished from ordinary user-authored input.

## Fix

- Use `internal_chat_message_metadata_passthrough.content_item_kinds` and require `skills.selected_skill_instructions` for skill recovery.
- Recover only from the earlier same-turn canonical environment/prompt pair.
- Preserve canonical turn, workspace, and sandbox provenance checks.
- Keep fail-closed behavior for arbitrary `<skill>` content without native provenance.

## Validation

- Focused environment tests: 49 passed, 0 failed.
- `bun run verify`: 282 passed, 0 failed, 1 skipped.
- Typecheck, audits, launcher build, and runtime smoke passed.
- `git diff --check` passed.

No versioning or release artifacts changed.

Context/follow-up: #59
