### PR TITLE
fix(chatgpt-web): recover V1 subagents with null agent paths

### DIFF
--- a/src/adapters/chatgpt-web/codex-rollout-environment.ts
+++ b/src/adapters/chatgpt-web/codex-rollout-environment.ts
@@ -50,6 +50,10 @@ function contains(root: string, path: string): boolean {
   return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
 }
 
+function matchesAgentPath(value: unknown, expected?: string): boolean {
+  return expected === undefined ? value == null : value === expected;
+}
+
 function canonicalRolloutName(name: string, threadId: string): boolean {
   const escapedThreadId = threadId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   return new RegExp(
@@ -102,7 +106,8 @@ function indexedRollout(
     if (!row) return { kind: "absent" };
     const child = "parentThreadId" in identity;
     const matchesOwner = child
-      ? row.agent_path === identity.agentName && row.parent_thread_id === identity.parentThreadId && row.status === "open"
+      ? matchesAgentPath(row.agent_path, identity.agentName)
+        && row.parent_thread_id === identity.parentThreadId && row.status === "open"
       : row.parent_thread_id == null && (row.agent_path == null || row.agent_path === "/root");
     if (typeof row.rollout_path !== "string" || !matchesOwner) {
       throw new Error(`Codex state does not authenticate the requested ${child ? "subagent" : "root thread"} rollout`);
@@ -249,10 +254,10 @@ function validateSessionMeta(
   if (item.type !== "session_meta"
     || payload?.id !== lineage.threadId
     || payload.parent_thread_id !== lineage.parentThreadId
-    || payload.agent_path !== lineage.agentName
+    || !matchesAgentPath(payload.agent_path, lineage.agentName)
     || payload.thread_source !== "subagent"
     || spawn?.parent_thread_id !== lineage.parentThreadId
-    || spawn.agent_path !== lineage.agentName) {
+    || !matchesAgentPath(spawn.agent_path, lineage.agentName)) {
     throw new Error("Codex rollout session metadata does not authenticate the requested subagent");
   }
 }

--- a/src/adapters/chatgpt-web/codex-rollout-environment.ts
+++ b/src/adapters/chatgpt-web/codex-rollout-environment.ts
@@ -50,8 +50,9 @@ function contains(root: string, path: string): boolean {
   return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
 }
 
-function matchesAgentPath(value: unknown, expected?: string): boolean {
-  return expected === undefined ? value == null : value === expected;
+function matchesAgentPath(value: unknown, expected: string): boolean {
+  // V1 reports /root without an assigned path; rollout metadata can omit the field.
+  return expected === "/root" ? value == null : value === expected;
 }
 
 function canonicalRolloutName(name: string, threadId: string): boolean {

--- a/src/adapters/chatgpt-web/environment.ts
+++ b/src/adapters/chatgpt-web/environment.ts
@@ -29,7 +29,7 @@ export interface ChatGptTurnIdentity {
 export interface ChatGptThreadSpawnLineage {
   threadId: string;
   parentThreadId: string;
-  agentName: string;
+  agentName?: string;
   sandboxType: ChatGptSandboxPolicy["type"];
   workspaceRoots: string[];
 }
@@ -705,7 +705,7 @@ export function extractCodexTurnIdentityFromBody(value: unknown): ChatGptTurnIde
 /**
  * Return the canonical parent link carried by a native Codex thread-spawn request.
  * This is deliberately stricter than generic metadata parsing: only a real child turn with an
- * agent path, explicit turn purpose, sandbox policy, and absolute workspace evidence can inherit
+ * optional native agent path, explicit turn purpose, sandbox policy, and absolute workspace evidence can inherit
  * filesystem authority from a previously verified parent thread.
  */
 export function extractChatGptThreadSpawnLineage(
@@ -715,8 +715,16 @@ export function extractChatGptThreadSpawnLineage(
   if (!metadata || !isEnvironmentRequest(metadata, parsed) || metadata.subagent_kind !== "thread_spawn") return undefined;
   const threadId = typeof metadata.thread_id === "string" ? metadata.thread_id.trim() : "";
   const parentThreadId = typeof metadata.parent_thread_id === "string" ? metadata.parent_thread_id.trim() : "";
-  const agentName = typeof metadata.agent_name === "string" ? metadata.agent_name.trim() : "";
-  if (!threadId || !parentThreadId || threadId === parentThreadId || !/^\/root\/.+/.test(agentName)) return undefined;
+  let agentName: string | undefined;
+  if (metadata.agent_name != null) {
+    if (typeof metadata.agent_name !== "string") return undefined;
+    const candidate = metadata.agent_name.trim();
+    if (candidate !== "/root") {
+      if (!/^\/root\/.+/.test(candidate)) return undefined;
+      agentName = candidate;
+    }
+  }
+  if (!threadId || !parentThreadId || threadId === parentThreadId) return undefined;
 
   const sandboxType = sandboxTypeFromMetadata(canonicalSandboxMetadata(metadata));
   if (!sandboxType || sandboxType === "platform") return undefined;
@@ -724,7 +732,7 @@ export function extractChatGptThreadSpawnLineage(
   const workspacePaths = workspaces ? Object.keys(workspaces) : [];
   if (workspacePaths.some(path => !isAbsolute(path))) return undefined;
   const workspaceRoots = [...new Set(workspacePaths.map(path => resolve(path)))];
-  return { threadId, parentThreadId, agentName, sandboxType, workspaceRoots };
+  return { threadId, parentThreadId, ...(agentName ? { agentName } : {}), sandboxType, workspaceRoots };
 }
 
 /** Root tasks have no spawn edge; their canonical session and current turn must prove authority. */

--- a/src/adapters/chatgpt-web/environment.ts
+++ b/src/adapters/chatgpt-web/environment.ts
@@ -29,7 +29,7 @@ export interface ChatGptTurnIdentity {
 export interface ChatGptThreadSpawnLineage {
   threadId: string;
   parentThreadId: string;
-  agentName?: string;
+  agentName: string;
   sandboxType: ChatGptSandboxPolicy["type"];
   workspaceRoots: string[];
 }
@@ -705,7 +705,7 @@ export function extractCodexTurnIdentityFromBody(value: unknown): ChatGptTurnIde
 /**
  * Return the canonical parent link carried by a native Codex thread-spawn request.
  * This is deliberately stricter than generic metadata parsing: only a real child turn with an
- * optional native agent path, explicit turn purpose, sandbox policy, and absolute workspace evidence can inherit
+ * agent name, explicit turn purpose, sandbox policy, and absolute workspace evidence can inherit
  * filesystem authority from a previously verified parent thread.
  */
 export function extractChatGptThreadSpawnLineage(
@@ -715,16 +715,9 @@ export function extractChatGptThreadSpawnLineage(
   if (!metadata || !isEnvironmentRequest(metadata, parsed) || metadata.subagent_kind !== "thread_spawn") return undefined;
   const threadId = typeof metadata.thread_id === "string" ? metadata.thread_id.trim() : "";
   const parentThreadId = typeof metadata.parent_thread_id === "string" ? metadata.parent_thread_id.trim() : "";
-  let agentName: string | undefined;
-  if (metadata.agent_name != null) {
-    if (typeof metadata.agent_name !== "string") return undefined;
-    const candidate = metadata.agent_name.trim();
-    if (candidate !== "/root") {
-      if (!/^\/root\/.+/.test(candidate)) return undefined;
-      agentName = candidate;
-    }
-  }
-  if (!threadId || !parentThreadId || threadId === parentThreadId) return undefined;
+  const agentName = typeof metadata.agent_name === "string" ? metadata.agent_name.trim() : "";
+  if (!threadId || !parentThreadId || threadId === parentThreadId
+    || (agentName !== "/root" && !/^\/root\/.+/.test(agentName))) return undefined;
 
   const sandboxType = sandboxTypeFromMetadata(canonicalSandboxMetadata(metadata));
   if (!sandboxType || sandboxType === "platform") return undefined;
@@ -732,7 +725,7 @@ export function extractChatGptThreadSpawnLineage(
   const workspacePaths = workspaces ? Object.keys(workspaces) : [];
   if (workspacePaths.some(path => !isAbsolute(path))) return undefined;
   const workspaceRoots = [...new Set(workspacePaths.map(path => resolve(path)))];
-  return { threadId, parentThreadId, ...(agentName ? { agentName } : {}), sandboxType, workspaceRoots };
+  return { threadId, parentThreadId, agentName, sandboxType, workspaceRoots };
 }
 
 /** Root tasks have no spawn edge; their canonical session and current turn must prove authority. */

--- a/tests/environment.test.ts
+++ b/tests/environment.test.ts
@@ -659,6 +659,13 @@ describe("trusted Codex task environment continuity", () => {
     metadata.subagent_kind = "other";
     (child._rawBody as { client_metadata: Record<string, string> }).client_metadata["x-codex-turn-metadata"] = JSON.stringify(metadata);
     expect(() => store.resolve(child)).toThrow("missing cwd");
+
+    for (const agent_name of [null, undefined]) {
+      (child._rawBody as { client_metadata: Record<string, string> }).client_metadata["x-codex-turn-metadata"] = JSON.stringify({
+        ...metadata, subagent_kind: "thread_spawn", agent_name,
+      });
+      expect(() => store.resolve(child)).toThrow("missing cwd");
+    }
   });
 
   const rolloutThreadId = "01a06c66-4232-7ae1-9108-69b5f70e0671";
@@ -883,7 +890,7 @@ describe("trusted Codex task environment continuity", () => {
       .toThrow("does not authenticate");
   });
 
-  test("recovers a V1 native child whose agent path is null and agent name is /root", () => {
+  test.each([null, undefined])("recovers a V1 native child with session agent_path=%s and agent name /root", agentPath => {
     const codexHome = mkdtempSync(join(tmpdir(), "codex-chatgpt-null-agent-path-"));
     temporaryRoots.push(codexHome);
     const rolloutPath = join(codexHome, "sessions", "2026", "09", "06",
@@ -891,7 +898,7 @@ describe("trusted Codex task environment continuity", () => {
     mkdirSync(dirname(rolloutPath), { recursive: true });
     const session = childSessionMeta();
     const payload = session.payload as Record<string, unknown>;
-    payload.agent_path = null;
+    payload.agent_path = agentPath;
     const spawn = ((payload.source as Record<string, unknown>).subagent as Record<string, unknown>)
       .thread_spawn as Record<string, unknown>;
     spawn.agent_path = null;

--- a/tests/environment.test.ts
+++ b/tests/environment.test.ts
@@ -883,6 +883,48 @@ describe("trusted Codex task environment continuity", () => {
       .toThrow("does not authenticate");
   });
 
+  test("recovers a V1 native child whose agent path is null and agent name is /root", () => {
+    const codexHome = mkdtempSync(join(tmpdir(), "codex-chatgpt-null-agent-path-"));
+    temporaryRoots.push(codexHome);
+    const rolloutPath = join(codexHome, "sessions", "2026", "09", "06",
+      `rollout-2026-09-06T13-55-13-${rolloutThreadId}.jsonl`);
+    mkdirSync(dirname(rolloutPath), { recursive: true });
+    const session = childSessionMeta();
+    const payload = session.payload as Record<string, unknown>;
+    payload.agent_path = null;
+    const spawn = ((payload.source as Record<string, unknown>).subagent as Record<string, unknown>)
+      .thread_spawn as Record<string, unknown>;
+    spawn.agent_path = null;
+    writeFileSync(rolloutPath, [JSON.stringify(session), JSON.stringify(childTurnContext())].join("\n") + "\n");
+    createRolloutState(join(codexHome, "state_5.sqlite"), rolloutPath);
+    const database = new Database(join(codexHome, "state_5.sqlite"));
+    database.query("UPDATE threads SET agent_path = NULL WHERE id = ?").run(rolloutThreadId);
+    database.close();
+
+    const request = environmentlessChild();
+    const body = request._rawBody as { client_metadata: Record<string, string> };
+    const metadata = JSON.parse(body.client_metadata["x-codex-turn-metadata"]!);
+    metadata.agent_name = "/root";
+    body.client_metadata["x-codex-turn-metadata"] = JSON.stringify(metadata);
+
+    expect(new ChatGptThreadEnvironmentStore(undefined, Date.now, codexHome).resolve(request).cwd).toBe(root);
+
+    const databaseWithWrongOwner = new Database(join(codexHome, "state_5.sqlite"));
+    databaseWithWrongOwner.query("UPDATE threads SET agent_path = ? WHERE id = ?")
+      .run(rolloutAgent, rolloutThreadId);
+    databaseWithWrongOwner.close();
+    expect(() => new ChatGptThreadEnvironmentStore(undefined, Date.now, codexHome).resolve(request))
+      .toThrow("does not authenticate");
+
+    const databaseWithNullOwner = new Database(join(codexHome, "state_5.sqlite"));
+    databaseWithNullOwner.query("UPDATE threads SET agent_path = NULL WHERE id = ?").run(rolloutThreadId);
+    databaseWithNullOwner.close();
+    spawn.agent_path = rolloutAgent;
+    writeFileSync(rolloutPath, [JSON.stringify(session), JSON.stringify(childTurnContext())].join("\n") + "\n");
+    expect(() => new ChatGptThreadEnvironmentStore(undefined, Date.now, codexHome).resolve(request))
+      .toThrow("session metadata");
+  });
+
   test("compaction authenticates the latest native turn as current or source, never an arbitrary ancestor", () => {
     const { codexHome, request, rolloutPath } = resumedRootFixture();
     request._compactionRequest = true;


### PR DESCRIPTION
Fixes the V1 `spawn_agent` compatibility case behind #314.

Codex 0.153.4 can create V1 thread-spawn children with `agent_path = null` while Responses metadata carries `agent_name = \"/root\"`. The existing child-lineage check required `agent_name` to match `/root/...`, so this V1 sentinel was rejected before canonical rollout recovery could run. That could surface as `ChatGPT web turn is missing cwd in trusted Codex environment context` even though the matching child rollout contained a valid cwd and workspace roots.

This change treats `/root` as the no-concrete-agent-path sentinel, while preserving provenance checks for the exact child thread, parent thread, open spawn edge, current turn, workspace/sandbox authority, and null agent path consistency across SQLite and rollout session metadata. Concrete `/root/<agent>` paths still require exact equality.

Regression coverage reproduces the Codex 0.153.4 V1 shape and verifies mismatched non-null agent paths are rejected.

Validation:
- `bun test tests/environment.test.ts`: 49 pass, 0 fail
- `bunx tsc --noEmit`: pass
- `git diff --check`: pass

Fixes #314.