### PR TITLE
fix: stop submitted generation on abort

### DIFF
--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -2700,7 +2700,11 @@ export class ChatGptBrowserWorker {
       Date.now() + graceMs,
     );
     for (;;) {
-      if (signal?.aborted) throw new DOMException("ChatGPT web turn aborted", "AbortError");
+      if (signal?.aborted) {
+        const stop = observationPage.locator(CHATGPT_STOP_BUTTON_SELECTOR).last();
+        if (await stop.isVisible().catch(() => false)) await stop.press("Enter").catch(() => {});
+        throw new DOMException("ChatGPT web turn aborted", "AbortError");
+      }
       if (observationPage.isClosed()) throw chatGptBrowserTabClosedError();
       let progress = externalProgress?.snapshot();
       if (progress?.lastProgressAt !== undefined) {
@@ -2722,6 +2726,11 @@ export class ChatGptBrowserWorker {
           signal,
         );
       } catch (error) {
+        if (signal?.aborted) {
+          const stop = observationPage.locator(CHATGPT_STOP_BUTTON_SELECTOR).last();
+          if (await stop.isVisible().catch(() => false)) await stop.press("Enter").catch(() => {});
+          throw new DOMException("ChatGPT web turn aborted", "AbortError");
+        }
         const latestProgress = externalProgress?.snapshot();
         if (error instanceof ChatGptBrowserObservationTimeoutError && recoverObservation) {
           recoveryAttempts += 1;

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -759,6 +759,52 @@ test("an accepted turn rebinds the missing assistant observation and acknowledge
   }
 });
 
+test("aborting after submission acceptance stops generation before assistant binding", async () => {
+  type Baseline = { initialResponseTurnIdentities: string[]; domCache: Record<string, unknown> };
+  const controller = new AbortController();
+  let stopPresses = 0;
+  const stop = {
+    filter() { return this; },
+    last() { return this; },
+    isVisible: async () => true,
+    press: async (key: string) => {
+      expect(key).toBe("Enter");
+      stopPresses += 1;
+    },
+  };
+  const page = {
+    isClosed: () => false,
+    locator: (selector: string) => selector === '[data-testid="stop-button"]'
+      ? stop
+      : { filter() { return this; }, last() { return this; }, isVisible: async () => false },
+  } as unknown as Page;
+  const worker = ChatGptBrowserWorker.forProvider({
+    adapter: "chatgpt-web",
+    baseUrl: `browser://accepted-abort-${Date.now()}-${Math.random()}`,
+    chatgptWeb: { localToolsEnabled: true, solAvailable: true, proAvailable: true },
+  }) as unknown as {
+    waitForNewAssistantTurn(
+      page: Page,
+      baseline: Baseline,
+      deadline: number | undefined,
+      signal?: AbortSignal,
+    ): Promise<unknown>;
+    submissionDomState(): Promise<never>;
+  };
+  worker.submissionDomState = async () => {
+    controller.abort();
+    throw new DOMException("ChatGPT prompt attachment aborted", "AbortError");
+  };
+
+  await expect(worker.waitForNewAssistantTurn(
+    page,
+    { initialResponseTurnIdentities: [], domCache: {} },
+    undefined,
+    controller.signal,
+  )).rejects.toMatchObject({ name: "AbortError", message: "ChatGPT web turn aborted" });
+  expect(stopPresses).toBe(1);
+});
+
 test("missing-assistant expiry checks fresh DOM after a delayed wake while preserving the turn deadline", async () => {
   type Baseline = { initialResponseTurnIdentities: string[]; domCache: Record<string, unknown> };
   type State = { userIdentities: string[]; responseIdentities: string[] };


### PR DESCRIPTION
## What this changes

Stop an active ChatGPT generation when a Full-harness browser turn is aborted after submission acceptance but before the assistant turn has been bound.

The worker now uses the existing ChatGPT stop-button selector before returning the normalized `ChatGPT web turn aborted` error from both abort boundaries in `waitForNewAssistantTurn`. This prevents the launcher from releasing the tab and retiring its turn-bound MCP capability while the already-submitted server-side generation continues running.

No selector, model, route, effort, connector, capability, or Browser-only behavior is changed.

Fixes #339

## Evidence

Before the change, the regression fixture aborts assistant-turn binding after submission acceptance and returns without activating the visible ChatGPT stop control. This matches the reported lifecycle: submission was accepted, the local turn aborted and retired its capability, and the submitted generation later issued claims against that retired binding.

After the change, the same fixture proves that the existing stop control receives `Enter` exactly once before the normalized abort reaches the caller. The focused regression test fails on unmodified v5.0.4 and passes with this change.

The change was packaged and installed into a real macOS ARM64 Codex integration. The installed runtime checksum matched the locally built runtime, `doctor` reported ready, and the affected Full-harness route successfully executed local `gh` commands in fresh Codex CLI sessions. A later repetition was blocked by the upstream ChatGPT account rate limit after five native retries; it did not expose a packaging, broker, tunnel, or local-command failure.

## Scope and invariants

- [x] I read and followed `CONTRIBUTING.md`.
- [x] This is a small, focused change with no unrelated cleanup or generated rewrite.
- [x] The change stays focused on ChatGPT web-backed Codex models; it does not add a generic provider or unrelated product surface.
- [x] Model, route, effort, connector, and capability selection remain explicit with no silent fallback or false-success path.
- [x] If this touches Full harness or MCP, every available Web effort retains the same turn-bound capability and Browser-only gains no broker or connector.
- [x] Terms and trademark claims remain factual; this change is not marketed as a quota or rate-limit bypass.

## Verification

- [x] I ran `bun install --frozen-lockfile` in the repository root and `launcher/`.
- [x] I ran `bun run verify` with the Bun version pinned by `package.json`.
- [x] I added or updated a focused regression test for behavior changes.
- [x] I manually tested the affected behavior.
- [x] If this changes local tools, MCP execution, or the outer Codex agent loop, I tested it through a real installed Codex integration; DEV mode alone is acceptable only when execution is not affected.
- [x] If this changes ChatGPT browser UI handling, I included observed DOM evidence and a reproducible fixture instead of broadening selectors speculatively.
- [x] If this changes the launcher, I preserved macOS, Windows, and Linux packaging and named the platform packages actually built below.
- [x] I did not commit browser state, credentials, Tunnel IDs, raw logs, generated artifacts, or private paths.
- [x] I did not include an unrelated dependency update, release artifact, or version change.

`bun run verify` completed successfully with Bun 1.4.0:

```text
Root tests:      656 passed, 0 failed
Launcher tests:  282 passed, 0 failed, 1 skipped
Root audit:       no vulnerabilities
Launcher audit:   no vulnerabilities
TypeScript:       passed
Launcher build:   passed
Runtime smoke:    RELOCATABLE_RUNTIME_SMOKE_OK
git diff --check: passed
```

## Platform or account validation

- Platform: macOS 15.7.1 ARM64
- ChatGPT account: Pro
- Integration mode: Full harness with Codex Native MCP
- Model exercised: `chatgpt-web/extra-high`
- Codex CLI: 0.153.4
- Base version: Codex Web GPT 5.0.4
- macOS ARM64 package: built, installed, and checksum-verified
- Browser-only mode: not run; code path unchanged
- Windows package: not built
- Linux package: not built
