### PR TITLE
launcher: localize connector diagnostics in Japanese

### DIFF
--- a/launcher/src/App.tsx
+++ b/launcher/src/App.tsx
@@ -9,7 +9,7 @@ import {
   type ReactNode,
 } from "react";
 import { createPortal } from "react-dom";
-import { copyFor, type Copy } from "./i18n";
+import { copyFor, localizeRuntimeMessage, type Copy } from "./i18n";
 import { Icon, type IconName } from "./icons";
 import type {
   BrowserInteractionMode,
@@ -1517,7 +1517,7 @@ function McpSurface({
             >
               {busy
                 ? operation?.name === "mcp-verification" && operation.status === "running"
-                  ? operation.message
+                  ? localizeRuntimeMessage(copy, operation.message)
                   : copy.running
                 : verified ? copy.done : copy.verifyRuntime}
             </PrimaryButton>
@@ -2142,7 +2142,7 @@ function DoctorSummary({ copy, report }: { copy: Copy; report: DoctorReport }) {
         {visibleChecks.map((check) => (
           <p key={check.id}>
             <StateDot state={check.status === "ok" ? "ready" : check.status === "warning" ? "busy" : "error"} />
-            <span>{check.message}</span>
+            <span>{localizeRuntimeMessage(copy, check.message, check.id)}</span>
           </p>
         ))}
       </div>

--- a/launcher/src/i18n.ts
+++ b/launcher/src/i18n.ts
@@ -137,6 +137,13 @@ const en = {
   openConnectors: "Open ChatGPT Plugins",
   connectorName: "Connector name",
   verifyRuntime: "Verify runtime",
+  checkingChatGptConnector: "Checking ChatGPT connector",
+  doctorProxyHealthy: "Responses proxy is healthy on {endpoint}",
+  doctorTunnelBinaryInstalled: "Pinned openai/tunnel-client binary is installed",
+  doctorTunnelKeyStored: "Tunnel runtime key is stored privately",
+  doctorTunnelRuntimeOwned: "Launcher owns the tunnel runtime",
+  doctorTunnelRuntimeReady: "Tunnel runtime reports healthy and ready",
+  doctorConnectorAvailable: "ChatGPT connector \"{name}\" is available",
   activityTitle: "Runtime activity",
   activitySubtitle: "Local diagnostics. Export a privacy-safe copy before sharing; raw logs stay on this device.",
   recentActivity: "Recent events",
@@ -322,6 +329,13 @@ const zh: Record<keyof typeof en, string> = {
   openConnectors: "打开 ChatGPT Plugins",
   connectorName: "连接器名称",
   verifyRuntime: "验证运行时",
+  checkingChatGptConnector: "Checking ChatGPT connector",
+  doctorProxyHealthy: "Responses proxy is healthy on {endpoint}",
+  doctorTunnelBinaryInstalled: "Pinned openai/tunnel-client binary is installed",
+  doctorTunnelKeyStored: "Tunnel runtime key is stored privately",
+  doctorTunnelRuntimeOwned: "Launcher owns the tunnel runtime",
+  doctorTunnelRuntimeReady: "Tunnel runtime reports healthy and ready",
+  doctorConnectorAvailable: "ChatGPT connector \"{name}\" is available",
   activityTitle: "运行时活动",
   activitySubtitle: "本地诊断。分享前请导出隐私安全副本；原始日志仅保留在此设备上。",
   recentActivity: "最近事件",
@@ -507,6 +521,13 @@ const ja: Record<keyof typeof en, string> = {
   openConnectors: "ChatGPT Plugins を開く",
   connectorName: "コネクタ名",
   verifyRuntime: "ランタイムを検証",
+  checkingChatGptConnector: "ChatGPT コネクタを確認中",
+  doctorProxyHealthy: "Responses プロキシは {endpoint} で正常に動作しています",
+  doctorTunnelBinaryInstalled: "固定バージョンの openai/tunnel-client バイナリがインストールされています",
+  doctorTunnelKeyStored: "トンネルのランタイムキーは安全に保存されています",
+  doctorTunnelRuntimeOwned: "ランチャーがトンネルランタイムを管理しています",
+  doctorTunnelRuntimeReady: "トンネルランタイムは正常で、使用可能です",
+  doctorConnectorAvailable: "ChatGPT コネクタ「{name}」を利用できます",
   activityTitle: "ランタイムアクティビティ",
   activitySubtitle: "ローカル診断です。共有する前にプライバシー保護済みのコピーをエクスポートしてください。生のログはこのデバイスにのみ保存されます。",
   recentActivity: "最近のイベント",
@@ -561,4 +582,39 @@ export function copyFor(language: Language): Copy {
   if (language === "zh-CN") return zh as Copy;
   if (language === "ja") return ja as Copy;
   return en;
+}
+
+export function localizeRuntimeMessage(copy: Copy, message: string, checkId?: string): string {
+  if (message === "Checking ChatGPT connector") return copy.checkingChatGptConnector;
+
+  if (checkId === "proxy") {
+    const match = /^Responses proxy is healthy on (127\.0\.0\.1:\d+)$/.exec(message);
+    if (match) return copy.doctorProxyHealthy.replace("{endpoint}", match[1]);
+  }
+  if (checkId === "tunnel-binary" && message === "Pinned openai/tunnel-client binary is installed") {
+    return copy.doctorTunnelBinaryInstalled;
+  }
+  if (checkId === "tunnel-key" && message === "Tunnel runtime key is stored privately") {
+    return copy.doctorTunnelKeyStored;
+  }
+  if (checkId === "tunnel-service" && message === "Launcher owns the tunnel runtime") {
+    return copy.doctorTunnelRuntimeOwned;
+  }
+  if (checkId === "tunnel-runtime" && message === "Tunnel runtime reports healthy and ready") {
+    return copy.doctorTunnelRuntimeReady;
+  }
+  if (checkId === "connector") {
+    const match = /^ChatGPT connector (".*") is available$/.exec(message);
+    if (match) {
+      try {
+        const connectorName = JSON.parse(match[1]);
+        if (typeof connectorName === "string") {
+          return copy.doctorConnectorAvailable.replace("{name}", connectorName);
+        }
+      } catch {
+        return message;
+      }
+    }
+  }
+  return message;
 }

--- a/launcher/tests/localization.test.cjs
+++ b/launcher/tests/localization.test.cjs
@@ -2,6 +2,7 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const path = require("node:path");
+const ts = require("typescript");
 
 const launcherRoot = path.resolve(__dirname, "..");
 const repositoryRoot = path.resolve(launcherRoot, "..");
@@ -10,6 +11,20 @@ const read = (...parts) => fs.readFileSync(path.join(repositoryRoot, ...parts), 
 const englishReadme = read("README.md");
 const chineseReadme = read("README.zh-CN.md");
 const japaneseReadme = read("README.ja.md");
+const appSource = read("launcher", "src", "App.tsx");
+
+function loadI18nModule() {
+  const source = read("launcher", "src", "i18n.ts");
+  const output = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2023,
+    },
+  }).outputText;
+  const loaded = { exports: {} };
+  Function("module", "exports", "require", output)(loaded, loaded.exports, require);
+  return loaded.exports;
+}
 
 function commandFences(source) {
   return [...source.matchAll(/```(bash|powershell)\n([\s\S]*?)```/g)]
@@ -27,4 +42,56 @@ test("localized READMEs preserve every command block and link target from Englis
     assert.deepEqual(commandFences(source), commandFences(englishReadme));
     assert.deepEqual(linkTargets(source), linkTargets(englishReadme));
   }
+});
+
+test("Japanese launcher runtime messages localize connector verification and doctor success checks", () => {
+  const { copyFor, localizeRuntimeMessage } = loadI18nModule();
+  const copy = copyFor("ja");
+
+  assert.equal(localizeRuntimeMessage(copy, "Checking ChatGPT connector"), "ChatGPT コネクタを確認中");
+  assert.equal(
+    localizeRuntimeMessage(copy, "Responses proxy is healthy on 127.0.0.1:7841", "proxy"),
+    "Responses プロキシは 127.0.0.1:7841 で正常に動作しています",
+  );
+  assert.equal(
+    localizeRuntimeMessage(copy, "Pinned openai/tunnel-client binary is installed", "tunnel-binary"),
+    "固定バージョンの openai/tunnel-client バイナリがインストールされています",
+  );
+  assert.equal(
+    localizeRuntimeMessage(copy, "Tunnel runtime key is stored privately", "tunnel-key"),
+    "トンネルのランタイムキーは安全に保存されています",
+  );
+  assert.equal(
+    localizeRuntimeMessage(copy, "Launcher owns the tunnel runtime", "tunnel-service"),
+    "ランチャーがトンネルランタイムを管理しています",
+  );
+  assert.equal(
+    localizeRuntimeMessage(copy, "Tunnel runtime reports healthy and ready", "tunnel-runtime"),
+    "トンネルランタイムは正常で、使用可能です",
+  );
+  assert.equal(
+    localizeRuntimeMessage(copy, 'ChatGPT connector "Codex Native2" is available', "connector"),
+    "ChatGPT コネクタ「Codex Native2」を利用できます",
+  );
+});
+
+test("runtime message localization preserves other languages and unknown backend messages", () => {
+  const { copyFor, localizeRuntimeMessage } = loadI18nModule();
+  const connector = 'ChatGPT connector "Codex Native2" is available';
+
+  assert.equal(localizeRuntimeMessage(copyFor("en"), connector, "connector"), connector);
+  assert.equal(localizeRuntimeMessage(copyFor("zh-CN"), connector, "connector"), connector);
+  assert.equal(
+    localizeRuntimeMessage(copyFor("ja"), "Tunnel runtime is not ready", "tunnel-runtime"),
+    "Tunnel runtime is not ready",
+  );
+  assert.equal(
+    localizeRuntimeMessage(copyFor("ja"), "Unexpected connector diagnostic", "connector"),
+    "Unexpected connector diagnostic",
+  );
+});
+
+test("launcher UI localizes MCP verification progress and doctor check messages", () => {
+  assert.match(appSource, /localizeRuntimeMessage\(copy, operation\.message\)/);
+  assert.match(appSource, /localizeRuntimeMessage\(copy, check\.message, check\.id\)/);
 });


### PR DESCRIPTION
## Summary

- Localize MCP connector verification progress and successful Doctor diagnostics when the launcher language is Japanese.
- Preserve dynamic values such as the Responses proxy endpoint and connector name.
- Keep English, Chinese, unknown backend messages, and backend/CLI Doctor output unchanged.

## Tests

- `node --test tests/localization.test.cjs tests/renderer-wiring.test.cjs` — 23 passed
- `node --test tests/*.test.cjs` — 284 passed, 2 skipped
- `bun run typecheck`
- `bun run build:renderer`
