### PR TITLE
fix: trust parent visualization roots for subagent steering

### DIFF
--- a/src/adapters/chatgpt-web/environment.ts
+++ b/src/adapters/chatgpt-web/environment.ts
@@ -376,20 +376,23 @@ function environmentMatchesCanonicalMetadata(
     normalizedMetadataRoots.length === 0
     || declaredRoots.some(root => (
       !normalizedMetadataRoots.some(metadataRoot => matchesPath(metadataRoot, root))
-      && !isCurrentThreadVisualizationRoot(root, metadata)
+      && !isCurrentOrParentThreadVisualizationRoot(root, metadata)
     ))
   )) return false;
   if (!declaredRoots.some(root => matchesPath(root, cwd))) return false;
   return sandboxMetadataMatchesEnvironment(metadataSandboxValue, environmentText);
 }
 
-function isCurrentThreadVisualizationRoot(path: string, metadata: Record<string, unknown>): boolean {
-  const threadId = typeof metadata.thread_id === "string" ? metadata.thread_id.trim() : "";
-  if (!threadId) return false;
+function isCurrentOrParentThreadVisualizationRoot(path: string, metadata: Record<string, unknown>): boolean {
+  const threadIds = [metadata.thread_id, metadata.parent_thread_id]
+    .filter((value): value is string => typeof value === "string")
+    .map(value => process.platform === "win32" ? value.trim().toLowerCase() : value.trim())
+    .filter(Boolean);
+  if (threadIds.length === 0) return false;
 
   // Codex advertises its task-scoped visualization output directory in workspace_roots but omits
   // it from Git-oriented turn metadata. Authenticate that one auxiliary shape by both its private
-  // Codex home and current thread id; arbitrary roots and another task's output remain untrusted.
+  // Codex home and current or parent thread id; arbitrary roots and unrelated output remain untrusted.
   const configuredCodexHome = process.env.CODEX_HOME?.trim();
   const codexHome = resolve(configuredCodexHome || join(homedir(), ".codex"));
   const visualizationBase = pathIdentity(join(codexHome, "visualizations"));
@@ -397,12 +400,11 @@ function isCurrentThreadVisualizationRoot(path: string, metadata: Record<string,
   if (!rel || rel.startsWith("..") || isAbsolute(rel)) return false;
 
   const parts = rel.split(sep);
-  const expectedThreadId = process.platform === "win32" ? threadId.toLowerCase() : threadId;
   return parts.length === 4
     && /^\d{4}$/.test(parts[0]!)
     && /^(?:0[1-9]|1[0-2])$/.test(parts[1]!)
     && /^(?:0[1-9]|[12]\d|3[01])$/.test(parts[2]!)
-    && parts[3] === expectedThreadId;
+    && threadIds.includes(parts[3]!);
 }
 
 function canonicalMetadataEnvironmentBeforeUser(

--- a/tests/environment.test.ts
+++ b/tests/environment.test.ts
@@ -33,14 +33,18 @@ const readOnlyProfileXml = `<permission_profile type="managed"><file_system type
 const externalProfileXml = `<permission_profile type="external"><file_system type="external" /></permission_profile>`;
 
 function currentWire(
-  options: { workspace?: string; sandbox?: string; includeIds?: boolean; environmentXml?: string } = {},
+  options: {
+    workspace?: string; sandbox?: string; includeIds?: boolean; environmentXml?: string;
+    threadId?: string; parentThreadId?: string;
+  } = {},
 ): CodexParsedRequest {
   const workspace = options.workspace ?? root;
   const sandbox = options.sandbox ?? "none";
   const includeIds = options.includeIds ?? true;
   const envXml = options.environmentXml ?? environmentXml;
   const turnMetadata = {
-    thread_id: "thread_current",
+    thread_id: options.threadId ?? "thread_current",
+    ...(options.parentThreadId ? { parent_thread_id: options.parentThreadId } : {}),
     turn_id: "turn_current",
     sandbox,
     workspaces: { [workspace]: { has_changes: true } },
@@ -319,6 +323,38 @@ describe("trusted current Codex environment envelope", () => {
     });
   });
 
+  test("steering accepts a spawned task's parent visualization root", () => {
+    const codexHome = resolve(process.env.CODEX_HOME?.trim() || join(homedir(), ".codex"));
+    const visualizationRoot = join(codexHome, "visualizations", "2026", "08", "25", "thread_parent");
+    const projectEnvironment = `<environment_context>
+  <cwd>${root}</cwd>
+  <filesystem><workspace_roots><root>${root}</root><root>${visualizationRoot}</root></workspace_roots>${dangerFullAccessProfileXml}</filesystem>
+</environment_context>`;
+    const request = currentWire({
+      environmentXml: projectEnvironment,
+      threadId: "thread_child",
+      parentThreadId: "thread_parent",
+    });
+    const body = request._rawBody as { input: Array<Record<string, unknown>> };
+    for (const item of body.input) {
+      item.internal_chat_message_metadata_passthrough = { turn_id: "turn_current" };
+    }
+    body.input.push(
+      {
+        type: "message", id: "msg_assistant", role: "assistant",
+        content: [{ type: "output_text", text: "Working." }],
+        internal_chat_message_metadata_passthrough: { turn_id: "turn_current" },
+      },
+      {
+        type: "message", id: "msg_steering", role: "user",
+        content: [{ type: "input_text", text: "Stop and review first." }],
+        internal_chat_message_metadata_passthrough: { turn_id: "turn_current" },
+      },
+    );
+
+    expect(extractChatGptTurnEnvironment(request).roots).toEqual([root, visualizationRoot]);
+  });
+
   test("skill recovery rejects another task's Codex visualization root", () => {
     const codexHome = resolve(process.env.CODEX_HOME?.trim() || join(homedir(), ".codex"));
     const visualizationRoot = join(codexHome, "visualizations", "2026", "08", "25", "thread_other");
@@ -326,7 +362,7 @@ describe("trusted current Codex environment envelope", () => {
   <cwd>${root}</cwd>
   <filesystem><workspace_roots><root>${root}</root><root>${visualizationRoot}</root></workspace_roots>${dangerFullAccessProfileXml}</filesystem>
 </environment_context>`;
-    const request = currentWire({ environmentXml: injectedEnvironment });
+    const request = currentWire({ environmentXml: injectedEnvironment, parentThreadId: "thread_parent" });
     const body = request._rawBody as { input: Array<Record<string, unknown>> };
     for (const item of body.input) {
       item.internal_chat_message_metadata_passthrough = { turn_id: "turn_current" };

--- a/tests/subagent-environment-history.test.ts
+++ b/tests/subagent-environment-history.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "bun:test";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { ChatGptThreadEnvironmentStore } from "../src/adapters/chatgpt-web/thread-environment";
+import type { CodexParsedRequest } from "../src/types";
+
+const root = resolve(process.cwd());
+const parentThreadId = "thread_parent";
+const parentTurnId = "turn_parent";
+const childThreadId = "thread_child";
+const childTurnId = "turn_child";
+const codexHome = resolve(process.env.CODEX_HOME?.trim() || join(homedir(), ".codex"));
+const visualizationRoot = join(codexHome, "visualizations", "2026", "09", "07", parentThreadId);
+const environment = `<environment_context>
+  <cwd>${root}</cwd>
+  <filesystem><workspace_roots><root>${root}</root><root>${visualizationRoot}</root></workspace_roots><permission_profile type="disabled"><file_system type="unrestricted" /></permission_profile></filesystem>
+</environment_context>`;
+const item = (id: string, role: "developer" | "user", text: string, turnId: string) => ({
+  type: "message",
+  id,
+  role,
+  content: [{ type: "input_text", text }],
+  internal_chat_message_metadata_passthrough: { turn_id: turnId },
+});
+const request = (
+  threadId: string,
+  turnId: string,
+  input: Array<Record<string, unknown>>,
+  parent?: string,
+): CodexParsedRequest => ({
+  modelId: "gpt-5.6-sol",
+  stream: true,
+  context: { messages: [], tools: [] },
+  options: { reasoning: "high" },
+  _rawBody: {
+    client_metadata: {
+      "x-codex-turn-metadata": JSON.stringify({
+        request_kind: "turn",
+        thread_id: threadId,
+        turn_id: turnId,
+        ...(parent ? {
+          parent_thread_id: parent,
+          agent_name: "/root/reviewer",
+          subagent_kind: "thread_spawn",
+        } : {}),
+        sandbox: "none",
+        workspaces: { [root]: {} },
+      }),
+    },
+    input,
+  },
+});
+
+test("fork-context child accepts its inherited parent visualization root", () => {
+  const parentInput = [
+    item("msg_parent_environment", "user", environment, parentTurnId),
+    item("msg_parent_prompt", "user", "Inspect the workspace.", parentTurnId),
+  ];
+  const store = new ChatGptThreadEnvironmentStore();
+  const child = request(childThreadId, childTurnId, [
+    ...parentInput,
+    item("msg_child_developer", "developer", "Review only.", childTurnId),
+    item("msg_child_prompt", "user", "Inspect the change.", childTurnId),
+  ], parentThreadId);
+
+  expect(store.resolve(child).cwd).toBe(root);
+});


### PR DESCRIPTION
## What this changes

Codex subagents can retain their parent task's visualization directory in `workspace_roots`. This occurs both when a fork-context child starts from inherited parent history and when user steering arrives after assistant output. Canonical environment recovery binds every auxiliary root to turn metadata, but the existing check accepts only `thread_id`, so it rejects the inherited parent directory and returns `missing cwd`.

Accept the existing dated visualization-root shape when its final component matches either the current `thread_id` or Codex Core's `parent_thread_id`. Paths outside the private Codex visualization directory and unrelated thread directories remain rejected.

## Evidence

- RED: the fork-context regression failed with `ChatGPT web turn is missing cwd in trusted Codex environment context`; the malformed-current-environment fail-closed control still passed.
- GREEN: `bun test tests/environment.test.ts tests/subagent-environment-history.test.ts` — 50 passed, 0 failed.
- Root suite in `bun run verify` — 655 passed; one unrelated existing Windows host-sensitive test failed because it read this machine's installed launcher registry path instead of its synthetic fixture path.
- Root and launcher typechecks passed.
- Launcher suite — 281 passed, 2 platform skips, 0 failed.
- Root and launcher audits passed with no vulnerabilities.
- Launcher renderer build, runtime bundle build, and relocatable runtime smoke passed.
- The original failure was reproduced with an installed Codex 0.153.4 Full-mode subagent. The patched runtime was not installed because active user turns were intentionally left uninterrupted.

## Scope and invariants

- [x] I read and followed `CONTRIBUTING.md`.
- [x] This is a small, focused change with no unrelated cleanup or generated rewrite.
- [x] The change stays focused on ChatGPT web-backed Codex models; it does not add a generic provider or unrelated product surface.
- [x] Model, route, effort, connector, and capability selection remain explicit with no silent fallback or false-success path.
- [x] If this touches Full harness or MCP, every available Web effort retains the same turn-bound capability and Browser-only gains no broker or connector.
- [x] Terms and trademark claims remain factual; this change is not marketed as a quota or rate-limit bypass.

## Verification

- [x] I ran `bun install --frozen-lockfile` in the repository root and `launcher/`.
- [ ] I ran `bun run verify` with the Bun version pinned by `package.json` (ran; blocked only by the unrelated installed-launcher registry fixture described above).
- [x] I added focused regressions for both steering and fork-context child startup.
- [ ] I manually tested the patched behavior (not installed over active user turns).
- [ ] If this changes local tools, MCP execution, or the outer Codex agent loop, I tested it through a real installed Codex integration (failure reproduced there; patched behavior covered deterministically).
- [x] If this changes ChatGPT browser UI handling, I included observed DOM evidence and a reproducible fixture instead of broadening selectors speculatively (not applicable; no browser UI handling changed).
- [x] If this changes the launcher, I preserved macOS, Windows, and Linux packaging and named the platform packages actually built below (not applicable; no launcher change).
- [x] I did not commit browser state, credentials, Tunnel IDs, raw logs, generated artifacts, or private paths.
- [x] I did not include an unrelated dependency update, release artifact, or version change.

## Platform or account validation

- Windows x64, Full mode, Codex 0.153.4: original steering and fork-context failures reproduced.
- Patched focused environment regressions: passed.
- Account-bound patched Web turn: not run.
- Platform packages: not run; no launcher or packaging files changed.
