### PR TITLE
fix(chatgpt-web): classify stopped thinking as upstream failure

### DIFF
--- a/src/adapters/chatgpt-web/adapter-error.ts
+++ b/src/adapters/chatgpt-web/adapter-error.ts
@@ -43,11 +43,11 @@ export function chatGptTurnSupersededError(): ChatGptWebAdapterError {
 
 export function chatGptStoppedThinkingError(): ChatGptWebAdapterError {
   return new ChatGptWebAdapterError(
-    "ChatGPT remained in 'Stopped thinking' for 5 seconds, so the Codex turn was cancelled.",
+    "ChatGPT stopped its response after accepting the prompt. Start a new Codex task instead of relying on automatic reconnect.",
     {
-      status: 499,
-      errorType: "client_closed_request",
-      code: "client_cancelled",
+      status: 502,
+      errorType: "server_error",
+      code: "chatgpt_stopped_thinking",
       retryable: false,
     },
   );

--- a/tests/bridge-stall-timeout.test.ts
+++ b/tests/bridge-stall-timeout.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
 import { bridgeToResponsesSSE } from "../src/bridge";
+import { chatGptStoppedThinkingError } from "../src/adapters/chatgpt-web/adapter-error";
 import { DEFAULT_STALL_TIMEOUT_SEC, MAX_STALL_TIMEOUT_SEC, resolveStallTimeoutSec } from "../src/stall-timeout";
 import type { AdapterEvent } from "../src/types";
 
@@ -74,4 +75,25 @@ test("the stall budget is configurable and falls back to the shipped default", (
   expect(resolveStallTimeoutSec(0)).toBe(1);
   expect(resolveStallTimeoutSec(Number.MAX_VALUE)).toBe(MAX_STALL_TIMEOUT_SEC);
   expect(resolveStallTimeoutSec(MAX_STALL_TIMEOUT_SEC + 1)).toBe(MAX_STALL_TIMEOUT_SEC);
+});
+
+test("Stopped thinking preserves its non-retryable upstream taxonomy in response.failed", async () => {
+  async function* stoppedThinking(): AsyncGenerator<AdapterEvent> {
+    const error = chatGptStoppedThinkingError();
+    yield {
+      type: "error",
+      message: error.message,
+      status: error.status,
+      errorType: error.errorType,
+      code: error.code,
+      retryable: error.retryable,
+    };
+  }
+
+  const body = await new Response(bridged(stoppedThinking(), 30, 10)).text();
+
+  expect(body).toContain("event: response.failed");
+  expect(body).toContain('"type":"server_error"');
+  expect(body).toContain('"code":"chatgpt_stopped_thinking"');
+  expect(body).toContain('"retryable":false');
 });

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -3017,7 +3017,7 @@ test("visible DOM trace emits one complete commentary paragraph before the next 
   expect(tracker.observe([...completed], false, 1_450)).toEqual([]);
 });
 
-test("persistent Stopped thinking is a terminal cancelled turn", () => {
+test("persistent Stopped thinking is an explicit upstream interruption, not a client cancellation", () => {
   expect(CHATGPT_STOPPED_THINKING_GRACE_MS).toBe(5_000);
   const tracker = new ChatGptStoppedThinkingTracker();
   expect(tracker.update(true, 1_000)).toBeFalse();
@@ -3026,9 +3026,9 @@ test("persistent Stopped thinking is a terminal cancelled turn", () => {
   expect(tracker.update(true, 10_000)).toBeFalse();
   expect(tracker.update(true, 15_000)).toBeTrue();
   expect(chatGptStoppedThinkingError()).toMatchObject({
-    status: 499,
-    errorType: "client_closed_request",
-    code: "client_cancelled",
+    status: 502,
+    errorType: "server_error",
+    code: "chatgpt_stopped_thinking",
     retryable: false,
   });
 });

--- a/tests/chatgpt-web-harness.test.ts
+++ b/tests/chatgpt-web-harness.test.ts
@@ -6,7 +6,7 @@ import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { buildResponseJSON } from "../src/bridge";
-import { ChatGptWebAdapterError } from "../src/adapters/chatgpt-web/adapter-error";
+import { ChatGptWebAdapterError, chatGptStoppedThinkingError } from "../src/adapters/chatgpt-web/adapter-error";
 import { ChatGptCompletionTracker, chatGptImageFilePayloads, chatGptPromptFilePayloads, chatGptTurnIsComplete } from "../src/adapters/chatgpt-web/browser-worker";
 import { ChatGptBrowserWorker, type BrowserTurn } from "../src/adapters/chatgpt-web/browser-worker";
 import { chatGptConversationKey } from "../src/adapters/chatgpt-web/conversation-key";
@@ -1308,6 +1308,42 @@ describe("ChatGPT outer-native harness v4", () => {
         expect(events.at(-1)).toMatchObject({
           type: "error",
           code: "context_length_exceeded",
+          retryable: false,
+        });
+      }
+      expect(browserStarts).toBe(1);
+    } finally {
+      (worker as unknown as { run: (turn: BrowserTurn) => Promise<string> }).run = originalRun;
+      await TurnBroker.forSocket(socketPath).close();
+    }
+  });
+
+  test("Stopped thinking remains replayable without starting another browser turn", async () => {
+    const socketPath = brokerTestEndpoint(`cgw-stopped-thinking-${process.pid}-${Date.now()}`);
+    const provider: CodexProviderConfig = {
+      adapter: "chatgpt-web",
+      baseUrl: "browser://chatgpt-stopped-thinking-test",
+      chatgptWeb: { brokerSocketPath: socketPath, localToolsEnabled: false, solAvailable: true, proAvailable: true },
+    };
+    const worker = ChatGptBrowserWorker.forProvider(provider);
+    const originalRun = worker.run.bind(worker);
+    let browserStarts = 0;
+    (worker as unknown as { run: (turn: BrowserTurn) => Promise<string> }).run = async () => {
+      browserStarts += 1;
+      throw chatGptStoppedThinkingError();
+    };
+    try {
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        const events: AdapterEvent[] = [];
+        await createChatGptWebAdapter(provider).runTurn!(
+          rawWireRequest(environmentXml),
+          { headers: new Headers() },
+          event => events.push(event),
+        );
+        expect(events.at(-1)).toMatchObject({
+          type: "error",
+          errorType: "server_error",
+          code: "chatgpt_stopped_thinking",
           retryable: false,
         });
       }


### PR DESCRIPTION
## Summary

- classify a persistent ChatGPT `Stopped thinking` state as a non-retryable upstream interruption instead of a client cancellation
- retain the terminal outcome across native reconnects without sending the prompt to the browser a second time
- verify the Responses SSE payload keeps `server_error`, `chatgpt_stopped_thinking`, and `retryable: false`

## Scope

This does not change the five-second grace window or the MCP-progress protection. Linux/X11 launcher visibility work is intentionally excluded.

## Verification

- `bun test tests/browser-worker-contract.test.ts tests/chatgpt-web-harness.test.ts tests/bridge-stall-timeout.test.ts`
- `bun run typecheck`
- `bun test`

All passed locally.