### PR TITLE
fix(launcher): rediscover uncached tunnel health before monitoring

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -160,6 +160,11 @@ ChatGPT のツール呼び出しを現在の Codex タスクへ接続します�
 アンインストール前の Codex 統合削除も行えます。すべてのブラウザーチェックポイントでスクリーンショットが必要な場合にのみ、
 `CODEX_CHATGPT_WEB_BROWSER_DIAGNOSTICS=1` を設定してください。
 
+ChatGPT の通常の応答は届くのに Codex Native2 のツール呼び出しが `502` を返す場合は、
+モデル経路とは別にツール経路で問題が発生している可能性があります。OS 別の復旧手順は
+[トラブルシューティング](TROUBLESHOOTING.md#every-codex-native2-tool-call-returns-502-but-chatgpt-text-still-works)
+を参照してください。トンネルを再起動する前に、実行中のタスクを完了またはキャンセルしてください。
+
 新規インストールでは、クロスバックエンドのサブエージェントに **Compatibility V1** を使用します。
 **Native** は Codex 独自の機能設定を維持し、プレーンテキストの Web-to-Web V2 delegation を有効にします。
 プロトコル変更後は Codex を再起動し、新しいタスクを開始してください。

--- a/README.md
+++ b/README.md
@@ -165,6 +165,11 @@ Use **Activity** for safe local diagnostics and **Settings → Run doctor** for 
 Settings can also cancel a retained browser turn or remove the Codex integration before uninstall.
 Set `CODEX_CHATGPT_WEB_BROWSER_DIAGNOSTICS=1` only when every browser checkpoint needs a screenshot.
 
+If Codex Native2 tool calls return `502` while ordinary ChatGPT replies still stream, the tool path
+may be unhealthy independently of the model path. See the platform-specific recovery steps in
+[Troubleshooting](TROUBLESHOOTING.md#every-codex-native2-tool-call-returns-502-but-chatgpt-text-still-works),
+and finish or cancel active tasks before restarting the tunnel.
+
 New installs use **Compatibility V1** for cross-backend subagents. **Native** preserves Codex's own
 feature settings and enables plaintext Web-to-Web V2 delegation. Restart Codex and start a new task
 after changing the protocol:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -151,6 +151,10 @@ bun run app
 取消保留的浏览器任务，或在卸载前移除 Codex 集成。仅在需要为每个浏览器检查点保存截图时设置
 `CODEX_CHATGPT_WEB_BROWSER_DIAGNOSTICS=1`。
 
+如果 ChatGPT 仍能正常返回文本，但 Codex Native2 工具调用返回 `502`，工具通道可能出现了独立于
+模型通道的故障。请参阅[故障排查](TROUBLESHOOTING.md#every-codex-native2-tool-call-returns-502-but-chatgpt-text-still-works)
+中的分平台恢复步骤，并在重启隧道前完成或取消正在运行的任务。
+
 新安装默认使用 **Compatibility V1** 以支持跨后端 subagent。**Native** 会保留 Codex 自身的
 功能设置，并启用明文 Web-to-Web V2 委派。切换协议后，请重启 Codex 并创建新任务：
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -123,6 +123,39 @@ approval review**, disable that optional Codex review setting and restart Codex.
 sandbox and explicit approvals still apply; this only prevents an unavailable native model from
 being inserted as an extra reviewer after the Web tool call already completed.
 
+## Every Codex Native2 tool call returns `502`, but ChatGPT text still works
+
+Repeated `502 Upstream or external service errors` from tool discovery and execution can indicate
+a tunnel dispatcher problem even while ordinary ChatGPT text continues streaming. HTTP `502` alone
+does not establish the cause. In the tunnel-client diagnostic log, look for this recent pattern:
+
+- one `command response deadline reached; dropping without posting`, then
+- `dispatcher received MCP upstream error` repeating, with `status_code=502`,
+  `failure_source=client_internal`, and `upstream_response_received=false`.
+
+The pattern is stronger when `dispatcher forwarded command to MCP server` stops appearing after the
+failure. A running process or a green `tunnel status` result does not prove that MCP calls can
+execute. The launcher also inspects recent internal MCP transport failures through the tunnel's
+loopback diagnostics endpoint. Continued chat text does not establish that the MCP server or its
+configuration is healthy.
+
+For a **launcher-managed macOS installation**, finish or cancel active Codex tasks first. Keep the
+launcher running, then stop the affected tunnel:
+
+```bash
+codex-chatgpt-web tunnel stop
+```
+
+The launcher monitor attempts to start a replacement, subject to its restart budget. Use `tunnel
+stop`, not `tunnel restart`: restart targets the installed macOS service rather than the
+launcher-owned runtime. The current CLI stop path also requires macOS service management, so this
+command is not a Windows/Linux recovery shortcut.
+
+On **Windows or Linux**, finish or cancel active tasks, then quit and reopen the launcher instead.
+After recovery, confirm that a read-only Codex Native2 tool call succeeds in Codex; a green status
+indicator alone is insufficient. If calls still fail, collect privacy-safe diagnostics and investigate
+the cause rather than assuming that reinstalling or changing configuration will fix it.
+
 ## `Reconnecting`, `stream disconnected`, or `ChatGPT failed`
 
 These are result boundaries, not one diagnosis. The bridge uses them when it cannot prove a complete

--- a/launcher/electron/runtime-supervisor.cjs
+++ b/launcher/electron/runtime-supervisor.cjs
@@ -827,7 +827,16 @@ class RuntimeSupervisor {
     );
   }
 
-  async readLocalTunnelHealth() {
+  async readLocalTunnelHealth(config) {
+    // An existing tunnel may not yet have a cached loopback health endpoint. Discover it before
+    // probing so inventory readiness cannot hide recent internal MCP transport failures.
+    if (!this.tunnelHealthBaseUrl && config?.tunnel) {
+      try {
+        await this.discoverTunnelHealthBaseUrl(config);
+      } catch {
+        // Best effort: the probes below still report whatever they can observe.
+      }
+    }
     const [healthz, readyz, mcp] = await Promise.all([
       this.probeTunnelEndpoint("/healthz"),
       this.probeTunnelEndpoint("/readyz"),
@@ -878,7 +887,7 @@ class RuntimeSupervisor {
   }
 
   async observeTunnelForMonitor(config) {
-    const local = await this.readLocalTunnelHealth();
+    const local = await this.readLocalTunnelHealth(config);
     if (local.statusKnown) return local;
     try {
       return await this.readTunnelHealth(config);

--- a/launcher/tests/runtime-supervisor.test.cjs
+++ b/launcher/tests/runtime-supervisor.test.cjs
@@ -615,6 +615,95 @@ test("recent internal MCP transport failures override false-green tunnel readine
   }
 });
 
+test("monitoring discovers an uncached tunnel endpoint and detects a wedged MCP dispatcher", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-web-gpt-tunnel-mcp-unowned-"));
+  const health = await localHealthServer(
+    () => 200,
+    pathname => pathname.startsWith("/api/logs")
+      ? JSON.stringify({
+        events: [{
+          time: new Date().toISOString(),
+          level: "WARN",
+          message: "dispatcher received MCP upstream error; posted error response to control plane",
+          attrs: {
+            failure_source: "client_internal",
+            status_code: 502,
+            upstream_response_received: false,
+            rpc_method: "tools/call",
+          },
+        }],
+      })
+      : "ok",
+  );
+  const supervisor = new RuntimeSupervisor({
+    app: { getVersion: () => "0.2.0", isPackaged: false },
+    logger: { info() {}, warn() {}, error() {} },
+    sourceRoot: root,
+    coreHome: root,
+    browserDescriptorPath: path.join(root, "launcher.json"),
+  });
+  // Discovery must not depend on a managed process identity being available.
+  supervisor.tunnel = null;
+  supervisor.tunnelHealthBaseUrl = null;
+  let discoveries = 0;
+  supervisor.runTunnelCommand = async (_config, args) => {
+    discoveries += 1;
+    assert.deepEqual(args, ["runtimes", "status", "codex-chatgpt-web", "--json"]);
+    return {
+      code: 0,
+      output: JSON.stringify({ local: { effective_health: { base_url: health.baseUrl } } }),
+    };
+  };
+  try {
+    const config = { tunnel: { alias: "codex-chatgpt-web" } };
+    const observation = await supervisor.observeTunnelForMonitor(config);
+    assert.equal(discoveries, 1);
+    assert.equal(observation.ready, false);
+    assert.equal(observation.statusKnown, true);
+    assert.equal(observation.fatal, true);
+    assert.match(observation.detail, /MCP transport returned internal HTTP 502/);
+    assert.equal((await supervisor.observeTunnelForMonitor(config)).fatal, true);
+    assert.equal(discoveries, 1, "the cached endpoint must avoid repeated discovery commands");
+  } finally {
+    await health.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+for (const [label, discovery] of [
+  ["command failure", { code: 1, output: "status unavailable" }],
+  ["malformed JSON", { code: 0, output: "not JSON" }],
+  ["non-loopback URL", { code: 0, output: JSON.stringify({ health_url: "https://example.com" }) }],
+]) {
+  test(`failed tunnel discovery remains unknown when inventory is unavailable: ${label}`, async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-web-gpt-discovery-unknown-"));
+    const supervisor = new RuntimeSupervisor({
+      app: { getVersion: () => "0.2.0", isPackaged: false },
+      logger: { info() {}, warn() {}, error() {} },
+      sourceRoot: root,
+      coreHome: root,
+      browserDescriptorPath: path.join(root, "launcher.json"),
+    });
+    let discoveries = 0;
+    supervisor.runTunnelCommand = async () => {
+      discoveries += 1;
+      return discovery;
+    };
+    supervisor.readTunnelHealth = async () => { throw new Error("inventory unavailable"); };
+    try {
+      const observation = await supervisor.observeTunnelForMonitor({ tunnel: { alias: "codex-chatgpt-web" } });
+      assert.equal(discoveries, 1);
+      assert.equal(supervisor.tunnelHealthBaseUrl, null);
+      assert.equal(observation.ready, false);
+      assert.equal(observation.statusKnown, false);
+      assert.equal(observation.fatal, false);
+      assert.match(observation.detail, /native status unavailable/);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+}
+
 test("tunnel readiness accepts the official tmux status without inventing a PID", async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-web-gpt-tunnel-health-tmux-"));
   const supervisor = new RuntimeSupervisor({


### PR DESCRIPTION
## What this changes

Discover an existing tunnel's loopback health endpoint when the launcher has not cached it yet, before monitoring falls back to runtime inventory. This lets the existing MCP diagnostics check detect a wedged dispatcher even when inventory reports readiness.

The change reuses the existing endpoint validation, diagnostics probes, and restart policy. It also adds platform-specific recovery guidance and links from the English, Japanese, and Chinese READMEs. There are no protocol, provider, packaging, or dependency changes.

## Evidence

Previously, an uncached endpoint made local probes unobservable and could leave monitoring dependent on inventory readiness. The new regression supplies a real isolated loopback diagnostics server with a recent internal MCP HTTP 502 event: monitoring discovers the endpoint and returns `ready: false`, `statusKnown: true`, and `fatal: true`.

Additional regressions cover cached discovery, command failure, malformed JSON, and rejection of a non-loopback endpoint. When both discovery and inventory are unavailable, the observation remains unknown rather than claiming recovery.

## Scope and invariants

- [x] Read `CONTRIBUTING.md`; remaining account-bound acceptance gates are explicitly recorded below.
- [x] One focused fix, regression coverage, and related recovery documentation only.
- [x] Model, route, effort, connector, and capability selection remain unchanged.
- [x] Full mode retains its existing turn-bound capability; Browser-only gains no broker or connector.
- [x] No credentials, browser state, tunnel IDs, raw logs, private paths, generated artifacts, version changes, or unrelated dependencies are committed.

## Verification

Fresh verification on 7 September 2026, on this exact branch based on upstream `c648c09`, using Bun 1.4.0 and isolated home, Codex, and application-state directories:

- [x] `bun install --frozen-lockfile` in the root and `launcher/`.
- [x] `bun run verify`: **655 runtime tests passed; 286 launcher tests passed, 1 platform-specific test skipped; 0 failures**.
- [x] Root and launcher audits: no vulnerabilities found.
- [x] Version consistency, both TypeScript checks, launcher production build, runtime bundle, and third-party notices generation passed.
- [x] Relocated runtime smoke: `RELOCATABLE_RUNTIME_SMOKE_OK`.
- [x] `git diff --check`; one commit with no unrelated fork commits.
- [ ] Installed Codex Full-mode recovery acceptance.
- [ ] Native macOS, Windows, and Linux package build/smoke validation.

## Platform or account validation

Automated verification: macOS arm64. The deterministic regression uses an isolated loopback server, not a live account-bound tunnel. Installed-app recovery and cross-platform packaged acceptance were **not run**; no active runtime was replaced and no user service was restarted. This PR remains a draft for those acceptance checks and upstream CI review.