### PR TITLE
fix(browser): bound viewport retries without replaying submitted turns

### DIFF
--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -1086,7 +1086,11 @@ export async function connectAfterClosingBrowserConnection<T>(
 
 export const CHATGPT_MIN_OPERATIONAL_VIEWPORT = Object.freeze({ width: 320, height: 240 });
 
-async function waitForOperationalChatGptViewport(page: Page, signal?: AbortSignal): Promise<void> {
+export async function waitForOperationalChatGptViewport(
+  page: Page,
+  signal?: AbortSignal,
+  options: { allowTurnRetry?: boolean } = {},
+): Promise<void> {
   try {
     await withBrowserTurnAbort(page.waitForFunction(
       ({ width, height }) => innerWidth >= width && innerHeight >= height,
@@ -1095,8 +1099,16 @@ async function waitForOperationalChatGptViewport(page: Page, signal?: AbortSigna
     ), signal);
   } catch (error) {
     if (signal?.aborted) throw new DOMException("ChatGPT browser page acquisition aborted", "AbortError");
-    throw new Error(
+    // Only initial page acquisition may opt into the shared browser-turn retry budget. A rebind
+    // can happen after submission or tool execution, when a fresh turn could repeat side effects.
+    throw new ChatGptWebAdapterError(
       `ChatGPT browser surface did not expose an operational viewport: ${error instanceof Error ? error.message : String(error)}`,
+      {
+        status: 503,
+        errorType: "server_error",
+        code: "chatgpt_surface_unavailable",
+        retryable: options.allowTurnRetry === true,
+      },
     );
   }
 }
@@ -4256,7 +4268,7 @@ export class ChatGptBrowserWorker {
           throw new DOMException("ChatGPT browser page acquisition aborted", "AbortError");
         }
         turnConnection = connection.browser;
-        await waitForOperationalChatGptViewport(connection.page, abortSignal);
+        await waitForOperationalChatGptViewport(connection.page, abortSignal, { allowTurnRetry: true });
         return connection.page;
       });
       if (!maintenancePage && !launcherSurfaceId) managedPage = page;

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Page } from "playwright-core";
 import { CHATGPT_BROWSER_OBSERVATION_PROBE_TIMEOUT_MS, CHATGPT_COMPLETION_SETTLE_MS, CHATGPT_EXTERNAL_PROGRESS_CLOCK_SKEW_MS, CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS, ChatGptCompletionTracker, chatGptExternalProgressSuppressesDomHealth, CHATGPT_RESPONSE_DOM_GRACE_MS, MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS, CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_COMPOSER_SELECT_ALL_KEY, CHATGPT_STOPPED_THINKING_GRACE_MS, ChatGptBrowserObservationTimeoutError, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_PAGE_REBINDS, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, assertChatGptWebMultipartInputWithinLimits, browserDiagnosticCheckpoint, chatGptConnectorAttachmentMode, chatGptNewTurnIdentity, chatGptReboundTurnIdentity, chatGptSubmissionEvidence, connectAfterClosingBrowserConnection, dismissChatGptTemporaryChatOnboarding, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, resolveChatGptWebMultipartStagingMode, sanitizeChatGptBrowserDiagnosticState, setChatGptThinkMode, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert, withChatGptBrowserObservationTimeout, CHATGPT_MULTIPART_RESPONSE_DOM_GRACE_MS, browserStageTimeouts, ChatGptSuspensionClock, remainingStageBudgetMs } from "../src/adapters/chatgpt-web/browser-worker";
-import { ensureChatGptPersonalizedConnectorAccess } from "../src/adapters/chatgpt-web/browser-worker";
+import { ensureChatGptPersonalizedConnectorAccess, waitForOperationalChatGptViewport } from "../src/adapters/chatgpt-web/browser-worker";
 import { chatGptStoppedThinkingError } from "../src/adapters/chatgpt-web/adapter-error";
 import { CHATGPT_WEB_MODEL_ID } from "../src/adapters/chatgpt-web/model";
 import { CHATGPT_CONNECTOR_NAME, DEV_CHATGPT_CONNECTOR_NAME, defaultChromeExecutable, legacyChatGptConnectorMigrationMessage } from "../src/config";
@@ -349,13 +349,14 @@ test("compaction retry submission evidence cannot make prompt-stage settlement u
 test("launcher page acquisition proves a nonzero operational viewport before DOM interaction", () => {
   const workerSource = readFileSync(new URL("../src/adapters/chatgpt-web/browser-worker.ts", import.meta.url), "utf8");
   const connect = workerSource.indexOf("const connection = await connectLauncherBrowserHost(");
-  const viewport = workerSource.indexOf("await waitForOperationalChatGptViewport(connection.page, abortSignal);", connect);
+  const viewport = workerSource.indexOf("await waitForOperationalChatGptViewport(connection.page, abortSignal, { allowTurnRetry: true });", connect);
   const acquired = workerSource.indexOf('await diagnostics.capture(page, "browser-page-acquired")', viewport);
 
   expect(connect).toBeGreaterThan(-1);
   expect(viewport).toBeGreaterThan(connect);
   expect(acquired).toBeGreaterThan(viewport);
   expect(workerSource).toContain("innerWidth >= width && innerHeight >= height");
+  expect(workerSource).toContain("await waitForOperationalChatGptViewport(rebound.page, signal);");
 });
 
 test("Luna turns without a retained conversation never send connector identity alone", () => {
@@ -2324,6 +2325,61 @@ test("the known terminal ChatGPT error alert returns a structured retryable fail
     retryable: true,
   });
   expect(fixture.pressed).toEqual([]);
+});
+
+test("a collapsed initial viewport explicitly opts into bounded turn retries", async () => {
+  const page = {
+    waitForFunction: () => Promise.reject(new Error("page.waitForFunction: Timeout 10000ms exceeded")),
+  } as unknown as Page;
+
+  await expect(waitForOperationalChatGptViewport(page, undefined, { allowTurnRetry: true })).rejects.toMatchObject({
+    name: "ChatGptWebAdapterError",
+    status: 503,
+    errorType: "server_error",
+    code: "chatgpt_surface_unavailable",
+    retryable: true,
+  });
+});
+
+test("a viewport failure does not authorise a fresh browser turn by default", async () => {
+  const page = {
+    waitForFunction: () => Promise.reject(new Error("operational viewport timed out during rebind")),
+  } as unknown as Page;
+
+  await expect(waitForOperationalChatGptViewport(page)).rejects.toMatchObject({
+    name: "ChatGptWebAdapterError",
+    status: 503,
+    code: "chatgpt_surface_unavailable",
+    retryable: false,
+  });
+});
+
+test("an operational viewport completes without an adapter error", async () => {
+  let observedOptions: unknown;
+  const page = {
+    waitForFunction: (_predicate: unknown, _dimensions: unknown, options: unknown) => {
+      observedOptions = options;
+      return Promise.resolve();
+    },
+  } as unknown as Page;
+
+  await expect(waitForOperationalChatGptViewport(page)).resolves.toBeUndefined();
+  expect(observedOptions).toEqual({ polling: 50, timeout: 10_000 });
+});
+
+test.each(["before", "during"])("viewport cancellation %s acquisition remains AbortError", async timing => {
+  const controller = new AbortController();
+  let finishProbe!: () => void;
+  const probe = new Promise<void>(resolve => { finishProbe = resolve; });
+  const page = { waitForFunction: () => probe } as unknown as Page;
+  if (timing === "before") controller.abort();
+  const result = waitForOperationalChatGptViewport(page, controller.signal, { allowTurnRetry: true });
+  if (timing === "during") controller.abort();
+  try {
+    await expect(result).rejects.toMatchObject({ name: "AbortError" });
+  } finally {
+    finishProbe();
+  }
 });
 
 test("a failed subscription fetch is retryable and does not falsely invalidate ChatGPT login", async () => {

--- a/tests/chatgpt-web-harness.test.ts
+++ b/tests/chatgpt-web-harness.test.ts
@@ -5,10 +5,11 @@ import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import type { Page } from "playwright-core";
 import { buildResponseJSON } from "../src/bridge";
 import { ChatGptWebAdapterError } from "../src/adapters/chatgpt-web/adapter-error";
 import { ChatGptCompletionTracker, chatGptImageFilePayloads, chatGptPromptFilePayloads, chatGptTurnIsComplete } from "../src/adapters/chatgpt-web/browser-worker";
-import { ChatGptBrowserWorker, type BrowserTurn } from "../src/adapters/chatgpt-web/browser-worker";
+import { ChatGptBrowserWorker, waitForOperationalChatGptViewport, type BrowserTurn } from "../src/adapters/chatgpt-web/browser-worker";
 import { chatGptConversationKey } from "../src/adapters/chatgpt-web/conversation-key";
 import { CHATGPT_TURN_REVISION_CONFLICT_MESSAGE, extractChatGptTurnEnvironment, extractChatGptTurnIdentity, extractChatGptTurnUserRevision, priorChatGptAbortedTurnIds } from "../src/adapters/chatgpt-web/environment";
 import { CHATGPT_WEB_ADAPTER_HEARTBEAT_MS, chatGptWebExecutionNamespace, chatGptWebTraceId, createChatGptWebAdapter } from "../src/adapters/chatgpt-web/index";
@@ -1242,6 +1243,85 @@ describe("ChatGPT outer-native harness v4", () => {
       await TurnBroker.forSocket(socketPath).close();
     }
   });
+
+  test("caps initial viewport acquisition retries across adapter instances", async () => {
+    const provider: CodexProviderConfig = {
+      adapter: "chatgpt-web",
+      baseUrl: `browser://chatgpt-viewport-retry-${Date.now()}`,
+      chatgptWeb: { localToolsEnabled: false, solAvailable: true, proAvailable: true },
+    };
+    const worker = ChatGptBrowserWorker.forProvider(provider);
+    const originalRun = worker.run.bind(worker);
+    const page = {
+      waitForFunction: () => Promise.reject(new Error("operational viewport timed out")),
+    } as unknown as Page;
+    let browserStarts = 0;
+    (worker as unknown as { run: (turn: BrowserTurn) => Promise<string> }).run = async turn => {
+      browserStarts += 1;
+      await waitForOperationalChatGptViewport(page, turn.abortSignal, { allowTurnRetry: true });
+      throw new Error("collapsed viewport unexpectedly became operational");
+    };
+    try {
+      const request = rawWireRequest(environmentXml);
+      for (let attempt = 0; attempt < MAX_CHATGPT_WEB_TURN_RETRIES + 2; attempt += 1) {
+        const events: AdapterEvent[] = [];
+        await createChatGptWebAdapter(provider).runTurn!(
+          request, { headers: new Headers() }, event => events.push(event),
+        );
+        expect(events.at(-1)).toMatchObject({
+          type: "error",
+          status: 503,
+          code: "chatgpt_surface_unavailable",
+          retryable: attempt < MAX_CHATGPT_WEB_TURN_RETRIES,
+        });
+      }
+      expect(browserStarts).toBe(MAX_CHATGPT_WEB_TURN_RETRIES + 1);
+    } finally {
+      (worker as unknown as { run: (turn: BrowserTurn) => Promise<string> }).run = originalRun;
+    }
+  });
+
+  test.each(["send_activated", "accepted"] as const)(
+    "a viewport rebind failure after %s never starts a replacement browser turn",
+    async phase => {
+      const provider: CodexProviderConfig = {
+        adapter: "chatgpt-web",
+        baseUrl: `browser://chatgpt-viewport-${phase}-${Date.now()}`,
+        chatgptWeb: { localToolsEnabled: false, solAvailable: true, proAvailable: true },
+      };
+      const worker = ChatGptBrowserWorker.forProvider(provider);
+      const originalRun = worker.run.bind(worker);
+      const page = {
+        waitForFunction: () => Promise.reject(new Error("operational viewport timed out during rebind")),
+      } as unknown as Page;
+      let browserStarts = 0;
+      (worker as unknown as { run: (turn: BrowserTurn) => Promise<string> }).run = async turn => {
+        browserStarts += 1;
+        await turn.onSendActivated?.();
+        if (phase === "accepted") turn.onSubmitted?.();
+        await waitForOperationalChatGptViewport(page, turn.abortSignal);
+        throw new Error("collapsed viewport unexpectedly became operational");
+      };
+      try {
+        const request = rawWireRequest(environmentXml);
+        for (let attempt = 0; attempt < 2; attempt += 1) {
+          const events: AdapterEvent[] = [];
+          await createChatGptWebAdapter(provider).runTurn!(
+            request, { headers: new Headers() }, event => events.push(event),
+          );
+          expect(events.at(-1)).toMatchObject({
+            type: "error",
+            status: 503,
+            code: "chatgpt_surface_unavailable",
+            retryable: false,
+          });
+        }
+        expect(browserStarts).toBe(1);
+      } finally {
+        (worker as unknown as { run: (turn: BrowserTurn) => Promise<string> }).run = originalRun;
+      }
+    },
+  );
 
   test("prompt preparation preserves its error instead of exposing a revoked MCP token", async () => {
     const socketPath = brokerTestEndpoint(`cgw-prepare-error-${process.pid}-${Date.now()}`);


### PR DESCRIPTION
## What this changes

Classify an operational-viewport failure as a structured `ChatGptWebAdapterError` with HTTP 503, `server_error`, and `chatgpt_surface_unavailable`.

Only initial page acquisition opts into the existing shared browser-turn retry budget. A viewport failure during a later page rebind remains non-retryable, preventing a replacement browser turn after submission or tool execution. Cancellation continues to surface as `AbortError`.

This does not change viewport dimensions, the ten-second probe deadline, browser selectors, compositing, model selection, or the retry-budget limit.

## Evidence

Focused regressions cover successful acquisition, retryable initial failure, non-retryable default/rebind failure, cancellation before and during acquisition, and exhaustion of the shared budget across adapter instances.

Two replay regressions verify both `send_activated` and `accepted` submission phases. Repeating the same request after a rebind failure returns the terminal non-retryable error and does not start another browser turn. During the preceding local review these regressions rejected an unrestricted-retry implementation; they pass with initial-acquisition-only opt-in.

Related PR #215 was rechecked: it is closed without merging and concerns viewport/compositor lifecycle. This PR is limited to error classification and replay safety, not those lifecycle changes.

## Scope and invariants

- [x] Read `CONTRIBUTING.md`; remaining account-bound acceptance gates are explicitly recorded below.
- [x] One focused fix and regression tests only, with no unrelated fork commits.
- [x] Explicit model, route, effort, connector, and capability selection is preserved.
- [x] Full mode retains its turn-bound capability; Browser-only gains no broker or connector.
- [x] No new DOM selectors or speculative UI matching.
- [x] No credentials, browser state, tunnel IDs, raw logs, private paths, generated artifacts, version changes, or dependency updates are committed.

## Verification

Fresh verification on 7 September 2026, on this exact branch based on upstream `c648c09`, using Bun 1.4.0 and isolated home, Codex, and application-state directories:

- [x] `bun install --frozen-lockfile` in the root and `launcher/`.
- [x] `bun run verify`: **663 runtime tests passed; 282 launcher tests passed, 1 platform-specific test skipped; 0 failures**.
- [x] Root and launcher audits: no vulnerabilities found.
- [x] Version consistency, both TypeScript checks, launcher production build, runtime bundle, and third-party notices generation passed.
- [x] Relocated runtime smoke: `RELOCATABLE_RUNTIME_SMOKE_OK`.
- [x] `git diff --check`; one independent commit.
- [ ] Account-bound, real installed Codex acceptance of the patched viewport failure/reconnect path.
- [ ] Native platform package build/smoke validation.

## Platform or account validation

Automated verification: macOS arm64, including deterministic page-failure and outer-harness fixtures. A patched installed Codex turn was **not run**, and no active application, runtime, or user configuration was replaced. Windows/Linux and packaged acceptance were **not run**. This PR remains a draft for those acceptance checks and upstream CI review.