### PR TITLE
feat: provider-only route mode defers Codex routing to an external router

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -172,7 +172,14 @@ ChatGPT endpoint so Voice session creation never falls through to the Responses-
 assignments are journaled and restored exactly on disconnect or uninstall; a conflicting existing
 Voice route requires explicit `--replace-codex-route` ownership. The daemon forwards the
 authenticated official model catalog and appends only the routed models owned by the
-`chatgpt-web/` namespace; no static catalog is installed. Subagent protocol selection is explicit,
+`chatgpt-web/` namespace; no static catalog is installed. An advanced
+`--codex-route-mode=external-provider` contract lets an external router (for example
+OpenCodex) permanently own the real Codex route. That installation never reads or writes the
+user's `~/.codex/config.toml`: setup, launcher bridge reconciliation, subagent protocol changes,
+and route connect/disconnect all fail closed instead. The local daemon serves only the routed
+ChatGPT Web models: non-Web native turns are rejected locally, and model discovery falls back
+to the web-owned rows when the built-in provider is unreachable. Returning to the default
+`managed` mode first unwinds an existing route journal so ownership can never split. Subagent protocol selection is explicit,
 and new installations default to Compatibility V1 because it is the only surface portable across
 native and routed Web backends:
 

--- a/launcher/electron/main.cjs
+++ b/launcher/electron/main.cjs
@@ -1161,6 +1161,11 @@ async function start() {
     }
     const runtime = await runtimeSupervisor.startIfConfigured();
     if (runtime.status !== "ready") return runtime;
+    if (runtimeHost.runtimeConfigSnapshot().config?.codexRouteMode === "external-provider") {
+      // Provider-only mode: OpenCodex owns the Codex route. The listener and tunnel are up;
+      // never reconcile, connect, or restore the route automatically.
+      return { ...runtime, bridgeRouteChanged: false };
+    }
     const route = await runtimeHost.connectBridgeRoute();
     return { ...runtime, bridgeRouteChanged: route.changed === true };
   })().then(async (runtime) => {

--- a/launcher/electron/runtime.cjs
+++ b/launcher/electron/runtime.cjs
@@ -804,6 +804,16 @@ class RuntimeHost {
 
   async bridgeStatus(operationName = "bridge-status") {
     this.assertProductionProfile("Codex bridge status");
+    if (this.runtimeConfigSnapshot().config?.codexRouteMode === "external-provider") {
+      // Provider-only mode never owns the Codex route: report a clean uninstalled state instead
+      // of inspecting (or worse, restoring) a route that belongs to an external router.
+      return {
+        installed: false,
+        active: false,
+        codexRouteMode: "external-provider",
+        errors: [],
+      };
+    }
     const result = await this.run(operationName, ["route", "status"], {
       embedded: true,
       message: "Checking Codex bridge route",
@@ -850,6 +860,7 @@ class RuntimeHost {
     this.lifecycleOperation = name;
     try {
       const current = await this.bridgeStatus(name);
+      if (current.codexRouteMode === "external-provider") return current;
       if (!current.installed) throw new Error("Install the Codex integration before connecting the bridge route");
       if (current.active) return current;
       try {
@@ -979,11 +990,15 @@ class RuntimeHost {
     if (!existing.configured && interactionMode === "manual") {
       throw new Error("Zero Risk must be installed through MCP setup because tunnel credentials are required");
     }
+    const explicitRouteMode = existing.config?.codexRouteMode === "external-provider"
+      ? ["--codex-route-mode", "external-provider"]
+      : [];
     const args = [
       "setup",
       mode === "full" ? "--full" : "--browser-only",
       "--browser-host-descriptor",
       this.browserDescriptorPath,
+      ...explicitRouteMode,
       ...this.browserInteractionArgs({
         mode: interactionMode,
         refreshCapabilities: interactionMode === "automatic",
@@ -1147,11 +1162,15 @@ class RuntimeHost {
         && !tunnelProfileMigrationRequired)) {
       return { updated: false };
     }
+    const explicitRouteMode = existing.config?.codexRouteMode === "external-provider"
+      ? ["--codex-route-mode", "external-provider"]
+      : [];
     const args = [
       "setup",
       existing.mode === "full" ? "--full" : "--browser-only",
       "--browser-host-descriptor",
       this.browserDescriptorPath,
+      ...explicitRouteMode,
       // A release may repair capability detection. Reusing the previous result can
       // keep eligible models disabled even after the corrected probe is installed.
       ...this.browserInteractionArgs({ mode: interactionMode, refreshCapabilities: true }),

--- a/launcher/tests/runtime-host.test.cjs
+++ b/launcher/tests/runtime-host.test.cjs
@@ -1256,3 +1256,50 @@ test("passkey sign-in is rejected outside macOS even if IPC is invoked directly"
   fixture.platform = "win32";
   assert.throws(() => fixture.passkeyChromeExecutable(), /supported only on macOS/);
 });
+
+test("bridge status treats provider-only mode as a clean never-owned route", async () => {
+  const calls = [];
+  const fixture = hostFor({ mode: "browser-only", browserHost: "launcher", codexRouteMode: "external-provider" });
+  fixture.host.run = async (_name, args) => {
+    calls.push(args.join(" "));
+    return { stdout: "", stderr: "" };
+  };
+  const result = await fixture.host.bridgeStatus();
+  assert.deepEqual(result, { installed: false, active: false, codexRouteMode: "external-provider", errors: [] });
+  assert.deepEqual(calls, []);
+});
+
+test("launcher never connects or restores a route when an external router owns Codex routing", async () => {
+  const calls = [];
+  const fixture = hostFor({ mode: "browser-only", browserHost: "launcher", codexRouteMode: "external-provider" });
+  fixture.host.run = async (_name, args) => {
+    calls.push(args.join(" "));
+    return { stdout: "", stderr: "" };
+  };
+  const connected = await fixture.host.connectBridgeRoute();
+  assert.equal(connected.codexRouteMode, "external-provider");
+  const restored = await fixture.host.restoreBridgeRoute("runtime-start-fail-safe");
+  assert.equal(restored.codexRouteMode, "external-provider");
+  assert.deepEqual(calls, []);
+});
+
+test("core setup preserves provider-only route ownership in its setup arguments", async () => {
+  const fixture = hostFor({ mode: "browser-only", browserHost: "launcher", codexRouteMode: "external-provider" });
+  await fixture.host.setupCore();
+  const args = fixture.invocation().args;
+  assert.equal(args.includes("--codex-route-mode"), true);
+  assert.equal(args[args.indexOf("--codex-route-mode") + 1], "external-provider");
+});
+
+test("runtime upgrade preserves provider-only route ownership", async () => {
+  const fixture = hostFor({
+    mode: "browser-only",
+    browserHost: "launcher",
+    codexRouteMode: "external-provider",
+    releaseVersion: "1.1.1",
+  });
+  assert.equal((await fixture.host.upgradeManagedRuntime()).updated, true);
+  const args = fixture.invocation().args;
+  assert.equal(args.includes("--codex-route-mode"), true);
+  assert.equal(args[args.indexOf("--codex-route-mode") + 1], "external-provider");
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,6 +74,8 @@ Setup options:
   --tunnel-id ID               Existing OpenAI tunnel id (full mode)
   --runtime-key-file PATH      File containing a Tunnels Read+Use runtime key
   --replace-codex-route        Reversibly replace existing Responses or Voice route settings
+  --codex-route-mode MODE      managed (default) or external-provider: never touch the Codex
+                               config; an external router (e.g. OpenCodex) keeps Codex routing
   --subagent-protocol MODE     compatibility-v1 (default) or native (advanced)
   --restart-service            Explicitly restart this project's daemon after an update
   --login                      Refresh the stored ChatGPT login even if one exists
@@ -313,6 +315,13 @@ async function setupCommand(args: string[]): Promise<void> {
   }
   if (zeroRiskPro || zeroRiskDefault) options.zeroRiskProEnabled = zeroRiskPro;
   options.replaceCodexRoute = takeFlag(args, "--replace-codex-route");
+  const codexRouteMode = takeOption(args, "--codex-route-mode");
+  if (codexRouteMode !== undefined) {
+    if (codexRouteMode !== "managed" && codexRouteMode !== "external-provider") {
+      throw new Error("--codex-route-mode must be \"managed\" or \"external-provider\"");
+    }
+    options.codexRouteMode = codexRouteMode;
+  }
   options.restartService = takeFlag(args, "--restart-service");
   assertNoArgs(args);
 
@@ -377,6 +386,7 @@ async function routeCommand(args: string[]): Promise<void> {
         return {
           installed: status.installed,
           active: status.active,
+          codexRouteMode: status.codexRouteMode,
           ...(status.routeUrl ? { routeUrl: status.routeUrl } : {}),
           errors: status.errors,
         };

--- a/src/codex-integration.ts
+++ b/src/codex-integration.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { dirname } from "node:path";
 import type { AppConfig } from "./config";
-import { atomicWriteFile, getConfigPath, loadConfig, saveConfig } from "./config";
+import { atomicWriteFile, getConfigPath, isExternalProviderMode, loadConfig, saveConfig } from "./config";
 import { installCodexInterruptHook, installCodexInterruptHookCommand } from "./codex-interrupt-hook";
 import {
   CODEX_REALTIME_WEBRTC_CALL_BASE_URL,
@@ -127,6 +127,7 @@ export function setCodexSubagentProtocol(
   config: AppConfig,
   protocol: AppConfig["subagentProtocol"],
 ): CodexIntegrationJournal {
+  if (isExternalProviderMode(config)) throw new Error(EXTERNAL_PROVIDER_ROUTE_BLOCKED);
   const status = inspectCodexIntegration();
   if (!status.installed) throw new Error("Codex integration is not installed; run setup first");
   if (!status.active) {
@@ -165,10 +166,26 @@ export function setCodexSubagentProtocol(
   }
 }
 
+export const EXTERNAL_PROVIDER_ROUTE_BLOCKED =
+  "codexRouteMode is external-provider: this installation never owns the Codex route."
+  + " Route ownership belongs to the external router (for example OpenCodex)."
+  + " Refusing to modify the user's Codex configuration.";
+
+/**
+ * Fail closed when route ownership is external: provider-only installations never mutate the
+ * Codex config. A missing app configuration behaves like the default managed mode, matching
+ * `inspectCodexIntegration`.
+ */
+function assertRouteOwnershipAllowed(): void {
+  if (!existsSync(getConfigPath())) return;
+  if (isExternalProviderMode(loadConfig())) throw new Error(EXTERNAL_PROVIDER_ROUTE_BLOCKED);
+}
+
 export function preflightCodexIntegration(
   config: AppConfig,
   options: InstallCodexIntegrationOptions = {},
 ): void {
+  if (isExternalProviderMode(config)) throw new Error(EXTERNAL_PROVIDER_ROUTE_BLOCKED);
   const configPath = getCodexConfigPath();
   const configExists = existsSync(configPath);
   const currentText = configExists ? readFileSync(configPath, "utf8") : "";
@@ -224,10 +241,12 @@ export function preflightCodexIntegration(
     options.replaceExistingRoute === true,
   );
 }
+
 export function installCodexIntegration(
   config: AppConfig,
   options: InstallCodexIntegrationOptions = {},
 ): CodexIntegrationJournal {
+  if (isExternalProviderMode(config)) throw new Error(EXTERNAL_PROVIDER_ROUTE_BLOCKED);
   const configPath = getCodexConfigPath();
   mkdirSync(dirname(configPath), { recursive: true, mode: 0o700 });
   const configExists = existsSync(configPath);
@@ -340,6 +359,7 @@ export function installCodexIntegration(
 }
 
 export function deactivateCodexIntegration(): SetCodexIntegrationActiveResult {
+  assertRouteOwnershipAllowed();
   const existing = readJournal();
   if (!existing) return { changed: false, active: false };
   if (existing.version === 2) {
@@ -369,6 +389,7 @@ export function deactivateCodexIntegration(): SetCodexIntegrationActiveResult {
 }
 
 export function activateCodexIntegration(): SetCodexIntegrationActiveResult {
+  assertRouteOwnershipAllowed();
   const existing = readJournal();
   if (!existing) throw new Error("Codex integration is not installed");
   if (existing.version === 2) {
@@ -484,6 +505,7 @@ export function uninstallCodexIntegration(): UninstallCodexIntegrationResult {
 export function inspectCodexIntegration(): {
   installed: boolean;
   active: boolean;
+  codexRouteMode: "managed" | "external-provider";
   configPath: string;
   routeUrl?: string;
   journal?: AnyCodexIntegrationJournal;
@@ -491,6 +513,12 @@ export function inspectCodexIntegration(): {
 } {
   const journal = readJournal();
   const errors: string[] = [];
+  let routeMode: "managed" | "external-provider" = "managed";
+  try {
+    routeMode = isExternalProviderMode(loadConfig()) ? "external-provider" : "managed";
+  } catch {
+    // Configuration may not exist yet; provider-only status is then simply not established.
+  }
   if (journal) {
     try {
       assertJournalTargetsConfig(journal, getCodexConfigPath());
@@ -516,6 +544,7 @@ export function inspectCodexIntegration(): {
   }
   return {
     installed: Boolean(journal),
+    codexRouteMode: routeMode,
     active: journal?.version === 4 || journal?.version === 5 || journal?.version === 6 || journal?.version === 7 || journal?.version === 8 || journal?.version === 9 || journal?.version === 10
       ? journal.active
       : Boolean(journal),

--- a/src/config.ts
+++ b/src/config.ts
@@ -98,12 +98,23 @@ export interface TunnelConfig {
   alias: string;
 }
 
+/**
+ * How the user's real Codex route (`openai_base_url` in `~/.codex/config.toml`) is owned:
+ * - "managed": this installation installs and reversibly owns the route (upstream default).
+ * - "external-provider": this installation NEVER touches the Codex config; an external router
+ *   (e.g. OpenCodex) permanently owns Codex routing and this runtime is only a selectable
+ *   Web-model provider. Route and subagent commands fail closed in this mode.
+ */
+export type CodexRouteMode = "managed" | "external-provider";
+
 export interface AppConfig {
   version: 3;
   purpose?: "dev-harness";
   releaseVersion: string;
   mode: RuntimeMode;
   subagentProtocol: SubagentProtocol;
+  /** Defaults to "managed"; see the CodexRouteMode docs for the provider-only contract. */
+  codexRouteMode?: CodexRouteMode;
   host: "127.0.0.1";
   port: number;
   contextWindow: number;
@@ -537,6 +548,11 @@ function parseConfig(value: unknown, path: string): AppConfig {
   if (proAvailable && !solAvailable) {
     throw new Error(`Invalid ChatGPT account capabilities in ${path}: Pro requires Sol`);
   }
+  if (parsed.codexRouteMode !== undefined
+    && parsed.codexRouteMode !== "managed"
+    && parsed.codexRouteMode !== "external-provider") {
+    throw new Error(`Invalid codexRouteMode in ${path}: must be "managed" or "external-provider"`);
+  }
   return {
     ...parsed,
     appName: expectedAppName,
@@ -555,6 +571,14 @@ export function saveConfig(config: AppConfig): void {
   const path = getConfigPath();
   const original = existsSync(path) ? readFileSync(path, "utf8") : "";
   atomicWriteFile(path, preserveUtf8Bom(`${JSON.stringify(config, null, 2)}\n`, original));
+}
+
+export function codexRouteMode(config: Pick<AppConfig, "codexRouteMode"> | undefined): CodexRouteMode {
+  return config?.codexRouteMode ?? "managed";
+}
+
+export function isExternalProviderMode(config: Pick<AppConfig, "codexRouteMode"> | undefined): boolean {
+  return codexRouteMode(config) === "external-provider";
 }
 
 export function providerConfig(config: AppConfig): CodexProviderConfig {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -149,7 +149,19 @@ export async function runDoctor(): Promise<DoctorReport> {
   }
 
   const codex = inspectCodexIntegration();
-  if (!codex.installed) {
+  if (codex.codexRouteMode === "external-provider") {
+    checks.push(codex.installed
+      ? {
+          id: "codex",
+          status: "warning",
+          message: "External-provider mode is active but a managed Codex route journal still exists; run `codex-chatgpt-web uninstall --yes`",
+        }
+      : {
+          id: "codex",
+          status: "ok",
+          message: "External-provider mode: the Codex route is owned externally and was not modified",
+        });
+  } else if (!codex.installed) {
     checks.push({ id: "codex", status: "error", message: "Codex model route is not installed" });
   } else if (codex.errors.length > 0) {
     checks.push({ id: "codex", status: "error", message: "Codex integration is inconsistent", detail: codex.errors.join("; ") });

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,7 +18,7 @@ import {
 import { rememberCompactionContinuation } from "./adapters/chatgpt-web/compaction-continuation";
 import { bridgeToResponsesSSE, buildResponseJSON, formatErrorResponse } from "./bridge";
 import type { AppConfig } from "./config";
-import { providerConfig } from "./config";
+import { codexRouteMode, isExternalProviderMode, providerConfig } from "./config";
 import { AsyncEventQueue } from "./event-queue";
 import { readJsonRequestBody } from "./http-body";
 import { httpStatusFromTerminalError } from "./lib/errors";
@@ -382,7 +382,12 @@ export async function modelsRequest(
   try {
     upstream = await forwardNativeCodexRequest(req, "models", fetchUpstream);
   } catch (error) {
-    return formatErrorResponse(502, "upstream_error", error instanceof Error ? error.message : String(error));
+    if (!isExternalProviderMode(config)) {
+      return formatErrorResponse(502, "upstream_error", error instanceof Error ? error.message : String(error));
+    }
+    // Provider-only mode has no real Codex bearer: serve the Web routes locally.
+    const catalog = augmentNativeModelCatalog({ models: [] }, config, contextOverride?.());
+    return Response.json(catalog);
   }
   if (!upstream.ok) return upstream;
   let catalog: Record<string, unknown>;
@@ -456,6 +461,15 @@ export async function responseRequest(
     return formatErrorResponse(400, "invalid_request_error", error instanceof Error ? error.message : String(error));
   }
   if (typeof requestedModel === "string" && !isChatGptWebModelSlug(requestedModel)) {
+    if (isExternalProviderMode(config)) {
+      // Fail closed: provider-only mode never forwards non-Web turns to a native backend.
+      return formatErrorResponse(
+        400,
+        "invalid_request_error",
+        `Model \"${requestedModel}\" is not a ChatGPT Web model; this server is provider-only`
+          + " (codexRouteMode=external-provider) and cannot route it natively",
+      );
+    }
     try {
       return await forwardNativeCodexRequest(nativeRequest, "responses", undefined, raw);
     } catch (error) {
@@ -681,6 +695,15 @@ export async function compactRequest(
     return formatErrorResponse(400, "invalid_request_error", "Compaction request requires a model");
   }
   if (!isChatGptWebModelSlug(raw.model)) {
+    if (isExternalProviderMode(config)) {
+      // Fail closed: provider-only mode never forwards non-Web compaction to a native backend.
+      return formatErrorResponse(
+        400,
+        "invalid_request_error",
+        `Model \"${raw.model}\" is not a ChatGPT Web model; this server is provider-only`
+          + " (codexRouteMode=external-provider) and cannot route it natively",
+      );
+    }
     try {
       return await forwardNativeCodexRequest(nativeRequest, "responses/compact", undefined, raw);
     } catch (error) {
@@ -794,6 +817,7 @@ export function startServer(
           service: "codex-chatgpt-web",
           version: VERSION,
           mode: config.mode,
+          codex_route_mode: codexRouteMode(config),
           pid: process.pid,
           port: config.port,
           uptime: (Date.now() - startedAt) / 1_000,

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -2,12 +2,14 @@ import { existsSync } from "node:fs";
 import { randomBytes } from "node:crypto";
 import { createServer } from "node:net";
 import { join } from "node:path";
-import type { AppConfig, BrowserInteractionMode, RuntimeMode, SubagentProtocol } from "./config";
+import type { AppConfig, BrowserInteractionMode, CodexRouteMode, RuntimeMode, SubagentProtocol } from "./config";
 import {
+  codexRouteMode,
   currentRuntimeCommand,
   defaultBrokerEndpoint,
   defaultConfig,
   getConfigPath,
+  isExternalProviderMode,
   loadConfigForSetup,
   resolveInteractionConnectorIdentities,
   resolveDevSetupConnectorName,
@@ -22,8 +24,10 @@ import {
 } from "./browser-login";
 import {
   installCodexIntegration,
+  inspectCodexIntegration,
   preflightCodexIntegration,
   readCodexSubagentProtocol,
+  uninstallCodexIntegration,
 } from "./codex-integration";
 import { inspectLauncherBrowserHost } from "./launcher-browser-host";
 import {
@@ -47,6 +51,12 @@ export interface SetupOptions {
   mode: RuntimeMode;
   browserInteractionMode?: BrowserInteractionMode;
   subagentProtocol?: SubagentProtocol;
+  /**
+   * How the real Codex route is owned. "external-provider" installs this runtime as a pure Web
+   * model provider: the Codex config is never read or modified, and an external router (e.g.
+   * OpenCodex) keeps permanent ownership of Codex routing. Defaults to "managed".
+   */
+  codexRouteMode?: CodexRouteMode;
   port?: number;
   chromeExecutablePath?: string;
   browserHostDescriptorPath?: string;
@@ -127,6 +137,7 @@ function meaningfulRuntimeChange(before: AppConfig, after: AppConfig): boolean {
   return JSON.stringify({
     mode: before.mode,
     subagentProtocol: before.subagentProtocol,
+    codexRouteMode: before.codexRouteMode,
     releaseVersion: before.releaseVersion,
     host: before.host,
     port: before.port,
@@ -154,6 +165,7 @@ function meaningfulRuntimeChange(before: AppConfig, after: AppConfig): boolean {
   }) !== JSON.stringify({
     mode: after.mode,
     subagentProtocol: after.subagentProtocol,
+    codexRouteMode: after.codexRouteMode,
     releaseVersion: after.releaseVersion,
     host: after.host,
     port: after.port,
@@ -246,6 +258,16 @@ function baseConfig(existing: AppConfig | undefined, options: SetupOptions): App
     config.browserInteractionMode,
     options.appName,
   ));
+  if (options.codexRouteMode !== undefined) {
+    if (options.codexRouteMode !== "managed" && options.codexRouteMode !== "external-provider") {
+      throw new Error('Invalid --codex-route-mode: must be "managed" or "external-provider"');
+    }
+    config.codexRouteMode = options.codexRouteMode;
+  } else if (existing && codexRouteMode(existing) !== codexRouteMode(config)) {
+    // Keep an established provider-only installation provider-only across re-runs. Managed
+    // setups only change when the request explicitly asks for the external-provider mode.
+    config.codexRouteMode = existing.codexRouteMode;
+  }
   if (options.subagentProtocol) config.subagentProtocol = options.subagentProtocol;
   config.releaseVersion = VERSION;
   config.runtimeCommand = currentRuntimeCommand();
@@ -458,16 +480,28 @@ export function preflightSetup(options: SetupOptions): void {
       throw new Error("Automatic and Zero Risk require different Tunnel IDs and separate ChatGPT connectors");
     }
   }
-  preflightCodexIntegration(config, {
-    replaceExistingRoute: options.replaceCodexRoute,
-  });
+  if (!isExternalProviderMode(config)) {
+    preflightCodexIntegration(config, {
+      replaceExistingRoute: options.replaceCodexRoute,
+    });
+  }
 }
 
 export async function setup(options: SetupOptions): Promise<SetupResult> {
   const { existing, config, launcherOwned } = prepareSetup(options);
-  preflightCodexIntegration(config, {
-    replaceExistingRoute: options.replaceCodexRoute,
-  });
+  const previousRouteMode = codexRouteMode(existing);
+  const requestedRouteMode = codexRouteMode(config);
+  if (previousRouteMode !== requestedRouteMode && existing) {
+    // Ownership of the real Codex route can only move while the integration is fully unwound, so
+    // switching between managed and external-provider ownership is a destructive migration that
+    // restores the user's prior Codex route before the new mode takes effect.
+    if (inspectCodexIntegration().installed) uninstallCodexIntegration();
+  }
+  if (!isExternalProviderMode(config)) {
+    preflightCodexIntegration(config, {
+      replaceExistingRoute: options.replaceCodexRoute,
+    });
+  }
   const refreshTunnelWorker = tunnelWorkerRuntimeChanged(existing, config);
   if (existing && options.restartService) config.controlToken = randomBytes(32).toString("base64url");
   const beforeService = getServiceStatus();
@@ -601,9 +635,13 @@ export async function setup(options: SetupOptions): Promise<SetupResult> {
     launcherOwned && existing && existing.browserHost !== "launcher",
   );
   if (!migratingTerminalRuntime) removeLegacyRuntimeArtifacts(config);
-  installCodexIntegration(config, {
-    replaceExistingRoute: options.replaceCodexRoute,
-  });
+  // Provider-only installations never touch Codex routing. Switching to provider mode performs a
+  // destructive uninstall first (see the top of this function) and then installs nothing.
+  if (!isExternalProviderMode(config)) {
+    installCodexIntegration(config, {
+      replaceExistingRoute: options.replaceCodexRoute,
+    });
+  }
 
   return {
     mode: config.mode,

--- a/tests/codex-integration.test.ts
+++ b/tests/codex-integration.test.ts
@@ -24,6 +24,7 @@ import {
   MANAGED_MULTI_AGENT_LINE,
   MANAGED_MULTI_AGENT_V2_LINE,
   MANAGED_ROUTE_COMMENT,
+  getCodexConfigPath,
   managedAgentMaxDepthLine,
 } from "../src/codex-integration-shared";
 
@@ -908,4 +909,67 @@ describe("reversible native Codex route integration", () => {
     expect(readFileSync(configPath, "utf8")).not.toContain("multi_agent");
   });
 
+});
+
+describe("external-provider route mode never touches the Codex config", () => {
+  function providerConfig(mode: "browser-only" | "full") {
+    const config = defaultConfig(mode);
+    config.codexRouteMode = "external-provider";
+    return config;
+  }
+
+  test("preflight and install fail closed when an external router owns the route", () => {
+    const { codexHome } = fixture();
+    const configPath = join(codexHome, "config.toml");
+    const original = `model = "gpt-5.6-sol"\n`;
+    writeFileSync(configPath, original);
+
+    const config = providerConfig("browser-only");
+    expect(() => preflightCodexIntegration(config)).toThrow(/external-provider/);
+    expect(() => installCodexIntegration(config)).toThrow(/external-provider/);
+    // Provider-only setup must leave the user's Codex config byte-for-byte untouched.
+    expect(readFileSync(configPath, "utf8")).toBe(original);
+  });
+
+  test("subagent protocol mutation refuses to run in provider-only mode", () => {
+    const { codexHome } = fixture();
+    const configPath = join(codexHome, "config.toml");
+    const original = `model = "gpt-5.6-sol"\n`;
+    writeFileSync(configPath, original);
+
+    const config = providerConfig("browser-only");
+    expect(() => setCodexSubagentProtocol(config, "compatibility-v1")).toThrow(/external-provider/);
+    expect(readFileSync(configPath, "utf8")).toBe(original);
+  });
+
+  test("route connect/disconnect fail closed after the app config is provider-only", () => {
+    const { appHome } = fixture();
+    // A previously managed integration could exist; provider mode must never unwind or touch it.
+    saveConfig(providerConfig("browser-only"));
+
+    expect(() => activateCodexIntegration()).toThrow(/external-provider/);
+    expect(() => deactivateCodexIntegration()).toThrow(/external-provider/);
+  });
+
+  test("inspection reports provider-only ownership without requiring a journal", () => {
+    fixture();
+    saveConfig(providerConfig("browser-only"));
+
+    expect(inspectCodexIntegration()).toEqual({
+      installed: false,
+      active: false,
+      codexRouteMode: "external-provider",
+      configPath: getCodexConfigPath(),
+      errors: [],
+    });
+  });
+
+  test("inspection reports managed ownership by default", () => {
+    fixture();
+    saveConfig(compatibilityV1Config("browser-only"));
+
+    const status = inspectCodexIntegration();
+    expect(status.codexRouteMode).toBe("managed");
+    expect(status.installed).toBe(false);
+  });
 });


### PR DESCRIPTION
Implements the external-provider route mode from the CGW_OPENCODEX handoff. This is an unsupported local fork patch; upstream defaults are unchanged (managed).

## Summary
- New `codexRouteMode` setting (`managed` default | `external-provider`)
- Provider-only mode NEVER reads or writes `~/.codex/config.toml`; setup, launcher bridge reconcile/connect/restore, and subagent mutations fail closed
- Setup route-mode transition unwinds an existing journal before switching ownership
- Server serves the Web model catalog locally when no native bearer exists and rejects non-Web native turns locally
- CLI `--codex-route-mode` / route status + doctor surface the mode

## Tests
- 5 new src tests (codex-integration) + 4 new launcher tests (runtime-host), all green
- src typecheck passes; launcher runtime.cjs/main.cjs parse cleanly

Full detail is delivered in `CGW_OPENCODEX_PROVIDER_IMPLEMENTATION_HANDOFF.md` (not committed).
