### PR TITLE
fix: read the current environment envelope per content part

### DIFF
--- a/src/adapters/chatgpt-web/environment.ts
+++ b/src/adapters/chatgpt-web/environment.ts
@@ -240,6 +240,31 @@ export function isChatGptCompactionContinuation(parsed: CodexParsedRequest): boo
     && isAcceptedCompactionContinuation(parsed, identity, revision);
 }
 
+const ENVIRONMENT_ENVELOPE = /^<environment_context>[\s\S]*<\/environment_context>$/;
+
+function environmentEnvelope(text: unknown): string[] {
+  if (typeof text !== "string") return [];
+  const trimmed = text.trim();
+  return ENVIRONMENT_ENVELOPE.test(trimmed) ? [trimmed] : [];
+}
+
+/**
+ * Return the environment envelopes one message carries, one content part at a time.
+ *
+ * Codex always sends the envelope as its own part. When it rebuilds the preamble for a compacted
+ * history it keeps that part but adds sibling parts around it (recommended plugins, AGENTS.md
+ * instructions), so the joined message text is not an envelope and must never be the unit of
+ * recognition; every caller here has to agree on the part, or a valid current update disappears.
+ *
+ * Only a real content array is read. Codex never sends the envelope as a bare message string, and
+ * that shape has never carried filesystem authority on these paths, so it must not start now.
+ */
+function environmentEnvelopeParts(item: Record<string, unknown>): string[] {
+  return Array.isArray(item.content)
+    ? item.content.flatMap(part => environmentEnvelope(record(part)?.text))
+    : [];
+}
+
 /** Parse a claim only: the caller must compare it with this turn's native rollout authority. */
 export function extractChatGptContinuationEnvironmentClaim(parsed: CodexParsedRequest): ChatGptTurnEnvironment {
   const turnId = extractChatGptTurnIdentity(parsed).turnId;
@@ -248,11 +273,16 @@ export function extractChatGptContinuationEnvironmentClaim(parsed: CodexParsedRe
     const item = record(value);
     if (item?.type !== "message" || item.role !== "user" || itemTurnId(item) !== turnId
       || typeof item.id !== "string" || !item.id) return [];
-    const text = rawMessageText(item).trim();
-    return /^<environment_context>[\s\S]*<\/environment_context>$/.test(text) ? [text] : [];
+    // A claim is only ever cross-checked against the native rollout, so the bare string shape the
+    // authority paths refuse stays readable here.
+    return typeof item.content === "string" ? environmentEnvelope(item.content) : environmentEnvelopeParts(item);
   });
-  if (updates.length !== 1) throw new Error("Compaction continuation requires one current native environment claim");
-  return parseChatGptEnvironmentText(parsed, updates[0]!);
+  // Reading per part finds an envelope the joined text used to hide, so one turn can now surface
+  // the same envelope twice: once from Codex and once quoted back in a current-turn message.
+  // Identical text is one claim; genuinely different claims stay ambiguous and still fail closed.
+  const distinct = [...new Set(updates)];
+  if (distinct.length !== 1) throw new Error("Compaction continuation requires one current native environment claim");
+  return parseChatGptEnvironmentText(parsed, distinct[0]!);
 }
 
 function environmentBeforeUser(input: unknown[], userIndex: number, expectedTurnId?: string): string | undefined {
@@ -276,14 +306,7 @@ function environmentBeforeUser(input: unknown[], userIndex: number, expectedTurn
   const candidateTurnId = itemTurnId(candidate);
   if (candidateTurnId !== userTurnId) return undefined;
 
-  const content = Array.isArray(candidate.content) ? candidate.content : [];
-  for (const part of content) {
-    const text = record(part)?.text;
-    if (typeof text !== "string") continue;
-    const trimmed = text.trim();
-    if (/^<environment_context>[\s\S]*<\/environment_context>$/.test(trimmed)) return trimmed;
-  }
-  return undefined;
+  return environmentEnvelopeParts(candidate)[0];
 }
 
 function sandboxTypeFromEnvironment(text: string): ChatGptSandboxPolicy["type"] | undefined {
@@ -434,12 +457,7 @@ function canonicalMetadataEnvironmentBeforeUser(
   const candidateTurnId = itemTurnId(candidate);
   if (candidateTurnId !== undefined && candidateTurnId !== metadataTurnId) return undefined;
 
-  const content = Array.isArray(candidate.content) ? candidate.content : [];
-  for (const part of content) {
-    const text = record(part)?.text;
-    if (typeof text !== "string") continue;
-    const trimmed = text.trim();
-    if (!/^<environment_context>[\s\S]*<\/environment_context>$/.test(trimmed)) continue;
+  for (const trimmed of environmentEnvelopeParts(candidate)) {
     // Current Codex stamps server-owned item IDs but not per-item turn IDs on the initial request,
     // and canonical workspaces contains Git enrichment rather than filesystem authority. Bind the
     // structurally adjacent context (allowing only provenance-checked developer messages) to

--- a/tests/environment.test.ts
+++ b/tests/environment.test.ts
@@ -3,7 +3,7 @@ import { Database } from "bun:sqlite";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import { extractChatGptTurnEnvironment, extractChatGptTurnIdentity } from "../src/adapters/chatgpt-web/environment";
+import { extractChatGptContinuationEnvironmentClaim, extractChatGptTurnEnvironment, extractChatGptTurnIdentity } from "../src/adapters/chatgpt-web/environment";
 import { rememberCompactionContinuation } from "../src/adapters/chatgpt-web/compaction-continuation";
 import { encodeCompactionSummary, SUMMARY_PREFIX } from "../src/responses/compaction";
 import { ChatGptThreadEnvironmentStore } from "../src/adapters/chatgpt-web/thread-environment";
@@ -817,6 +817,79 @@ describe("trusted Codex task environment continuity", () => {
     ].join("\n") + "\n");
     // A valid cached environment and matching wire claim cannot overrule a different native turn.
     expect(() => store.resolve(request)).toThrow("current turn");
+  });
+
+  test("continuation accepts a current environment part beside Codex's own preamble parts", () => {
+    const { codexHome, request } = resumedRootFixture();
+    const body = request._rawBody as { input: Array<Record<string, unknown>> };
+    const oldTurnId = "01a06c66-0000-75c6-a0df-318f890ef6de";
+    const source = {
+      type: "message", role: "user", id: "msg_source_instruction",
+      content: [{ type: "input_text", text: "Finish the migration" }],
+      internal_chat_message_metadata_passthrough: { turn_id: oldTurnId },
+    };
+    // Codex rebuilds its own preamble when it installs a compacted history: the recommended
+    // plugins, the AGENTS.md instructions and the environment envelope arrive as separate parts
+    // of one server-owned user item, ahead of the replayed instruction the summary continues.
+    const current = {
+      type: "message", role: "user", id: "msg_current_environment",
+      content: [
+        { type: "input_text", text: "<recommended_plugins>\nAirtable (airtable@openai-curated-remote)\n</recommended_plugins>" },
+        { type: "input_text", text: "# AGENTS.md instructions\n\n<INSTRUCTIONS>\nKeep answers short.\n</INSTRUCTIONS>" },
+        { type: "input_text", text: environmentXml },
+      ],
+      internal_chat_message_metadata_passthrough: { turn_id: rolloutTurnId },
+    };
+    const summary = "Confirmed multipart checkpoint";
+    body.input.splice(0, body.input.length, {
+      type: "message", role: "user", id: "msg_replayed_history",
+      content: [{ type: "input_text", text: "Earlier request" }],
+      internal_chat_message_metadata_passthrough: { turn_id: oldTurnId },
+    }, {
+      type: "message", role: "developer", id: "msg_current_preamble",
+      content: [{ type: "input_text", text: "<skills_instructions>none</skills_instructions>" }],
+      internal_chat_message_metadata_passthrough: { turn_id: rolloutTurnId },
+    }, current, source, { type: "compaction", encrypted_content: encodeCompactionSummary(summary) });
+    rememberCompactionContinuation({ ...request, _compactionRequest: true }, extractChatGptTurnIdentity(request), [
+      { turnId: oldTurnId, content: source.content },
+    ], summary);
+    const store = new ChatGptThreadEnvironmentStore(undefined, Date.now, codexHome);
+    expect(store.resolve(request).cwd).toBe(root);
+  });
+
+  // Reading per part finds envelopes the joined message text used to hide, so the exported claim
+  // parser can now see the same turn carry two. Codex does not produce that shape today, but the
+  // parser is public and must not turn a quoted copy into a failed continuation.
+  test("duplicate current claims are one claim and conflicting ones still fail closed", () => {
+    const { request } = resumedRootFixture();
+    const body = request._rawBody as { input: Array<Record<string, unknown>> };
+    const quoted = {
+      type: "message", role: "user", id: "msg_quoted_environment",
+      content: [
+        { type: "input_text", text: "Also check the lockfile" },
+        { type: "input_text", text: environmentXml },
+      ],
+      internal_chat_message_metadata_passthrough: { turn_id: rolloutTurnId },
+    };
+    body.input.splice(0, body.input.length, {
+      type: "message", role: "user", id: "msg_current_environment",
+      content: [{ type: "input_text", text: environmentXml }],
+      internal_chat_message_metadata_passthrough: { turn_id: rolloutTurnId },
+    }, quoted);
+    expect(extractChatGptContinuationEnvironmentClaim(request).cwd).toBe(root);
+    quoted.content[1]!.text = environmentXml.replaceAll(root, resolve(root, "another-workspace"));
+    expect(() => extractChatGptContinuationEnvironmentClaim(request))
+      .toThrow("one current native environment claim");
+  });
+
+  test("a whole-message string envelope is not an authority-bearing shape", () => {
+    const request = currentWire();
+    const body = request._rawBody as { input: Array<Record<string, unknown>> };
+    // The same envelope split into content parts is trusted, as the v0.146 split envelope test
+    // shows. Codex never sends it as a bare message string, and reading that shape would hand a
+    // client filesystem authority the canonical part-wise paths never granted it.
+    body.input[0]!.content = environmentXml;
+    expect(() => extractChatGptTurnEnvironment(request)).toThrow("missing cwd");
   });
 
   test("old untagged transcript context cannot block or replace current rollout authority after restart", () => {


### PR DESCRIPTION
## The failure

A thread dies permanently at its first context compaction. The handoff itself succeeds; the
continuation immediately after does not:

```
15:32:04.883  broker trace=0903cffd4623 accepted structured compaction handoff
15:32:05.475  browser turn 0903cffd4623 failed: ChatGPT web turn aborted
15:32:07.291  trusted environment unavailable (thread_id=present, turn_id=present,
              previous_response_id=none, replay_prefix_items=0, context_messages=38)
   ... x6 with backoff, then Codex gives up on the turn
```

Seen on v5.0.4, Windows, Full mode, `chatgpt-web/pro`.

## Cause

`extractChatGptContinuationEnvironmentClaim` matched the envelope against `rawMessageText(item)` —
every content part joined with a newline — while `environmentBeforeUser` and
`canonicalMetadataEnvironmentBeforeUser` matched it against each part on its own.

That disagreement is invisible until compaction. When Codex installs a compacted history it
rebuilds its preamble into one server-owned user item. From the captured `replacement_history`,
item 34 has three parts:

| part | content |
|---|---|
| 0 | `<recommended_plugins>…` |
| 1 | `# AGENTS.md instructions <INSTRUCTIONS>…` |
| 2 | `<environment_context><cwd>…</cwd>…</environment_context>` |

Before compaction the envelope is its own item and matches. After, the *joined* text starts with
`<recommended_plugins>`, so the anchored regex finds zero claims and the parser throws
`"Compaction continuation requires one current native environment claim"` from
`ChatGptThreadEnvironmentStore.resolve` (thread-environment.ts:158) — before the native rollout
recovery at lines 165-181, which had the correct environment in the turn's own `turn_context`.

Replaying the real 37-item `replacement_history` through the exported parser:

```
v5.0.4    CLAIM THREW: Compaction continuation requires one current native environment claim
patched   CLAIM OK: cwd C:\...\AATS | workspaceWrite | roots: 2
```

The recovered authority matches the `turn_context` Codex wrote for that turn, so the
`sameAuthority` cross-check passes and the continuation proceeds.

## The change

Read envelopes one content part at a time through a single helper the three call sites share, so
they cannot drift apart again.

Two deliberate details, both from adversarial review of an earlier draft of this patch:

- **The helper reads a content array only.** `rawMessageText` also flattened a bare string
  `content`. Carrying that into the helper let a whole-message string reach `environmentBeforeUser`,
  which is on the primary authority path and has no metadata/workspace binding — a shape that path
  never accepted. Verified as a real widening before it was removed: with the string branch, an
  input claiming `<cwd>C:\</cwd>` with `dangerFullAccess` was granted despite client metadata
  declaring a different workspace. The claim parser keeps its own string handling, because a claim
  is only cross-checked against the rollout at thread-environment.ts:175 and never becomes
  authority on its own.
- **Identical claims are deduplicated.** Per-part reading finds envelopes the joined text used to
  hide, so one turn can surface the same envelope twice — once from Codex, once quoted back in a
  current-turn message. Identical text is one claim. Genuinely different claims stay ambiguous and
  still fail closed. I could not reach the duplicate shape through `resolve()` with a realistic
  payload (the primary path resolves first in every ordering I tried), so its regression test calls
  the exported parser directly rather than pretending otherwise.

## Tests

Three regression tests in `tests/environment.test.ts`, each verified to fail without the specific
line it guards:

| test | fails against |
|---|---|
| current environment part beside Codex's preamble parts | v5.0.4 as shipped |
| whole-message string envelope is not authority-bearing | the draft with the string branch |
| duplicate claims are one claim, conflicting ones fail closed | the draft without dedupe |

## Verification

- `bun x tsc --noEmit` — clean.
- `bun test tests/environment.test.ts` — 51 pass, 0 fail.
- `bun test tests/*.test.ts` — 521 pass, 135 fail. Those 135 are **pre-existing on the pristine
  `v5.0.4` tag** in my Windows environment; I captured the failure set before and after and diffed
  it — byte-identical, no new failures. `bun run verify` fails for that same pre-existing reason,
  so I did not use it as evidence.

## Not fixed here, but noticed

`contextualUserMessage` (environment.ts:135) still classifies on joined text, so Codex's multi-part
preamble is not recognized as contextual and `extractChatGptTurnUserRevision` will hand it back as
the human instruction whenever that item is the last user item. The compaction ordering (preamble
before the replayed source) hides it today. It is the same joined-vs-per-part disagreement in a
different recognizer, but fixing it means teaching the contextual vocabulary about
`<recommended_plugins>` and AGENTS.md blocks, which is a larger change than this bug needs. Happy
to open it separately if you want it.
