### PR TITLE
fix(chatgpt-web): normalize Windows rollout path identity

### DIFF
--- a/src/adapters/chatgpt-web/codex-rollout-environment.ts
+++ b/src/adapters/chatgpt-web/codex-rollout-environment.ts
@@ -10,7 +10,7 @@ import {
   readdirSync,
   realpathSync,
 } from "node:fs";
-import { basename, isAbsolute, join, relative, resolve } from "node:path";
+import { basename, isAbsolute, join, relative, resolve, toNamespacedPath } from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import { expandUserPath } from "../../config";
 import { findTopLevelAssignment } from "../../codex-integration-document";
@@ -41,7 +41,7 @@ function record(value: unknown): Record<string, unknown> | undefined {
 }
 
 function pathIdentity(value: string): string {
-  const normalized = resolve(value);
+  const normalized = toNamespacedPath(resolve(value));
   return process.platform === "win32" ? normalized.toLowerCase() : normalized;
 }
 

--- a/tests/environment.test.ts
+++ b/tests/environment.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { Database } from "bun:sqlite";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, resolve, toNamespacedPath } from "node:path";
 import { extractChatGptTurnEnvironment, extractChatGptTurnIdentity } from "../src/adapters/chatgpt-web/environment";
 import { rememberCompactionContinuation } from "../src/adapters/chatgpt-web/compaction-continuation";
 import { encodeCompactionSummary, SUMMARY_PREFIX } from "../src/responses/compaction";
@@ -768,6 +768,18 @@ describe("trusted Codex task environment continuity", () => {
     });
     return { codexHome, request, rolloutPath };
   }
+
+  test.skipIf(process.platform !== "win32")("resolves a Windows namespaced rollout path from the index", () => {
+    const { codexHome, request, rolloutPath } = resumedRootFixture();
+    const databasePath = join(codexHome, "state_5.sqlite");
+    createRolloutState(databasePath, toNamespacedPath(rolloutPath));
+    const database = new Database(databasePath);
+    database.exec("DELETE FROM thread_spawn_edges");
+    database.query("UPDATE threads SET agent_path = NULL WHERE id = ?").run(rolloutThreadId);
+    database.close();
+
+    expect(new ChatGptThreadEnvironmentStore(undefined, Date.now, codexHome).resolve(request).cwd).toBe(root);
+  });
 
   test("recovers an ordinary resumed task from its exact current rollout with an empty bridge cache", () => {
     const { codexHome, request } = resumedRootFixture();


### PR DESCRIPTION
Windows Codex state can store an extended-length rollout path (`\\?\...`) while the bridge derives the sessions root with the normal drive spelling. Comparing those forms directly can reject the active rollout even though both paths identify the same file.

This normalizes both sides with `toNamespacedPath()` before containment/identity checks and adds a Windows regression test covering a namespaced `state_5.sqlite` rollout path.

Validation:
- `git diff --check` passes.
- Local Bun verification could not run because Bun is not installed/on PATH on this machine; the PR CI matrix should exercise the regression on Windows, macOS, and Linux.
