### PR TITLE
fix(dev-profile): keep injected launcher discovery pure

### DIFF
--- a/src/dev-chat/profile.ts
+++ b/src/dev-chat/profile.ts
@@ -133,7 +133,11 @@ export function installedLauncherCandidates({
     );
   } else if (platform === "win32") {
     const registeredLocation = windowsInstallLocation?.trim()
-      || (process.platform === "win32" ? registeredWindowsLauncherInstallLocation() : undefined);
+      // Only consult the real machine when the caller did not inject an environment.
+      // A synthetic environment must stay pure so platform candidates are reproducible off-host.
+      || (environment === process.env && process.platform === "win32"
+        ? registeredWindowsLauncherInstallLocation()
+        : undefined);
     if (registeredLocation && win32.isAbsolute(registeredLocation)) {
       candidates.push(win32.join(registeredLocation, "Codex Web GPT.exe"));
     } else {


### PR DESCRIPTION
`installedLauncherCandidates()` accepts an injected platform/environment for deterministic path discovery, but the Windows branch still queried the real machine registry. On a development machine with Codex Web GPT installed, that overrides the injected `LOCALAPPDATA` and makes the supposedly synthetic lookup impure.

Only consult the real Windows registry when the caller is using the real `process.env`. Production behavior is unchanged; injected test/dev environments stay deterministic.

Validation:
- `bun test tests/dev-profile.test.ts` — 5 pass, 0 fail.
- The previously failing `installed launcher discovery has explicit platform candidates` case passes on a machine where the launcher is actually installed.
- `git diff --check` passes.
