### PR TITLE
fix(browser-host): invalidate retained chats after navigation

### DIFF
--- a/launcher/electron/browser-host.cjs
+++ b/launcher/electron/browser-host.cjs
@@ -869,6 +869,15 @@ class BrowserHost {
 
   bindManualTurnContents(tab) {
     const contents = tab.view.webContents;
+    const invalidateRetainedConversation = () => {
+      if (tab.status !== "ready" || !tab.conversationKey) return;
+      this.logger.info("browser.manual_retained_conversation_invalidated", {
+        tabId: tab.id,
+        traceId: tab.traceId,
+      });
+      tab.conversationKey = null;
+      tab.manualConversationReused = false;
+    };
     contents.setWindowOpenHandler(({ url }) => {
       let parsed;
       try { parsed = new URL(url); } catch { return { action: "deny" }; }
@@ -884,6 +893,7 @@ class BrowserHost {
     });
     contents.on("did-start-navigation", (_event, url, _inPlace, mainFrame) => {
       if (!mainFrame) return;
+      invalidateRetainedConversation();
       tab.url = url;
       tab.loading = true;
       this.publishState?.(this.snapshot());
@@ -906,7 +916,10 @@ class BrowserHost {
       this.publishState?.(this.snapshot());
     });
     contents.on("did-navigate-in-page", (_event, url, mainFrame) => {
-      if (mainFrame) tab.url = url;
+      if (mainFrame) {
+        invalidateRetainedConversation();
+        tab.url = url;
+      }
       this.publishState?.(this.snapshot());
     });
     contents.on("did-fail-load", (_event, errorCode, errorDescription, url, mainFrame) => {

--- a/launcher/tests/browser-host.test.cjs
+++ b/launcher/tests/browser-host.test.cjs
@@ -2698,6 +2698,44 @@ test("a retained manual chat copies only its incremental resume prompt", () => {
   clearTimeout(fixture.turnTabs.get(second.tabId).manualDeadlineTimer);
 });
 
+test("navigating a retained manual chat invalidates it before the next resume", () => {
+  const { fixture, clipboardWrites } = manualTurnFixture();
+  const conversationKey = "a".repeat(64);
+  const first = fixture.beginManualTurn(
+    "manual_trace_initial_navigation",
+    process.pid,
+    "full initial context",
+    conversationKey,
+  );
+  fixture.confirmManualSent(first.tabId);
+  fixture.markManualTurnStarted("manual_trace_initial_navigation", process.pid);
+  fixture.endManualTurn("manual_trace_initial_navigation", process.pid, "completed", true);
+
+  const retained = fixture.turnTabs.get(first.tabId);
+  const contents = new EventEmitter();
+  contents.setWindowOpenHandler = () => {};
+  contents.getURL = () => "https://chatgpt.com/?temporary-chat=true";
+  retained.view = { webContents: contents };
+  fixture.bindManualTurnContents(retained);
+
+  contents.emit("did-start-navigation", {}, "https://chatgpt.com/", false, true);
+
+  const second = fixture.beginManualTurn(
+    "manual_trace_after_navigation",
+    process.pid,
+    "full history after the retained chat was closed",
+    conversationKey,
+    "only the new request",
+  );
+  assert.notEqual(second.tabId, first.tabId);
+  assert.equal(second.reused, false);
+  assert.deepEqual(clipboardWrites, [
+    "full initial context",
+    "full history after the retained chat was closed",
+  ]);
+  for (const tab of fixture.turnTabs.values()) clearTimeout(tab.manualDeadlineTimer);
+});
+
 test("manual start rejects a different prompt after Sent instead of replaying a trace", () => {
   const { fixture, clipboardWrites } = manualTurnFixture();
   const lease = fixture.beginManualTurn("manual_trace_mismatch", process.pid, "original prompt");


### PR DESCRIPTION
A retained manual/Native2 conversation can remain marked reusable after its tab navigates. The next resume then sends only the incremental prompt into a page that no longer represents the retained conversation.

Invalidate the retained conversation on navigation so the next resume rebuilds the full context instead of reusing stale page ownership.

Validation:
- `node --test launcher/tests/browser-host.test.cjs` — 96 pass, 0 fail.
- Includes a focused regression: `navigating a retained manual chat invalidates it before the next resume`.
- `git diff --check` passes.
