### PR TITLE
fix(chatgpt-web): refuse an archived rollout record, not the turn

### DIFF
--- a/src/adapters/chatgpt-web/codex-rollout-environment.ts
+++ b/src/adapters/chatgpt-web/codex-rollout-environment.ts
@@ -578,8 +578,24 @@ export function resolveCurrentCodexRolloutEnvironment(options: {
   }
 
   const matching: ChatGptTurnEnvironment[] = [];
+  let unusableCandidates = 0;
+  let unusableReason: Error | undefined;
   for (const candidate of candidates) {
-    const rolloutPath = validateRolloutPath(codexHome, candidate, lineage.threadId);
+    let rolloutPath: string;
+    try {
+      rolloutPath = validateRolloutPath(codexHome, candidate, lineage.threadId);
+    } catch (error) {
+      // Codex archives its own sessions and its state index keeps pointing at the moved file, so
+      // an ordinary thread can offer a rollout that no longer sits under sessions/. Such a record
+      // proves nothing, which is not the same as the turn being unauthorised: the caller still
+      // holds the authority this thread established earlier. Refuse the record, not the turn.
+      unusableCandidates += 1;
+      unusableReason ??= error instanceof Error ? error : new Error(String(error));
+      console.warn(
+        `[chatgpt-web] ignoring an unusable Codex rollout candidate: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      continue;
+    }
     const fd = openSync(rolloutPath, "r");
     try {
       const size = fstatSync(fd).size;
@@ -601,6 +617,12 @@ export function resolveCurrentCodexRolloutEnvironment(options: {
     }
   }
   if (matching.length === 0) {
+    // Every candidate was refused on its path alone, so nothing here was ever read. A subagent
+    // still needs a proven rollout; an ordinary thread falls back to its established authority.
+    if (unusableCandidates === candidates.length && !("parentThreadId" in lineage)) return undefined;
+    // Nothing usable was found and there is no established authority to fall back on, so the
+    // caller still needs to know why the record was refused rather than a generic absence.
+    if (unusableReason && unusableCandidates === candidates.length) throw unusableReason;
     throw new Error("Codex has no canonical rollout for the requested current turn");
   }
   if (matching.length > 1) {

--- a/tests/environment.test.ts
+++ b/tests/environment.test.ts
@@ -769,6 +769,35 @@ describe("trusted Codex task environment continuity", () => {
     return { codexHome, request, rolloutPath };
   }
 
+  test("an archived rollout is refused as a record without failing the turn", () => {
+    // Codex archives its own sessions and its state index keeps pointing at the moved file, so an
+    // ordinary thread can offer a rollout that no longer sits under sessions/. On this machine 95
+    // of 149 rollouts were already archived, and every turn of a live conversation died with
+    // "Codex rollout path escapes the sessions directory" rather than falling back to the
+    // authority the same thread had already established.
+    const { codexHome, request, rolloutPath } = resumedRootFixture();
+    const store = new ChatGptThreadEnvironmentStore(undefined, Date.now, codexHome);
+    const trusted = store.resolve(request);
+    expect(trusted.cwd).toBe(root);
+
+    const archived = join(codexHome, "archived_sessions", "rollout-archived.jsonl");
+    mkdirSync(dirname(archived), { recursive: true });
+    writeFileSync(archived, [
+      JSON.stringify({ type: "session_meta", payload: { id: rolloutThreadId, source: "vscode" } }),
+      JSON.stringify(childTurnContext()),
+    ].join("\n") + "\n");
+    const databasePath = join(codexHome, "state_5.sqlite");
+    createRolloutState(databasePath, archived);
+    const database = new Database(databasePath);
+    database.exec("DELETE FROM thread_spawn_edges");
+    database.query("UPDATE threads SET agent_path = NULL WHERE id = ?").run(rolloutThreadId);
+    database.close();
+
+    // The archived record is never read, and the turn keeps the environment this thread proved.
+    expect(store.resolve(request)).toEqual(trusted);
+    expect(rolloutPath.includes("sessions")).toBeTrue();
+  });
+
   test("recovers an ordinary resumed task from its exact current rollout with an empty bridge cache", () => {
     const { codexHome, request } = resumedRootFixture();
     request.context.tools = [{ name: "current_tool", description: "current", parameters: { type: "object" } }];


### PR DESCRIPTION
Codex can move a session into `archived_sessions` while its state index still points at the moved rollout. The bridge correctly refuses to read outside `sessions/`, but currently turns that refused record into a fatal turn error even when the same thread already has trusted cached authority.

Treat an out-of-sessions candidate as an unusable record and fall back to previously proven thread authority. The archived file is never opened. Fresh/subagent recovery still fails closed when no trusted authority exists.

Validation:
- `bun test tests/environment.test.ts` — 49 pass, 0 fail.
- Regression covers an indexed archived rollout and confirms outside-path recovery still fails closed.
- `git diff --check` passes.
