### PR TITLE
fix(chatgpt-web): preserve authority across ambient environment diffs

### DIFF
--- a/src/adapters/chatgpt-web/environment.ts
+++ b/src/adapters/chatgpt-web/environment.ts
@@ -111,12 +111,25 @@ export function hasRawChatGptEnvironmentContext(parsed: CodexParsedRequest): boo
   });
 }
 
+const ENVELOPE_PATTERN = /<\/?environment_context\b/i;
+const CWD_TAG_PATTERN = /<\/?cwd\b/i;
+const WORKSPACE_ROOTS_PATTERN = /<workspace_roots>[\s\S]*?<\/workspace_roots>/gi;
+const ROOT_PATTERN = /<root>([^<]+)<\/root>/gi;
 /** Historical XML is not a current environment update, including in old untagged rollouts. */
-export function hasCurrentChatGptEnvironmentContext(parsed: CodexParsedRequest): boolean {
-  const turnId = extractChatGptTurnIdentity(parsed).turnId;
-  if (!turnId) return hasRawChatGptEnvironmentContext(parsed);
+export function currentChatGptEnvironmentContextTexts(parsed: CodexParsedRequest): string[] {
   const body = record(parsed._rawBody);
   const input = Array.isArray(body?.input) ? body.input : [];
+  const envelopeText = (value: unknown): string | undefined => {
+    const item = record(value);
+    if (item?.type !== "message") return undefined;
+    const text = rawMessageText(item);
+    return ENVELOPE_PATTERN.test(text) ? text : undefined;
+  };
+  const turnId = extractChatGptTurnIdentity(parsed).turnId;
+  if (!turnId) {
+    return input.map(envelopeText).filter((text): text is string => text !== undefined);
+  }
+  const texts: string[] = [];
   let laterAssistantOutput = false;
   for (let index = input.length - 1; index >= 0; index -= 1) {
     const item = record(input[index]);
@@ -125,11 +138,54 @@ export function hasCurrentChatGptEnvironmentContext(parsed: CodexParsedRequest):
       || item.type === "function_call" || item.type === "reasoning" || item.type === "compaction") {
       laterAssistantOutput = true;
     }
-    if (item.type !== "message" || !/<\/?environment_context\b/i.test(rawMessageText(item))) continue;
+    const text = envelopeText(item);
+    if (text === undefined) continue;
     const owner = itemTurnId(item);
-    if (owner === turnId || (owner === undefined && !laterAssistantOutput)) return true;
+    if (owner === turnId || (owner === undefined && !laterAssistantOutput)) texts.push(text);
   }
-  return false;
+  return texts;
+}
+
+export function hasCurrentChatGptEnvironmentContext(parsed: CodexParsedRequest): boolean {
+  return currentChatGptEnvironmentContextTexts(parsed).length > 0;
+}
+
+function declaresCwd(text: string): boolean {
+  return CWD_TAG_PATTERN.test(text);
+}
+
+/**
+ * Codex sends a cwd-less environment envelope when only ambient facts change - the local date
+ * rolling over at midnight is the common one. Such a diff states no working directory of its own,
+ * so it must not be read as an attempt to redeclare filesystem authority.
+ */
+export function currentChatGptEnvironmentDeclaresCwd(parsed: CodexParsedRequest): boolean {
+  return currentChatGptEnvironmentContextTexts(parsed).some(declaresCwd);
+}
+
+/** True when any raw envelope, current or historical, tried to state a working directory. */
+export function hasRawChatGptEnvironmentContextDeclaringCwd(parsed: CodexParsedRequest): boolean {
+  const body = record(parsed._rawBody);
+  const input = Array.isArray(body?.input) ? body.input : [];
+  return input.some(value => {
+    const item = record(value);
+    if (item?.type !== "message") return false;
+    const text = rawMessageText(item);
+    return ENVELOPE_PATTERN.test(text) && declaresCwd(text);
+  });
+}
+
+/** Workspace roots declared by the current envelopes, so a diff can be checked against cached authority. */
+export function currentChatGptEnvironmentWorkspaceRoots(parsed: CodexParsedRequest): string[] {
+  const roots: string[] = [];
+  for (const text of currentChatGptEnvironmentContextTexts(parsed)) {
+    for (const section of text.matchAll(WORKSPACE_ROOTS_PATTERN)) {
+      for (const match of section[0].matchAll(ROOT_PATTERN)) {
+        roots.push(decodeXmlText((match[1] ?? "").trim()));
+      }
+    }
+  }
+  return roots;
 }
 
 function contextualUserMessage(value: Record<string, unknown>): boolean {

--- a/src/adapters/chatgpt-web/thread-environment.ts
+++ b/src/adapters/chatgpt-web/thread-environment.ts
@@ -10,8 +10,10 @@ import {
   extractChatGptTurnIdentity,
   extractChatGptThreadSpawnLineage,
   extractChatGptRootThreadMetadata,
+  currentChatGptEnvironmentDeclaresCwd,
+  currentChatGptEnvironmentWorkspaceRoots,
   hasCurrentChatGptEnvironmentContext,
-  hasRawChatGptEnvironmentContext,
+  hasRawChatGptEnvironmentContextDeclaringCwd,
   isChatGptCompactionContinuation,
   MissingTrustedCodexEnvironmentError,
   type ChatGptSandboxPolicy,
@@ -116,6 +118,22 @@ function authority(environment: ChatGptTurnEnvironment, updatedAt: number): Stor
   };
 }
 
+/**
+ * An ambient environment diff still lists the workspace roots. They must stay inside the
+ * authority this store already holds: a cached cwd may survive a diff, but it may never
+ * silently authorise filesystem reach the trusted turn never granted.
+ */
+function assertDeclaredRootsWithinAuthority(declared: string[], trusted: string[]): void {
+  if (declared.length === 0) return;
+  const known = new Set(trusted.map(pathIdentity));
+  const widened = declared.filter(root => !isAbsolute(root) || !known.has(pathIdentity(resolve(root))));
+  if (widened.length > 0) {
+    throw new Error(
+      "ChatGPT web environment update declares workspace roots outside the trusted thread authority",
+    );
+  }
+}
+
 function sameAuthority(left: ChatGptTurnEnvironment, right: ChatGptTurnEnvironment): boolean {
   const samePaths = (a: string[], b: string[]): boolean => {
     const expected = new Set(b.map(pathIdentity));
@@ -154,8 +172,16 @@ export class ChatGptThreadEnvironmentStore {
     } catch (error) {
       if (!(error instanceof MissingTrustedCodexEnvironmentError) || !identity.threadId) throw error;
       const hasCurrentContext = hasCurrentChatGptEnvironmentContext(parsed);
-      if (hasCurrentContext && !isChatGptCompactionContinuation(parsed)) throw error;
-      const currentClaim = hasCurrentContext ? extractChatGptContinuationEnvironmentClaim(parsed) : undefined;
+      // An envelope that states no cwd is an ambient diff, not a redeclaration of authority:
+      // Codex sends one when only the date or timezone changes, which happens to every running
+      // turn at local midnight. Treating that as a current claim suppressed the fallback below
+      // and failed live turns outright while this store already held the right cwd.
+      const currentContextClaimsCwd = hasCurrentContext && currentChatGptEnvironmentDeclaresCwd(parsed);
+      if (currentContextClaimsCwd && !isChatGptCompactionContinuation(parsed)) throw error;
+      // A cwd-less diff makes no environment claim, so there is nothing here to reconcile.
+      const currentClaim = currentContextClaimsCwd
+        ? extractChatGptContinuationEnvironmentClaim(parsed)
+        : undefined;
       const lineage = extractChatGptThreadSpawnLineage(parsed);
       const rolloutIdentity = lineage ?? extractChatGptRootThreadMetadata(parsed);
       // Automatic compaction has a current turn_context; standalone compaction has only its
@@ -181,8 +207,12 @@ export class ChatGptThreadEnvironmentStore {
       }
       // Only a current native rollout can supersede an unrecognized historical envelope. Without
       // that proof, do not turn arbitrary history or an invalid update into cached authority.
-      if (hasRawChatGptEnvironmentContext(parsed)) throw error;
+      if (hasRawChatGptEnvironmentContextDeclaringCwd(parsed)) throw error;
       const sameThread = this.get(identity.threadId);
+      if (sameThread) assertDeclaredRootsWithinAuthority(
+        currentChatGptEnvironmentWorkspaceRoots(parsed),
+        sameThread.roots,
+      );
       if (sameThread) return {
         cwd: sameThread.cwd,
         roots: sameThread.roots,

--- a/tests/environment.test.ts
+++ b/tests/environment.test.ts
@@ -1247,3 +1247,60 @@ describe("trusted Codex task environment continuity", () => {
       .toThrow("missing cwd");
   });
 });
+
+describe("ambient environment diffs during a running turn", () => {
+  // Codex emits a cwd-less environment_context when only ambient facts change. The local date
+  // rolling over hands one to every turn that is running at midnight, mid-task.
+  const ambientDiff = (roots: string[]) => [
+    "<environment_context>",
+    "  <current_date>2026-09-07</current_date>",
+    "  <timezone>Europe/Istanbul</timezone>",
+    `  <filesystem><workspace_roots>${roots.map(r => `<root>${r}</root>`).join("")}</workspace_roots>`
+      + `<permission_profile type="disabled"><file_system type="unrestricted" /></permission_profile></filesystem>`,
+    "</environment_context>",
+  ].join("\n");
+
+  const turnCarrying = (threadId: string, diff: string): CodexParsedRequest => {
+    const request = currentWire();
+    request._rawBody = {
+      client_metadata: {
+        "x-codex-turn-metadata": JSON.stringify({ thread_id: threadId, turn_id: "turn_next" }),
+      },
+      input: [
+        { type: "message", role: "user", content: [{ type: "input_text", text: "Keep going" }] },
+        { type: "function_call", name: "exec_command", arguments: "{}" },
+        { type: "message", role: "user", content: [{ type: "input_text", text: diff }] },
+      ],
+    };
+    return request;
+  };
+
+  test("a cwd-less diff keeps the trusted thread authority instead of failing the turn", () => {
+    const store = new ChatGptThreadEnvironmentStore();
+    store.resolve(currentWire());
+    expect(store.resolve(turnCarrying("thread_current", ambientDiff([root]))).cwd).toBe(root);
+  });
+
+  test("a diff that widens the workspace roots is still refused", () => {
+    const store = new ChatGptThreadEnvironmentStore();
+    store.resolve(currentWire());
+    expect(() => store.resolve(turnCarrying("thread_current", ambientDiff([root, resolve(root, "..")]))))
+      .toThrow("outside the trusted thread authority");
+  });
+
+  test("a diff cannot conjure authority for a thread this store never trusted", () => {
+    const store = new ChatGptThreadEnvironmentStore();
+    store.resolve(currentWire());
+    expect(() => store.resolve(turnCarrying("thread_unknown", ambientDiff([root])))).toThrow("missing cwd");
+  });
+
+  test("an envelope that does state a cwd still fails closed when it cannot be trusted", () => {
+    const store = new ChatGptThreadEnvironmentStore();
+    store.resolve(currentWire());
+    const claiming = turnCarrying(
+      "thread_current",
+      `<environment_context><cwd>${resolve(root, "..")}</cwd></environment_context>`,
+    );
+    expect(() => store.resolve(claiming)).toThrow("missing cwd");
+  });
+});


### PR DESCRIPTION
Codex can emit a cwd-less `<environment_context>` when only ambient facts change, for example when the local date rolls over mid-turn. The bridge currently notices that diff as a current environment claim but cannot extract a cwd from it, which can discard the thread authority established moments earlier and fail the turn.

Only treat envelopes that actually state a cwd as current authority claims. Cwd-less ambient diffs may keep the already-proven thread authority, while their workspace roots are still checked so a widened root remains fail-closed.

Validation:
- `bun test tests/environment.test.ts` — 52 pass, 0 fail.
- Four focused regressions cover trusted fallback, widened roots, untrusted threads, and explicit cwd claims.
- `git diff --check` passes.
