### PR TITLE
fix(launcher): hand off running retained turns safely

### DIFF
--- a/launcher/electron/browser-host.cjs
+++ b/launcher/electron/browser-host.cjs
@@ -352,6 +352,7 @@ class BrowserHost {
     this.visible = false;
     this.surfaceActive = true;
     this.turnTabs = new Map();
+    this.automaticTurnHandoffs = new Map();
     this.closedTurnOwners = new Map();
     this.userCancelledTurnOwners = new Map();
     this.manualTerminalSignals = new Map();
@@ -1489,6 +1490,11 @@ class BrowserHost {
 
   removeTurnTab(tab, abortRunning) {
     if (!this.turnTabs.has(tab.id)) return;
+    const handoffs = this.automaticTurnHandoffs?.get(tab.id) || [];
+    this.automaticTurnHandoffs?.delete(tab.id);
+    for (const handoff of handoffs) {
+      handoff.reject(new Error("The ChatGPT browser conversation closed before the steering turn could take over"));
+    }
     this.turnTabs.delete(tab.id);
     if (tab.interactionMode === "manual") {
       if (tab.manualDeadlineTimer) clearTimeout(tab.manualDeadlineTimer);
@@ -2201,19 +2207,46 @@ class BrowserHost {
       || sameTrace.connectorIdentity !== connectorIdentity)) {
       throw new Error(`ChatGPT browser turn ${traceId} conversation metadata does not match its owned tab`);
     }
-    const retainedMatches = conversationKey ? [...this.turnTabs.values()].filter((tab) => (
+    const conversationMatches = conversationKey ? [...this.turnTabs.values()].filter((tab) => (
       tab.interactionMode === "automatic"
-      && tab.status === "ready"
       && tab.conversationKey === conversationKey
       && tab.connectorIdentity === connectorIdentity
-      && (!connectorIdentity || tab.connectorBound === true)
     )) : [];
+    if (conversationMatches.length > 1) {
+      throw new Error(`ChatGPT conversation ${conversationKey} owns multiple browser tabs`);
+    }
+    const runningConversation = conversationMatches.find((tab) => tab.status === "running");
+    const retainedMatches = conversationMatches.filter((tab) => (
+      tab.status === "ready"
+      && (!connectorIdentity || tab.connectorBound === true)
+    ));
     if (retainedMatches.length > 1) {
       throw new Error(`ChatGPT retained conversation ${conversationKey} owns multiple browser tabs`);
     }
     const exactRetained = retainedMatches[0];
     if (sameTrace?.status === "ready" && sameTrace !== exactRetained) {
       throw new Error(`ChatGPT browser turn ${traceId} is retained under different conversation metadata`);
+    }
+    if (runningConversation && runningConversation !== sameTrace) {
+      this.automaticTurnHandoffs ??= new Map();
+      const queue = this.automaticTurnHandoffs.get(runningConversation.id) || [];
+      const duplicate = queue.find(handoff => handoff.traceId === traceId && handoff.helperPid === helperPid);
+      if (duplicate) return duplicate.promise;
+      let resolveHandoff;
+      let rejectHandoff;
+      const promise = new Promise((resolve, reject) => {
+        resolveHandoff = resolve;
+        rejectHandoff = reject;
+      });
+      queue.push({ traceId, helperPid, reveal, promise, resolve: resolveHandoff, reject: rejectHandoff });
+      this.automaticTurnHandoffs.set(runningConversation.id, queue);
+      this.logger.info("browser.tab_handoff_queued", {
+        tabId: runningConversation.id,
+        traceId,
+        previousTraceId: runningConversation.traceId,
+        waiters: queue.length,
+      });
+      return promise;
     }
     const existing = sameTrace?.status === "running" ? sameTrace : exactRetained;
     if (existing) {
@@ -2302,6 +2335,45 @@ class BrowserHost {
     if (!tab.view.webContents.isDestroyed()) tab.view.webContents.setBackgroundThrottling(true);
     if (status === "completed") {
       this.logger.info("browser.tab_completed", { tabId: tab.id, traceId });
+    }
+    const handoffQueue = this.automaticTurnHandoffs?.get(tab.id);
+    if (handoffQueue?.length && (status === "aborted" || status === "completed")) {
+      let handoff;
+      while (handoffQueue.length > 0 && !handoff) {
+        const candidate = handoffQueue.shift();
+        if (candidate && processRunning(candidate.helperPid)) handoff = candidate;
+        else candidate?.reject(new Error("The waiting steering helper exited before browser takeover"));
+      }
+      if (handoffQueue.length === 0) this.automaticTurnHandoffs.delete(tab.id);
+      if (handoff) {
+        tab.helperPid = handoff.helperPid;
+        tab.traceId = handoff.traceId;
+        tab.status = "running";
+        tab.loading = true;
+        tab.message = "ChatGPT is working";
+        tab.bootstrapReady = true;
+        tab.bootstrapDeadlineAt = null;
+        tab.lastHeartbeatAt = Date.now();
+        if (!tab.view.webContents.isDestroyed()) tab.view.webContents.setBackgroundThrottling(false);
+        this.selectedTabId = tab.id;
+        if (handoff.reveal) this.show();
+        else this.syncViewVisibility();
+        this.publishState?.(this.snapshot());
+        this.writeDescriptor();
+        this.logger.info("browser.tab_reused", {
+          tabId: tab.id,
+          traceId: handoff.traceId,
+          previousTraceId: traceId,
+          handoff: true,
+        });
+        handoff.resolve({
+          surfaceId: tab.surfaceId,
+          tabId: tab.id,
+          reused: true,
+          connectorBound: tab.connectorBound === true,
+        });
+        return { cancelledByUser };
+      }
     }
     if (status === "completed"
       && retain

--- a/launcher/electron/browser-host.cjs
+++ b/launcher/electron/browser-host.cjs
@@ -30,6 +30,9 @@ const IDLE_BROWSER_URL = "data:text/html;charset=utf-8,%3C!doctype%20html%3E%3Ch
 const PRIMARY_VIEW_BOOTSTRAP_TIMEOUT_MS = 10_000;
 const MAX_BROWSER_VIEW_DIMENSION = 16_384;
 const MAX_BROWSER_TABS = 5;
+// A steering turn waits for the tab it is taking over. The wait is bounded so a turn that never
+// ends cannot strand its waiters indefinitely, and the timeout says what it was waiting on.
+const TURN_HANDOFF_WAIT_TIMEOUT_MS = 180_000;
 const MAX_CANCELLED_TURN_TRACES = 256;
 const MANUAL_SUBMIT_TIMEOUT_MS = 30_000;
 const MANUAL_COMPACTION_SUBMIT_TIMEOUT_MS = 120_000;
@@ -1493,6 +1496,7 @@ class BrowserHost {
     const handoffs = this.automaticTurnHandoffs?.get(tab.id) || [];
     this.automaticTurnHandoffs?.delete(tab.id);
     for (const handoff of handoffs) {
+      if (handoff.timer) clearTimeout(handoff.timer);
       handoff.reject(new Error("The ChatGPT browser conversation closed before the steering turn could take over"));
     }
     this.turnTabs.delete(tab.id);
@@ -2238,7 +2242,25 @@ class BrowserHost {
         resolveHandoff = resolve;
         rejectHandoff = reject;
       });
-      queue.push({ traceId, helperPid, reveal, promise, resolve: resolveHandoff, reject: rejectHandoff });
+      const entry = { traceId, helperPid, reveal, promise, resolve: resolveHandoff, reject: rejectHandoff };
+      entry.timer = setTimeout(() => {
+        const pending = this.automaticTurnHandoffs?.get(runningConversation.id);
+        const index = pending ? pending.indexOf(entry) : -1;
+        if (index < 0) return;
+        pending.splice(index, 1);
+        if (pending.length === 0) this.automaticTurnHandoffs.delete(runningConversation.id);
+        this.logger.info("browser.tab_handoff_timeout", {
+          tabId: runningConversation.id,
+          traceId,
+          previousTraceId: runningConversation.traceId,
+        });
+        entry.reject(new Error(
+          "Waited " + Math.round(TURN_HANDOFF_WAIT_TIMEOUT_MS / 1000) + "s for ChatGPT browser turn "
+          + runningConversation.traceId + " to release its conversation tab, and it did not finish",
+        ));
+      }, TURN_HANDOFF_WAIT_TIMEOUT_MS);
+      entry.timer.unref?.();
+      queue.push(entry);
       this.automaticTurnHandoffs.set(runningConversation.id, queue);
       this.logger.info("browser.tab_handoff_queued", {
         tabId: runningConversation.id,
@@ -2337,10 +2359,13 @@ class BrowserHost {
       this.logger.info("browser.tab_completed", { tabId: tab.id, traceId });
     }
     const handoffQueue = this.automaticTurnHandoffs?.get(tab.id);
-    if (handoffQueue?.length && (status === "aborted" || status === "completed")) {
+    // endTurn only ever receives a terminal status, so every one of them must move the queue on.
+    // A turn that ends in "failed" used to drop its waiters; the log showed exactly that happening.
+    if (handoffQueue?.length && (status === "aborted" || status === "completed" || status === "failed")) {
       let handoff;
       while (handoffQueue.length > 0 && !handoff) {
         const candidate = handoffQueue.shift();
+        if (candidate?.timer) clearTimeout(candidate.timer);
         if (candidate && processRunning(candidate.helperPid)) handoff = candidate;
         else candidate?.reject(new Error("The waiting steering helper exited before browser takeover"));
       }
@@ -2366,6 +2391,7 @@ class BrowserHost {
           previousTraceId: traceId,
           handoff: true,
         });
+        if (handoff.timer) clearTimeout(handoff.timer);
         handoff.resolve({
           surfaceId: tab.surfaceId,
           tabId: tab.id,

--- a/launcher/tests/browser-host.test.cjs
+++ b/launcher/tests/browser-host.test.cjs
@@ -2092,6 +2092,134 @@ test("a later provider round reuses only its exact connector-bound conversation"
   assert.deepEqual(events, ["visible", "published", "descriptor", "browser.tab_reused"]);
 });
 
+test("a steering turn waits for the running automatic conversation and reuses its tab", async () => {
+  const throttling = [];
+  const conversationKey = "s".repeat(64);
+  const tab = {
+    id: "tab-steering",
+    surfaceId: "surface-steering",
+    traceId: "trace_previous",
+    conversationKey,
+    connectorIdentity: "Codex Native2",
+    connectorBound: true,
+    interactionMode: "automatic",
+    helperPid: process.pid,
+    status: "running",
+    loading: true,
+    message: "ChatGPT is working",
+    bootstrapReady: true,
+    view: {
+      webContents: {
+        isDestroyed: () => false,
+        setBackgroundThrottling: (enabled) => throttling.push(enabled),
+      },
+    },
+  };
+  let created = 0;
+  const fixture = Object.assign(Object.create(BrowserHost.prototype), {
+    manualOperation: null,
+    turnTabs: new Map([[tab.id, tab]]),
+    userCancelledTurnOwners: new Map(),
+    closedTurnOwners: new Map(),
+    selectedTabId: "home",
+    createTurnTab: () => {
+      created += 1;
+      return { id: "unexpected", surfaceId: "unexpected" };
+    },
+    syncPowerSaveBlocker() {},
+    syncViewVisibility() {},
+    snapshot: () => ({ tabs: [] }),
+    publishState() {},
+    writeDescriptor() {},
+    logger: { info() {}, warn() {} },
+  });
+
+  const nextLease = BrowserHost.prototype.beginTurn.call(
+    fixture,
+    "trace_next",
+    false,
+    process.pid,
+    conversationKey,
+    "Codex Native2",
+  );
+  await new Promise(resolve => setImmediate(resolve));
+
+  assert.equal(created, 0);
+  assert.equal(tab.traceId, "trace_previous");
+  assert.equal(tab.helperPid, process.pid);
+
+  assert.deepEqual(
+    await BrowserHost.prototype.endTurn.call(
+      fixture,
+      "trace_previous",
+      process.pid,
+      "aborted",
+      false,
+      "superseded",
+    ),
+    { cancelledByUser: false },
+  );
+
+  assert.deepEqual(await nextLease, {
+    surfaceId: "surface-steering",
+    tabId: "tab-steering",
+    reused: true,
+    connectorBound: true,
+  });
+  assert.equal(fixture.turnTabs.get(tab.id), tab);
+  assert.equal(tab.traceId, "trace_next");
+  assert.equal(tab.helperPid, process.pid);
+  assert.equal(tab.status, "running");
+  assert.equal(tab.loading, true);
+  assert.equal(created, 0);
+  assert.deepEqual(throttling, [true, false]);
+});
+
+test("a running automatic conversation is not handed to a different conversation key", async () => {
+  const retained = {
+    id: "running-other-conversation",
+    traceId: "trace_old",
+    helperPid: 111,
+    status: "running",
+    conversationKey: "x".repeat(64),
+    connectorIdentity: "Codex Native2",
+    connectorBound: true,
+    interactionMode: "automatic",
+  };
+  const fixture = Object.assign(Object.create(BrowserHost.prototype), {
+    manualOperation: null,
+    turnTabs: new Map([[retained.id, retained]]),
+    userCancelledTurnOwners: new Map(),
+    createTurnTab: (...args) => {
+      assert.deepEqual(args, ["trace_next", 222, "y".repeat(64), "Codex Native2"]);
+      return { id: "fresh", surfaceId: "surface-fresh" };
+    },
+    syncViewVisibility() {},
+    publishState() {},
+    snapshot: () => ({ tabs: [] }),
+    logger: { info() {} },
+  });
+
+  assert.deepEqual(
+    await BrowserHost.prototype.beginTurn.call(
+      fixture,
+      "trace_next",
+      false,
+      222,
+      "y".repeat(64),
+      "Codex Native2",
+    ),
+    {
+      surfaceId: "surface-fresh",
+      tabId: "fresh",
+      reused: false,
+      connectorBound: false,
+    },
+  );
+  assert.equal(retained.traceId, "trace_old");
+  assert.equal(retained.status, "running");
+});
+
 test("a retained conversation is not reused for a different connector identity", async () => {
   const conversationKey = "b".repeat(64);
   const retained = {

--- a/launcher/tests/browser-host.test.cjs
+++ b/launcher/tests/browser-host.test.cjs
@@ -3140,3 +3140,75 @@ test("manual turns have no live-session TTL but are revoked when their owner pro
     status: "failed",
   });
 });
+
+test("a turn that ends in failure still hands its tab to the waiting steering turn", async () => {
+  const conversationKey = "f".repeat(64);
+  const tab = {
+    id: "tab-failed-handoff",
+    surfaceId: "surface-failed-handoff",
+    traceId: "trace_previous",
+    conversationKey,
+    connectorIdentity: "Codex Native2",
+    connectorBound: true,
+    interactionMode: "automatic",
+    helperPid: process.pid,
+    status: "running",
+    loading: true,
+    message: "ChatGPT is working",
+    bootstrapReady: true,
+    view: {
+      webContents: {
+        isDestroyed: () => false,
+        setBackgroundThrottling: () => {},
+      },
+    },
+  };
+  let created = 0;
+  const fixture = Object.assign(Object.create(BrowserHost.prototype), {
+    manualOperation: null,
+    turnTabs: new Map([[tab.id, tab]]),
+    userCancelledTurnOwners: new Map(),
+    closedTurnOwners: new Map(),
+    selectedTabId: "home",
+    createTurnTab: () => {
+      created += 1;
+      return { id: "unexpected", surfaceId: "unexpected" };
+    },
+    syncPowerSaveBlocker() {},
+    syncViewVisibility() {},
+    snapshot: () => ({ tabs: [] }),
+    publishState() {},
+    writeDescriptor() {},
+    logger: { info() {}, warn() {} },
+  });
+
+  const nextLease = BrowserHost.prototype.beginTurn.call(
+    fixture,
+    "trace_next",
+    false,
+    process.pid,
+    conversationKey,
+    "Codex Native2",
+  );
+  await new Promise(resolve => setImmediate(resolve));
+  assert.equal(created, 0);
+
+  await BrowserHost.prototype.endTurn.call(
+    fixture,
+    "trace_previous",
+    process.pid,
+    "failed",
+    false,
+    "superseded",
+  );
+
+  assert.deepEqual(await nextLease, {
+    surfaceId: "surface-failed-handoff",
+    tabId: "tab-failed-handoff",
+    reused: true,
+    connectorBound: true,
+  });
+  assert.equal(tab.traceId, "trace_next");
+  assert.equal(tab.status, "running");
+  assert.equal(created, 0);
+});

--- a/tests/retained-compaction.test.ts
+++ b/tests/retained-compaction.test.ts
@@ -67,6 +67,7 @@ function request(compaction = false): CodexParsedRequest {
         { role: "user", content: "Original task", timestamp: 1 },
         { role: "assistant", content: [{ type: "text", text: "Work completed" }], timestamp: 2 },
         { role: "user", content: "Continue with the next step", timestamp: 3 },
+        { role: "user", content: "Also keep the same browser conversation", timestamp: 4 },
       ],
     },
     options: { reasoning: "high" },
@@ -135,6 +136,7 @@ test("one browser conversation spans native turns and rotates only at compaction
   expect(chatGptConversationKey(otherThread, "provider")).not.toBe(chatGptConversationKey(before, "provider"));
   expect(retainedConversationResumeRequest(before)?.context.messages).toEqual([
     { role: "user", content: "Continue with the next step", timestamp: 3 },
+    { role: "user", content: "Also keep the same browser conversation", timestamp: 4 },
   ]);
 
   const v1Compact = structuredClone(before);


### PR DESCRIPTION
When a follow-up/steering turn arrives while the retained Automatic conversation is still running, the launcher currently cannot hand that tab to the waiting turn. A failed owner can also strand waiters indefinitely.

This adds a bounded FIFO handoff for the same conversation key, drains waiters on every terminal status (`completed`, `failed`, `aborted`), and clears handoff timers on takeover, timeout, helper exit, and tab destruction.

Validation:
- `node --test launcher/tests/browser-host.test.cjs` — 98 pass, 0 fail.
- Regressions cover same-conversation steering reuse and failed-turn handoff.
- `git diff --check` passes.
- `bun test tests/retained-compaction.test.ts` hits the known Windows single-file named-pipe scheduling hang documented by the original change; the launcher suite completes cleanly.
