### PR TITLE
fix(browser): serialize heavy page-driving phases across concurrent turns

### DIFF
--- a/launcher/electron/browser-host.cjs
+++ b/launcher/electron/browser-host.cjs
@@ -30,6 +30,10 @@ const IDLE_BROWSER_URL = "data:text/html;charset=utf-8,%3C!doctype%20html%3E%3Ch
 const PRIMARY_VIEW_BOOTSTRAP_TIMEOUT_MS = 10_000;
 const MAX_BROWSER_VIEW_DIMENSION = 16_384;
 const MAX_BROWSER_TABS = 5;
+// Concurrent turns each own a ChatGPT document in one Electron renderer pool. Two turns doing
+// heavy DOM work at the same time starve each other until a DOM probe times out, so the heavy
+// phases take a single-owner lock while waiting for a ChatGPT response stays free.
+const HEAVY_PHASE_WAIT_TIMEOUT_MS = 180_000;
 const MAX_CANCELLED_TURN_TRACES = 256;
 const MANUAL_SUBMIT_TIMEOUT_MS = 30_000;
 const MANUAL_COMPACTION_SUBMIT_TIMEOUT_MS = 120_000;
@@ -352,6 +356,7 @@ class BrowserHost {
     this.visible = false;
     this.surfaceActive = true;
     this.turnTabs = new Map();
+    this.heavyPhase = { holder: null, queue: [] };
     this.closedTurnOwners = new Map();
     this.userCancelledTurnOwners = new Map();
     this.manualTerminalSignals = new Map();
@@ -1489,6 +1494,7 @@ class BrowserHost {
 
   removeTurnTab(tab, abortRunning) {
     if (!this.turnTabs.has(tab.id)) return;
+    if (tab.traceId) this.releaseHeavyPhase(tab.traceId);
     this.turnTabs.delete(tab.id);
     if (tab.interactionMode === "manual") {
       if (tab.manualDeadlineTimer) clearTimeout(tab.manualDeadlineTimer);
@@ -2270,6 +2276,87 @@ class BrowserHost {
     return { surfaceId: tab.surfaceId, tabId: tab.id, reused: false, connectorBound: false };
   }
 
+  heavyPhaseState() {
+    this.heavyPhase ??= { holder: null, queue: [] };
+    return this.heavyPhase;
+  }
+
+  /** A holder whose helper process is gone can never release; reclaim the lock for the queue. */
+  reclaimAbandonedHeavyPhase() {
+    const state = this.heavyPhaseState();
+    if (!state.holder) return;
+    if (processRunning(state.holder.helperPid)) return;
+    this.logger.info("browser.heavy_phase_reclaimed", {
+      traceId: state.holder.traceId,
+      helperPid: state.holder.helperPid,
+    });
+    state.holder = null;
+  }
+
+  grantNextHeavyPhase() {
+    const state = this.heavyPhaseState();
+    while (!state.holder && state.queue.length > 0) {
+      const next = state.queue.shift();
+      if (next.timer) clearTimeout(next.timer);
+      if (!processRunning(next.helperPid)) {
+        next.reject(new Error("The waiting helper exited before it entered the heavy browser phase"));
+        continue;
+      }
+      state.holder = { traceId: next.traceId, helperPid: next.helperPid, depth: 1 };
+      this.logger.info("browser.heavy_phase_granted", { traceId: next.traceId, waiting: state.queue.length });
+      next.resolve({ acquired: true });
+    }
+  }
+
+  async acquireHeavyPhase(traceId, helperPid) {
+    const state = this.heavyPhaseState();
+    this.reclaimAbandonedHeavyPhase();
+    if (state.holder && state.holder.traceId === traceId) {
+      // Heavy phases nest (a rebind runs inside a stage); the owner must not deadlock on itself.
+      state.holder.depth += 1;
+      return { acquired: true, reentrant: true };
+    }
+    if (!state.holder) {
+      state.holder = { traceId, helperPid, depth: 1 };
+      return { acquired: true };
+    }
+    return new Promise((resolve, reject) => {
+      const entry = { traceId, helperPid, resolve, reject };
+      entry.timer = setTimeout(() => {
+        const index = state.queue.indexOf(entry);
+        if (index >= 0) state.queue.splice(index, 1);
+        this.logger.info("browser.heavy_phase_timeout", {
+          traceId,
+          holderTraceId: state.holder ? state.holder.traceId : null,
+        });
+        reject(new Error(
+          "Waited " + Math.round(HEAVY_PHASE_WAIT_TIMEOUT_MS / 1000) + "s to enter the heavy ChatGPT "
+          + "browser phase while turn " + (state.holder ? state.holder.traceId : "unknown") + " held it",
+        ));
+      }, HEAVY_PHASE_WAIT_TIMEOUT_MS);
+      entry.timer.unref?.();
+      state.queue.push(entry);
+      this.logger.info("browser.heavy_phase_queued", { traceId, waiting: state.queue.length });
+    });
+  }
+
+  releaseHeavyPhase(traceId) {
+    const state = this.heavyPhaseState();
+    if (state.holder && state.holder.traceId === traceId) {
+      state.holder.depth -= 1;
+      if (state.holder.depth > 0) return { released: false, reentrant: true };
+      state.holder = null;
+    }
+    for (let index = state.queue.length - 1; index >= 0; index -= 1) {
+      if (state.queue[index].traceId !== traceId) continue;
+      const [entry] = state.queue.splice(index, 1);
+      if (entry.timer) clearTimeout(entry.timer);
+      entry.reject(new Error("The heavy ChatGPT browser phase was released before it was granted"));
+    }
+    this.grantNextHeavyPhase();
+    return { released: true };
+  }
+
   async endTurn(
     traceId,
     helperPid,
@@ -2303,6 +2390,8 @@ class BrowserHost {
     if (status === "completed") {
       this.logger.info("browser.tab_completed", { tabId: tab.id, traceId });
     }
+    // A turn that ends without releasing would strand every other turn behind its lock.
+    this.releaseHeavyPhase(traceId);
     if (status === "completed"
       && retain
       && tab.conversationKey

--- a/launcher/electron/browser-host.cjs
+++ b/launcher/electron/browser-host.cjs
@@ -33,7 +33,15 @@ const MAX_BROWSER_TABS = 5;
 // Concurrent turns each own a ChatGPT document in one Electron renderer pool. Two turns doing
 // heavy DOM work at the same time starve each other until a DOM probe times out, so the heavy
 // phases take a single-owner lock while waiting for a ChatGPT response stays free.
-const HEAVY_PHASE_WAIT_TIMEOUT_MS = 180_000;
+//
+// The wait has to cover every turn that can legitimately be ahead of this one. A holder cannot
+// exceed its own stage budget, and the longest heavy stage (a Bigger Context part submission)
+// is allowed 180s, so a full field of tabs can legally put MAX_BROWSER_TABS - 1 of those in
+// front of the last arrival. A flat 180s covered exactly one of them and failed the fifth chat
+// with a lock timeout while every turn ahead of it was behaving correctly. A dead holder is not
+// what this bounds - reclaimAbandonedHeavyPhase frees those immediately.
+const LONGEST_HEAVY_STAGE_BUDGET_MS = 180_000;
+const HEAVY_PHASE_WAIT_TIMEOUT_MS = (MAX_BROWSER_TABS - 1) * LONGEST_HEAVY_STAGE_BUDGET_MS;
 const MAX_CANCELLED_TURN_TRACES = 256;
 const MANUAL_SUBMIT_TIMEOUT_MS = 30_000;
 const MANUAL_COMPACTION_SUBMIT_TIMEOUT_MS = 120_000;
@@ -2978,7 +2986,9 @@ module.exports = {
   BrowserHost,
   BrowserTurnCancelledError,
   CHATGPT_VIEWPORT_CSS,
+  HEAVY_PHASE_WAIT_TIMEOUT_MS,
   IDLE_BROWSER_URL,
+  MAX_BROWSER_TABS,
   isChatGptCloudflareChallengeResponse,
   isTemporaryChatUrl,
   loadCommittedBrowserSurface,

--- a/launcher/electron/control-server.cjs
+++ b/launcher/electron/control-server.cjs
@@ -291,6 +291,14 @@ class BrowserControlServer {
         this.logger.info("browser.turn_started", { traceId: body.traceId });
         writeJson(response, 200, { ok: true, ...lease });
         return;
+      } else if (request.url === "/v1/turn/heavy-acquire") {
+        const granted = await host.acquireHeavyPhase(body.traceId, body.helperPid);
+        writeJson(response, 200, { ok: true, ...granted });
+        return;
+      } else if (request.url === "/v1/turn/heavy-release") {
+        const released = host.releaseHeavyPhase(body.traceId);
+        writeJson(response, 200, { ok: true, ...released });
+        return;
       } else if (request.url === "/v1/turn/heartbeat") {
         host.heartbeatTurn(body.traceId, body.helperPid, body.refreshViewport === true);
         this.logger.debug?.("browser.turn_heartbeat", { traceId: body.traceId });

--- a/launcher/electron/control-server.cjs
+++ b/launcher/electron/control-server.cjs
@@ -93,8 +93,13 @@ class BrowserControlServer {
       writeJson(response, 401, { error: "unauthorized" });
       return;
     }
+    // Every automatic turn phase the helper can post must be listed here. A phase handled below
+    // but missing from this guard is unreachable: the request is rejected as not_found before it
+    // ever reaches its branch, which took the whole bridge down when the heavy-phase lock shipped.
     const isTurn = request.url === "/v1/turn/start"
       || request.url === "/v1/turn/heartbeat"
+      || request.url === "/v1/turn/heavy-acquire"
+      || request.url === "/v1/turn/heavy-release"
       || request.url === "/v1/turn/end";
     const isTurnRelease = request.url === "/v1/turn/release";
     const isSessionInspect = request.url === "/v1/session/inspect";

--- a/launcher/tests/browser-host.test.cjs
+++ b/launcher/tests/browser-host.test.cjs
@@ -15,7 +15,9 @@ const {
 const {
   allowedAuthUrl,
   BrowserHost,
+  HEAVY_PHASE_WAIT_TIMEOUT_MS,
   IDLE_BROWSER_URL,
+  MAX_BROWSER_TABS,
   isChatGptCloudflareChallengeResponse,
   isTemporaryChatUrl,
   loadCommittedBrowserSurface,
@@ -3064,4 +3066,76 @@ test("a heavy phase held by a dead helper is reclaimed for the queue", async () 
     { acquired: true },
   );
   assert.equal(fixture.heavyPhase.holder.traceId, "trace_live");
+});
+
+test("five concurrent turns take the heavy phase one at a time and in arrival order", async () => {
+  // Five simultaneous chats is the goal the lock exists for; the earlier coverage stopped at two,
+  // which cannot show that the queue stays fair rather than starving whoever arrived first.
+  const fixture = heavyPhaseFixture();
+  const granted = [];
+
+  assert.deepEqual(
+    await BrowserHost.prototype.acquireHeavyPhase.call(fixture, "trace_1", process.pid),
+    { acquired: true },
+  );
+  granted.push("trace_1");
+
+  const waiters = ["trace_2", "trace_3", "trace_4", "trace_5"].map(traceId => (
+    BrowserHost.prototype.acquireHeavyPhase
+      .call(fixture, traceId, process.pid)
+      .then((value) => { granted.push(traceId); return value; })
+  ));
+  await new Promise(resolve => setImmediate(resolve));
+
+  assert.equal(fixture.heavyPhase.queue.length, 4, "four turns must wait rather than open a second heavy phase");
+  assert.equal(fixture.heavyPhase.holder.traceId, "trace_1");
+  assert.deepEqual(granted, ["trace_1"], "no waiter may enter while the first turn holds the lock");
+
+  for (const holder of ["trace_1", "trace_2", "trace_3", "trace_4"]) {
+    BrowserHost.prototype.releaseHeavyPhase.call(fixture, holder);
+    await new Promise(resolve => setImmediate(resolve));
+  }
+  assert.deepEqual(await Promise.all(waiters), [
+    { acquired: true },
+    { acquired: true },
+    { acquired: true },
+    { acquired: true },
+  ]);
+  assert.deepEqual(granted, ["trace_1", "trace_2", "trace_3", "trace_4", "trace_5"]);
+
+  BrowserHost.prototype.releaseHeavyPhase.call(fixture, "trace_5");
+  assert.equal(fixture.heavyPhase.holder, null);
+  assert.equal(fixture.heavyPhase.queue.length, 0);
+});
+
+test("a waiter whose helper died is skipped without holding up the turns behind it", async () => {
+  const fixture = heavyPhaseFixture();
+  await BrowserHost.prototype.acquireHeavyPhase.call(fixture, "trace_holder", process.pid);
+
+  // 2^30 is far above any live pid on this machine, so processRunning reports it as gone.
+  const dead = BrowserHost.prototype.acquireHeavyPhase.call(fixture, "trace_dead", 1073741824);
+  const live = BrowserHost.prototype.acquireHeavyPhase.call(fixture, "trace_live", process.pid);
+  await new Promise(resolve => setImmediate(resolve));
+  assert.equal(fixture.heavyPhase.queue.length, 2);
+
+  BrowserHost.prototype.releaseHeavyPhase.call(fixture, "trace_holder");
+  await assert.rejects(dead, /waiting helper exited/);
+  assert.deepEqual(await live, { acquired: true });
+  assert.equal(fixture.heavyPhase.holder.traceId, "trace_live");
+});
+
+test("the heavy phase wait covers a full field of tabs, not just one holder ahead", () => {
+  // A holder cannot exceed its own stage budget, and the longest heavy stage (a Bigger Context
+  // part submission) is allowed 180s. With five tabs, four of those can legally be ahead of the
+  // last arrival, so a flat 180s failed the fifth chat while every turn ahead of it behaved.
+  const longestHeavyStageBudgetMs = 180_000;
+  assert.equal(
+    HEAVY_PHASE_WAIT_TIMEOUT_MS,
+    (MAX_BROWSER_TABS - 1) * longestHeavyStageBudgetMs,
+    "the wait must be derived from the tab limit so raising one raises the other",
+  );
+  assert.ok(
+    HEAVY_PHASE_WAIT_TIMEOUT_MS >= longestHeavyStageBudgetMs * 2,
+    "a bound that covers only one holder ahead cannot support concurrent chats",
+  );
 });

--- a/launcher/tests/browser-host.test.cjs
+++ b/launcher/tests/browser-host.test.cjs
@@ -3012,3 +3012,56 @@ test("manual turns have no live-session TTL but are revoked when their owner pro
     status: "failed",
   });
 });
+
+function heavyPhaseFixture() {
+  return Object.assign(Object.create(BrowserHost.prototype), {
+    heavyPhase: { holder: null, queue: [] },
+    logger: { info() {}, warn() {} },
+  });
+}
+
+test("only one turn holds the heavy browser phase and the next one waits for it", async () => {
+  const fixture = heavyPhaseFixture();
+
+  assert.deepEqual(
+    await BrowserHost.prototype.acquireHeavyPhase.call(fixture, "trace_a", process.pid),
+    { acquired: true },
+  );
+
+  let secondGranted = false;
+  const second = BrowserHost.prototype.acquireHeavyPhase
+    .call(fixture, "trace_b", process.pid)
+    .then((value) => { secondGranted = true; return value; });
+  await new Promise(resolve => setImmediate(resolve));
+  assert.equal(secondGranted, false, "the second turn must not enter while the first holds the lock");
+  assert.equal(fixture.heavyPhase.queue.length, 1);
+
+  BrowserHost.prototype.releaseHeavyPhase.call(fixture, "trace_a");
+  assert.deepEqual(await second, { acquired: true });
+  assert.equal(fixture.heavyPhase.holder.traceId, "trace_b");
+});
+
+test("a turn re-entering the heavy phase does not deadlock on itself", async () => {
+  const fixture = heavyPhaseFixture();
+  await BrowserHost.prototype.acquireHeavyPhase.call(fixture, "trace_a", process.pid);
+  assert.deepEqual(
+    await BrowserHost.prototype.acquireHeavyPhase.call(fixture, "trace_a", process.pid),
+    { acquired: true, reentrant: true },
+  );
+  assert.equal(fixture.heavyPhase.holder.depth, 2);
+
+  BrowserHost.prototype.releaseHeavyPhase.call(fixture, "trace_a");
+  assert.equal(fixture.heavyPhase.holder.traceId, "trace_a");
+  BrowserHost.prototype.releaseHeavyPhase.call(fixture, "trace_a");
+  assert.equal(fixture.heavyPhase.holder, null);
+});
+
+test("a heavy phase held by a dead helper is reclaimed for the queue", async () => {
+  const fixture = heavyPhaseFixture();
+  fixture.heavyPhase.holder = { traceId: "trace_dead", helperPid: 1073741824, depth: 1 };
+  assert.deepEqual(
+    await BrowserHost.prototype.acquireHeavyPhase.call(fixture, "trace_live", process.pid),
+    { acquired: true },
+  );
+  assert.equal(fixture.heavyPhase.holder.traceId, "trace_live");
+});

--- a/launcher/tests/control-server.test.cjs
+++ b/launcher/tests/control-server.test.cjs
@@ -500,3 +500,51 @@ test("browser control server rejects malformed retained-conversation contracts",
     await server.close();
   }
 });
+
+test("browser control server routes every heavy-phase lock call the helper can post", async () => {
+  // The heavy-phase branches are dispatched far below the request guard. When the guard did not
+  // list them, every automatic turn died on its first heavy stage with HTTP 404: not_found, so
+  // this exercises the real HTTP surface rather than the host methods directly.
+  const calls = [];
+  const host = {
+    browserInteractionMode: () => "automatic",
+    acquireHeavyPhase: (...args) => {
+      calls.push(["heavy-acquire", ...args]);
+      return { acquired: true };
+    },
+    releaseHeavyPhase: (...args) => {
+      calls.push(["heavy-release", ...args]);
+      return { released: true };
+    },
+  };
+  const server = await new BrowserControlServer({
+    logger: { info: () => {}, warn: () => {}, debug: () => {} },
+    getBrowserHost: () => host,
+    getPreferences: () => ({ showBrowserDuringTurns: false }),
+  }).start();
+  const descriptor = server.descriptor();
+  const post = (phase) => fetch(`${descriptor.endpoint}/v1/turn/${phase}`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${descriptor.token}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ phase, traceId: "abcdef123456", helperPid: process.pid }),
+  });
+  try {
+    const acquire = await post("heavy-acquire");
+    assert.equal(acquire.status, 200);
+    assert.deepEqual(await acquire.json(), { ok: true, acquired: true });
+
+    const release = await post("heavy-release");
+    assert.equal(release.status, 200);
+    assert.deepEqual(await release.json(), { ok: true, released: true });
+
+    assert.deepEqual(calls, [
+      ["heavy-acquire", "abcdef123456", process.pid],
+      ["heavy-release", "abcdef123456"],
+    ]);
+  } finally {
+    await server.close();
+  }
+});

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -1099,10 +1099,10 @@ const CHATGPT_HEAVY_STAGES = new Set([
  * probe times out. Waiting for a ChatGPT response is deliberately absent - that is where concurrent
  * turns spend most of their time, and holding the lock there would remove all parallelism.
  */
-function isHeavyChatGptStage(stage: string): boolean {
+export function isHeavyChatGptStage(stage: string): boolean {
   return CHATGPT_HEAVY_STAGES.has(stage)
-    || /^response_page_rebind_d+$/.test(stage)
-    || /^multipart_stage_d+_(attachment|send)$/.test(stage);
+    || /^response_page_rebind_\d+$/.test(stage)
+    || /^multipart_stage_\d+_(attachment|send)$/.test(stage);
 }
 
 export const CHATGPT_MIN_OPERATIONAL_VIEWPORT = Object.freeze({ width: 320, height: 240 });

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -1088,6 +1088,8 @@ const CHATGPT_HEAVY_STAGES = new Set([
   "browser_page",
   "temporary_chat_preparation",
   "effort_selection",
+  "final_part_effort_selection",
+  "connector_catalog_refresh",
   "prompt_attachment",
   "file_attachment",
   "send",

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -1084,6 +1084,27 @@ export async function connectAfterClosingBrowserConnection<T>(
   return connect();
 }
 
+const CHATGPT_HEAVY_STAGES = new Set([
+  "browser_page",
+  "temporary_chat_preparation",
+  "effort_selection",
+  "prompt_attachment",
+  "file_attachment",
+  "send",
+]);
+
+/**
+ * Stages that drive the ChatGPT document: navigation, composer preparation, prompt attachment and
+ * submission. Two turns doing these at once in one renderer pool starve each other until a DOM
+ * probe times out. Waiting for a ChatGPT response is deliberately absent - that is where concurrent
+ * turns spend most of their time, and holding the lock there would remove all parallelism.
+ */
+function isHeavyChatGptStage(stage: string): boolean {
+  return CHATGPT_HEAVY_STAGES.has(stage)
+    || /^response_page_rebind_d+$/.test(stage)
+    || /^multipart_stage_d+_(attachment|send)$/.test(stage);
+}
+
 export const CHATGPT_MIN_OPERATIONAL_VIEWPORT = Object.freeze({ width: 320, height: 240 });
 
 async function waitForOperationalChatGptViewport(page: Page, signal?: AbortSignal): Promise<void> {
@@ -2146,6 +2167,17 @@ export class ChatGptBrowserWorker {
     suspensionClock: Pick<ChatGptSuspensionClock, "suspendedMs"> = chatGptSuspensionClock,
     awaitAbortedActionSettlement = false,
   ): Promise<T> {
+    // The contract tests invoke this with a synthetic `this`, so nothing here may assume config.
+    const heavyDescriptorPath = this.config?.browserHost === "launcher" && isHeavyChatGptStage(stage)
+      ? this.config.browserHostDescriptorPath
+      : undefined;
+    if (heavyDescriptorPath) {
+      await notifyLauncherTurn(heavyDescriptorPath, {
+        phase: "heavy-acquire",
+        traceId,
+        helperPid: process.pid,
+      });
+    }
     chatGptSuspensionClock.start();
     const startedAt = performance.now();
     const suspendedAtStart = suspensionClock.suspendedMs();
@@ -2190,6 +2222,14 @@ export class ChatGptBrowserWorker {
       throw surfacedError;
     } finally {
       if (timer) clearTimeout(timer);
+      if (heavyDescriptorPath) {
+        // Releasing must never mask the stage's own outcome; the launcher also releases on turn end.
+        await notifyLauncherTurn(heavyDescriptorPath, {
+          phase: "heavy-release",
+          traceId,
+          helperPid: process.pid,
+        }).catch(() => {});
+      }
     }
   }
 

--- a/src/launcher-browser-host.ts
+++ b/src/launcher-browser-host.ts
@@ -375,8 +375,14 @@ export const LAUNCHER_TURN_START_TIMEOUT_MS = 5_000;
 export const LAUNCHER_TURN_HEARTBEAT_INTERVAL_MS = 10_000;
 export const LAUNCHER_TURN_HEARTBEAT_TIMEOUT_MS = 5_000;
 export const LAUNCHER_TURN_END_TIMEOUT_MS = 15_000;
-/** Longer than the launcher's own heavy-phase wait, so its explicit error surfaces before this aborts. */
-export const LAUNCHER_HEAVY_PHASE_TIMEOUT_MS = 200_000;
+/**
+ * Longer than the launcher's own heavy-phase wait, so its explicit error surfaces before this
+ * aborts. The launcher bounds that wait at (MAX_BROWSER_TABS - 1) x the longest heavy stage,
+ * which is 720s for five tabs; anything shorter here would abort the request while the launcher
+ * still considers the turn a legitimate waiter, and the helper would report a transport failure
+ * instead of the launcher's message naming what it was waiting on.
+ */
+export const LAUNCHER_HEAVY_PHASE_TIMEOUT_MS = 750_000;
 
 export interface LauncherManualTurnOwner {
   traceId: string;

--- a/src/launcher-browser-host.ts
+++ b/src/launcher-browser-host.ts
@@ -358,12 +358,25 @@ export type LauncherTurnActivity =
       message?: string;
       retain?: boolean;
       connectorBound?: boolean;
+    }
+  | {
+      /** Take the single-owner lock that keeps concurrent turns off the renderer at the same time. */
+      phase: "heavy-acquire";
+      traceId: string;
+      helperPid: number;
+    }
+  | {
+      phase: "heavy-release";
+      traceId: string;
+      helperPid: number;
     };
 
 export const LAUNCHER_TURN_START_TIMEOUT_MS = 5_000;
 export const LAUNCHER_TURN_HEARTBEAT_INTERVAL_MS = 10_000;
 export const LAUNCHER_TURN_HEARTBEAT_TIMEOUT_MS = 5_000;
 export const LAUNCHER_TURN_END_TIMEOUT_MS = 15_000;
+/** Longer than the launcher's own heavy-phase wait, so its explicit error surfaces before this aborts. */
+export const LAUNCHER_HEAVY_PHASE_TIMEOUT_MS = 200_000;
 
 export interface LauncherManualTurnOwner {
   traceId: string;
@@ -594,7 +607,11 @@ export async function notifyLauncherTurn(
     ? LAUNCHER_TURN_END_TIMEOUT_MS
     : activity.phase === "heartbeat"
       ? LAUNCHER_TURN_HEARTBEAT_TIMEOUT_MS
-      : LAUNCHER_TURN_START_TIMEOUT_MS,
+      : activity.phase === "heavy-acquire"
+        ? LAUNCHER_HEAVY_PHASE_TIMEOUT_MS
+        : activity.phase === "heavy-release"
+          ? LAUNCHER_TURN_END_TIMEOUT_MS
+          : LAUNCHER_TURN_START_TIMEOUT_MS,
 ): Promise<{
   surfaceId?: string;
   reused?: boolean;

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -3682,6 +3682,8 @@ test("heavy stage matching covers the numbered stages and never the response wai
     "browser_page",
     "temporary_chat_preparation",
     "effort_selection",
+    "final_part_effort_selection",
+    "connector_catalog_refresh",
     "prompt_attachment",
     "file_attachment",
     "send",

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import type { Page } from "playwright-core";
 import { CHATGPT_BROWSER_OBSERVATION_PROBE_TIMEOUT_MS, CHATGPT_COMPLETION_SETTLE_MS, CHATGPT_EXTERNAL_PROGRESS_CLOCK_SKEW_MS, CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS, ChatGptCompletionTracker, chatGptExternalProgressSuppressesDomHealth, CHATGPT_RESPONSE_DOM_GRACE_MS, MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS, CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_COMPOSER_SELECT_ALL_KEY, CHATGPT_STOPPED_THINKING_GRACE_MS, ChatGptBrowserObservationTimeoutError, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_PAGE_REBINDS, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, assertChatGptWebMultipartInputWithinLimits, browserDiagnosticCheckpoint, chatGptConnectorAttachmentMode, chatGptNewTurnIdentity, chatGptReboundTurnIdentity, chatGptSubmissionEvidence, connectAfterClosingBrowserConnection, dismissChatGptTemporaryChatOnboarding, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, resolveChatGptWebMultipartStagingMode, sanitizeChatGptBrowserDiagnosticState, setChatGptThinkMode, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert, withChatGptBrowserObservationTimeout, CHATGPT_MULTIPART_RESPONSE_DOM_GRACE_MS, browserStageTimeouts, ChatGptSuspensionClock, remainingStageBudgetMs } from "../src/adapters/chatgpt-web/browser-worker";
 import { ensureChatGptPersonalizedConnectorAccess } from "../src/adapters/chatgpt-web/browser-worker";
+import { isHeavyChatGptStage } from "../src/adapters/chatgpt-web/browser-worker";
 import { chatGptStoppedThinkingError } from "../src/adapters/chatgpt-web/adapter-error";
 import { CHATGPT_WEB_MODEL_ID } from "../src/adapters/chatgpt-web/model";
 import { CHATGPT_CONNECTOR_NAME, DEV_CHATGPT_CONNECTOR_NAME, defaultChromeExecutable, legacyChatGptConnectorMigrationMessage } from "../src/config";
@@ -3673,3 +3674,33 @@ test("a stage that spans a system sleep is not charged for the slept time", asyn
   await stage;
   expect(outcome).toEqual(["ChatGPT browser stage timed out: probe"]);
 }, 10_000);
+
+test("heavy stage matching covers the numbered stages and never the response wait", () => {
+  // A lost backslash turned both numbered patterns into literal "d+" matchers, so the rebind and
+  // multipart delivery stages silently escaped the lock they were written for.
+  for (const stage of [
+    "browser_page",
+    "temporary_chat_preparation",
+    "effort_selection",
+    "prompt_attachment",
+    "file_attachment",
+    "send",
+    "response_page_rebind_1",
+    "response_page_rebind_12",
+    "multipart_stage_1_attachment",
+    "multipart_stage_2_send",
+  ]) {
+    expect(isHeavyChatGptStage(stage)).toBe(true);
+  }
+  // Waiting for ChatGPT to answer is where concurrent turns spend most of their time. Holding the
+  // lock across it would serialize the whole system and remove the parallelism the lock exists for.
+  for (const stage of [
+    "multipart_stage_1_acknowledgement",
+    "multipart_stage_2_acknowledgement",
+    "response_page_rebind_",
+    "response_page_rebind_d",
+    "multipart_stage_d_send",
+  ]) {
+    expect(isHeavyChatGptStage(stage)).toBe(false);
+  }
+});

--- a/tests/launcher-browser-host.test.ts
+++ b/tests/launcher-browser-host.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   LAUNCHER_BROWSER_HOST_KIND,
+  LAUNCHER_HEAVY_PHASE_TIMEOUT_MS,
   LAUNCHER_BROWSER_IDLE_URL,
   LauncherManualTurnTimedOutError,
   LauncherRetainedConversationUnavailableError,
@@ -567,4 +568,13 @@ test("manual Sent wait preserves typed timeout and cancellation signals", async 
       await new Promise<void>(resolveClose => server.close(() => resolveClose()));
     }
   }
+});
+
+test("the helper outwaits the launcher's heavy-phase bound so its message survives", () => {
+  // The launcher bounds a heavy-phase wait at (MAX_BROWSER_TABS - 1) x the longest heavy stage,
+  // which is 4 x 180s for five tabs (see HEAVY_PHASE_WAIT_TIMEOUT_MS in browser-host.cjs). If this
+  // fetch aborted first, the helper would report a transport failure instead of the launcher's
+  // explicit error naming the turn it was waiting on.
+  const launcherHeavyPhaseBoundMs = (5 - 1) * 180_000;
+  expect(LAUNCHER_HEAVY_PHASE_TIMEOUT_MS).toBeGreaterThan(launcherHeavyPhaseBoundMs);
 });


### PR DESCRIPTION
Five ChatGPT browser tabs can run concurrently, but the expensive page-driving phases share one Electron renderer pool. Concurrent DOM setup/rebind/multipart-send work can starve another turn until its DOM probe times out even when both turns are otherwise healthy.

Add a single-owner FIFO lock only around the heavy page-driving stages. Waiting for model output remains outside the lock, so normal concurrent reasoning still proceeds. The lock is re-entrant per turn, reclaims dead helpers, skips dead waiters, releases on every terminal path, and sizes its wait budget for the full five-tab field.

This also includes the follow-up fixes that make the lock effective: expose the heavy acquire/release control routes, match numbered rebind/multipart stages correctly, and cover connector catalog refresh/final effort selection.

Validation:
- `node --test launcher/tests/browser-host.test.cjs launcher/tests/control-server.test.cjs` — 111 pass, 0 fail.
- `bun test tests/browser-worker-contract.test.ts tests/launcher-browser-host.test.ts` — 135 pass, 0 fail.
- `bun x tsc --noEmit` passes.
- `git diff --check` passes.
