### PR TITLE
fix(chatgpt-web): guard browser message capacity before send

### DIFF
--- a/src/adapters/chatgpt-web/capacity.ts
+++ b/src/adapters/chatgpt-web/capacity.ts
@@ -1,0 +1,82 @@
+import type { CodexParsedRequest } from "../../types";
+import { ChatGptWebAdapterError } from "./adapter-error";
+import {
+  compiledChatGptWebMaxMessageChars,
+  DEFAULT_CHATGPT_WEB_MAX_MESSAGE_CHARS,
+} from "./input-tokens";
+import { CHATGPT_WEB_LUNA_MODEL_ID, type ChatGptWebCapabilities } from "./model";
+import {
+  CHATGPT_BIGGER_CONTEXT_PARTS,
+  compileChatGptWebPrompt,
+  type CompileChatGptWebPromptOptions,
+  type CompiledChatGptWebPrompt,
+} from "./prompt";
+
+export { DEFAULT_CHATGPT_WEB_MAX_MESSAGE_CHARS } from "./input-tokens";
+
+export interface ChatGptWebCapacityCompileOptions
+  extends Omit<CompileChatGptWebPromptOptions, "multipartParts" | "experimentalMultipartParts" | "preserveCompactionHistory"> {
+  maxMessageChars?: number;
+}
+
+function capacityError(
+  actualChars: number,
+  maxMessageChars: number,
+  transport: "automatic" | "manual" | "luna",
+): ChatGptWebAdapterError {
+  const actual = actualChars.toLocaleString("en-US");
+  const limit = maxMessageChars.toLocaleString("en-US");
+  const transportGuidance = transport === "manual"
+    ? " Zero Risk cannot split the prompt into multiple browser messages."
+    : transport === "luna"
+      ? " Luna cannot use multipart browser transport because its staged transcript shares one browser input budget."
+      : " Even the three-part browser transport cannot keep every message within the configured page limit.";
+  return new ChatGptWebAdapterError(
+    `ChatGPT browser prompt requires ${actual} characters in one message, above the configured page limit of ${limit}.${transportGuidance}`
+      + " Reduce or compact the Codex context, or raise chatGptWebMaxMessageChars only after verifying this machine's ChatGPT page capacity.",
+    {
+      status: 413,
+      errorType: "invalid_request_error",
+      code: "browser_message_too_large",
+      retryable: false,
+    },
+  );
+}
+
+export function compileChatGptWebPromptWithinPageCapacity(
+  parsed: CodexParsedRequest,
+  capabilities: ChatGptWebCapabilities,
+  turnToken?: string,
+  options: ChatGptWebCapacityCompileOptions = {},
+): CompiledChatGptWebPrompt {
+  const maxMessageChars = options.maxMessageChars ?? DEFAULT_CHATGPT_WEB_MAX_MESSAGE_CHARS;
+  if (!Number.isSafeInteger(maxMessageChars) || maxMessageChars <= 0) {
+    throw new Error("ChatGPT browser maxMessageChars must be a positive safe integer");
+  }
+  const { maxMessageChars: _ignored, ...compileOptions } = options;
+  const baseOptions = {
+    ...compileOptions,
+    preserveCompactionHistory: true,
+  } satisfies CompileChatGptWebPromptOptions;
+  const inline = compileChatGptWebPrompt(parsed, capabilities, turnToken, baseOptions);
+  const inlineChars = compiledChatGptWebMaxMessageChars(inline);
+  if (inlineChars <= maxMessageChars) return inline;
+
+  if (options.manualControl === true) {
+    throw capacityError(inlineChars, maxMessageChars, "manual");
+  }
+  if (parsed.modelId === CHATGPT_WEB_LUNA_MODEL_ID) {
+    throw capacityError(inlineChars, maxMessageChars, "luna");
+  }
+
+  let lastChars = inlineChars;
+  for (const multipartParts of [2, CHATGPT_BIGGER_CONTEXT_PARTS] as const) {
+    const candidate = compileChatGptWebPrompt(parsed, capabilities, turnToken, {
+      ...baseOptions,
+      multipartParts,
+    });
+    lastChars = compiledChatGptWebMaxMessageChars(candidate);
+    if (lastChars <= maxMessageChars) return candidate;
+  }
+  throw capacityError(lastChars, maxMessageChars, "automatic");
+}

--- a/src/adapters/chatgpt-web/capacity.ts
+++ b/src/adapters/chatgpt-web/capacity.ts
@@ -15,7 +15,7 @@ import {
 export { DEFAULT_CHATGPT_WEB_MAX_MESSAGE_CHARS } from "./input-tokens";
 
 export interface ChatGptWebCapacityCompileOptions
-  extends Omit<CompileChatGptWebPromptOptions, "multipartParts" | "experimentalMultipartParts" | "preserveCompactionHistory"> {
+  extends Omit<CompileChatGptWebPromptOptions, "preserveCompactionHistory"> {
   maxMessageChars?: number;
 }
 
@@ -70,7 +70,12 @@ export function compileChatGptWebPromptWithinPageCapacity(
   }
 
   let lastChars = inlineChars;
-  for (const multipartParts of [2, CHATGPT_BIGGER_CONTEXT_PARTS] as const) {
+  const requestedParts = options.multipartParts ?? options.experimentalMultipartParts;
+  const candidates = requestedParts === CHATGPT_BIGGER_CONTEXT_PARTS
+    ? [CHATGPT_BIGGER_CONTEXT_PARTS] as const
+    : [2, CHATGPT_BIGGER_CONTEXT_PARTS] as const;
+  for (const multipartParts of candidates) {
+    if (multipartParts === requestedParts) continue;
     const candidate = compileChatGptWebPrompt(parsed, capabilities, turnToken, {
       ...baseOptions,
       multipartParts,

--- a/src/adapters/chatgpt-web/index.ts
+++ b/src/adapters/chatgpt-web/index.ts
@@ -33,7 +33,7 @@ import { createChatGptStructuredOutputValidator } from "./output-validation";
 import { chatGptWebTurnRetryPolicy } from "./retry-policy";
 import { TurnBroker, type BrokerToolRequest, type BrokerToolResult, type TurnBrokerOwner } from "./turn-broker";
 import { ChatGptTextFeed, ChatGptTraceFeed, chatGptCompactionSourceExecutionKey, chatGptInstructionLineage, chatGptThreadOwnershipKey, chatGptTurnExecutionKey, chatGptTurnRetryKey, chatGptTurnRoundKey, chatGptTurnSessions, type ChatGptBrowserOutcome, type ChatGptTraceEvent, type ChatGptTurnRuntime, type ChatGptTurnSession } from "./turn-execution";
-import { estimateChatGptWebUsage } from "./usage";
+import { estimateChatGptWebUsage, resolveBiggerContextMultipartParts } from "./usage";
 import { ChatGptThreadEnvironmentStore } from "./thread-environment";
 import {
   ChatGptLunaCheckpointStore,
@@ -439,16 +439,17 @@ export function createChatGptWebAdapter(
       input: CodexParsedRequest,
       turnToken?: string,
       manualControl = false,
-    ) => compileChatGptWebPromptWithinPageCapacity(
-      input,
-      turnCapabilities,
-      turnToken,
-      {
+    ) => {
+      const multipartParts = !manualControl && experimentalBiggerContext
+        ? resolveBiggerContextMultipartParts(input, turnCapabilities)
+        : undefined;
+      return compileChatGptWebPromptWithinPageCapacity(input, turnCapabilities, turnToken, {
         captureLunaCheckpoint,
         maxMessageChars,
         ...(manualControl ? { manualControl: true as const } : {}),
-      },
-    );
+        ...(multipartParts !== undefined ? { multipartParts } : {}),
+      });
+    };
     if (captureLunaCheckpoint) {
       console.info(
         `[chatgpt-web] Luna rolling checkpoint applied=${checkpointInput.applied}${checkpointInput.reason ? ` reason=${checkpointInput.reason}` : ""}`,

--- a/src/adapters/chatgpt-web/index.ts
+++ b/src/adapters/chatgpt-web/index.ts
@@ -22,14 +22,18 @@ import type { ProviderAdapter } from "../base";
 import { parseDataUrl } from "../image";
 import { ChatGptWebAdapterError } from "./adapter-error";
 import { ChatGptBrowserWorker } from "./browser-worker";
+import {
+  compileChatGptWebPromptWithinPageCapacity,
+  DEFAULT_CHATGPT_WEB_MAX_MESSAGE_CHARS,
+} from "./capacity";
 import { extractChatGptTurnEnvironment, extractChatGptTurnIdentity, priorChatGptAbortedTurnIds } from "./environment";
 import { CHATGPT_WEB_LUNA_MODEL_ID, resolveChatGptWebModelMode, type ChatGptWebCapabilities } from "./model";
-import { chatGptReadOnlyContextWarning, compileChatGptWebPrompt } from "./prompt";
+import { chatGptReadOnlyContextWarning } from "./prompt";
 import { createChatGptStructuredOutputValidator } from "./output-validation";
 import { chatGptWebTurnRetryPolicy } from "./retry-policy";
 import { TurnBroker, type BrokerToolRequest, type BrokerToolResult, type TurnBrokerOwner } from "./turn-broker";
 import { ChatGptTextFeed, ChatGptTraceFeed, chatGptCompactionSourceExecutionKey, chatGptInstructionLineage, chatGptThreadOwnershipKey, chatGptTurnExecutionKey, chatGptTurnRetryKey, chatGptTurnRoundKey, chatGptTurnSessions, type ChatGptBrowserOutcome, type ChatGptTraceEvent, type ChatGptTurnRuntime, type ChatGptTurnSession } from "./turn-execution";
-import { estimateChatGptWebUsage, resolveBiggerContextMultipartParts } from "./usage";
+import { estimateChatGptWebUsage } from "./usage";
 import { ChatGptThreadEnvironmentStore } from "./thread-environment";
 import {
   ChatGptLunaCheckpointStore,
@@ -352,6 +356,10 @@ export function createChatGptWebAdapter(
   if (experimentalBiggerContext !== undefined && typeof experimentalBiggerContext !== "boolean") {
     throw new Error("ChatGPT Bigger Context preference must be a boolean");
   }
+  const maxMessageChars = provider.chatgptWeb?.maxMessageChars ?? DEFAULT_CHATGPT_WEB_MAX_MESSAGE_CHARS;
+  if (!Number.isSafeInteger(maxMessageChars) || maxMessageChars <= 0) {
+    throw new Error("ChatGPT browser maxMessageChars must be a positive safe integer");
+  }
   const configuredCapabilities: ChatGptWebCapabilities = {
     localToolsEnabled: provider.chatgptWeb?.localToolsEnabled === true,
     solAvailable: provider.chatgptWeb?.solAvailable !== false,
@@ -427,18 +435,20 @@ export function createChatGptWebAdapter(
         await releaseLauncherRetainedConversation(retainedLauncherDescriptor, conversationKey);
       }
       : undefined;
-    const compileOptionsFor = (input: CodexParsedRequest) => {
-      if (manualRequest) return {};
-      const experimentalMultipartParts = experimentalBiggerContext
-        ? resolveBiggerContextMultipartParts(input, turnCapabilities)
-        : undefined;
-      return {
+    const compileForCapacity = (
+      input: CodexParsedRequest,
+      turnToken?: string,
+      manualControl = false,
+    ) => compileChatGptWebPromptWithinPageCapacity(
+      input,
+      turnCapabilities,
+      turnToken,
+      {
         captureLunaCheckpoint,
-        ...(experimentalMultipartParts !== undefined
-          ? { experimentalMultipartParts }
-          : {}),
-      };
-    };
+        maxMessageChars,
+        ...(manualControl ? { manualControl: true as const } : {}),
+      },
+    );
     if (captureLunaCheckpoint) {
       console.info(
         `[chatgpt-web] Luna rolling checkpoint applied=${checkpointInput.applied}${checkpointInput.reason ? ` reason=${checkpointInput.reason}` : ""}`,
@@ -527,19 +537,9 @@ export function createChatGptWebAdapter(
         try {
           activeToken = await broker.registerSafe(environment, surfaceNonce, undefined, traceId);
           observeCapabilityRetirement(activeToken, externalProgress);
-          const compiled = compileChatGptWebPrompt(
-            checkpointInput.parsed,
-            turnCapabilities,
-            activeToken,
-            { manualControl: true },
-          );
+          const compiled = compileForCapacity(checkpointInput.parsed, activeToken, true);
           const resumeCompiled = resumeInput
-            ? compileChatGptWebPrompt(
-              resumeInput,
-              turnCapabilities,
-              activeToken,
-              { manualControl: true },
-            )
+            ? compileForCapacity(resumeInput, activeToken, true)
             : undefined;
           for (const candidate of [compiled, resumeCompiled]) {
             if (!candidate) continue;
@@ -675,12 +675,7 @@ export function createChatGptWebAdapter(
         reasoning: parsed.options.reasoning,
         capabilities: turnCapabilities,
         prepare: async () => ({
-          ...compileChatGptWebPrompt(
-            checkpointInput.parsed,
-            turnCapabilities,
-            undefined,
-            compileOptionsFor(checkpointInput.parsed),
-          ),
+          ...compileForCapacity(checkpointInput.parsed),
           release: () => {},
         }),
         abortSignal: browserAbort.signal,
@@ -719,12 +714,7 @@ export function createChatGptWebAdapter(
       );
       activeToken = turnToken;
       try {
-        const compiled = compileChatGptWebPrompt(
-          input,
-          turnCapabilities,
-          turnToken,
-          compileOptionsFor(input),
-        );
+        const compiled = compileForCapacity(input, turnToken);
         // Publish only after preparation succeeds: otherwise its failure revokes the token
         // before the response observer uses it and masks the cause as an expired capability.
         observeCapabilityRetirement(turnToken, externalProgress);

--- a/src/adapters/chatgpt-web/input-tokens.ts
+++ b/src/adapters/chatgpt-web/input-tokens.ts
@@ -12,6 +12,13 @@ const CHATGPT_IMAGE_RESERVE_TOKENS = 4_096;
 const CHATGPT_ORIGINAL_IMAGE_RESERVE_TOKENS = 8_192;
 
 /**
+ * Empirical ChatGPT page/composer capacity guard. This is deliberately independent of the model
+ * context window: browser responsiveness was observed to fail at larger message sizes, and the
+ * exact threshold can vary by machine/browser build. Override it only with local evidence.
+ */
+export const DEFAULT_CHATGPT_WEB_MAX_MESSAGE_CHARS = 80_000;
+
+/**
  * The Free/Luna product accepted measured browser inputs at 25,400 and 28,547 estimated tokens,
  * but rejected the same shape at 32,283 before producing a response. This is a ChatGPT browser
  * transport boundary, not Luna's model context window, and applies to normal and checkpoint turns.

--- a/src/adapters/chatgpt-web/prompt.ts
+++ b/src/adapters/chatgpt-web/prompt.ts
@@ -17,7 +17,7 @@ export interface ChatGptWebPromptImage {
 export interface CompiledChatGptWebPrompt {
   text: string;
   images: ChatGptWebPromptImage[];
-  /** DEV-only transactional context transport. Production prompts remain inline. */
+  /** Transactional context transport used when one browser message would exceed page capacity. */
   multipart?: ChatGptWebMultipartPrompt;
   /** Oldest history items removed by native-style compaction fit recovery; absent on normal turns. */
   trimmedCompactionMessages?: number;
@@ -25,7 +25,11 @@ export interface CompiledChatGptWebPrompt {
 
 export interface CompileChatGptWebPromptOptions {
   captureLunaCheckpoint?: boolean;
+  multipartParts?: ChatGptWebMultipartPartCount;
+  /** @deprecated Use multipartParts. Kept for direct callers during the transport migration. */
   experimentalMultipartParts?: ChatGptWebMultipartPartCount;
+  /** Measure/transport canonical compaction history before the retired inline byte-fit fallback. */
+  preserveCompactionHistory?: boolean;
   /**
    * Manual Zero Risk transport keeps ChatGPT model/effort selection and prompt submission under the
    * user's control. The browser bridge may open the owned tab and copy this prompt, but it never
@@ -422,7 +426,12 @@ export function compileChatGptWebPrompt(
     ? { localTools: true, effort: "low" as const, displayLabel: "Zero Risk" as const }
     : resolveChatGptWebModelMode(parsed.modelId, parsed.options.reasoning, capabilities);
   const captureLunaCheckpoint = options?.captureLunaCheckpoint === true;
-  const multipartParts = options?.experimentalMultipartParts;
+  if (options?.multipartParts !== undefined
+    && options.experimentalMultipartParts !== undefined
+    && options.multipartParts !== options.experimentalMultipartParts) {
+    throw new Error("ChatGPT multipart part-count options disagree");
+  }
+  const multipartParts = options?.multipartParts ?? options?.experimentalMultipartParts;
   const multipartEnabled = multipartParts !== undefined;
   if (manualControl) {
     if (!capabilities.localToolsEnabled) {
@@ -433,7 +442,7 @@ export function compileChatGptWebPrompt(
     }
   }
   if (multipartParts !== undefined && multipartParts !== 2 && multipartParts !== CHATGPT_BIGGER_CONTEXT_PARTS) {
-    throw new Error("Bigger Context requires two or three multipart stages");
+    throw new Error("ChatGPT multipart transport requires two or three stages");
   }
   if (multipartEnabled && parsed.modelId === CHATGPT_WEB_LUNA_MODEL_ID) {
     throw new Error("Bigger Context is unavailable for Luna because its accumulated browser transcript still shares one 28,000-token transport budget");
@@ -629,7 +638,7 @@ export function compileChatGptWebPrompt(
   // as ordinary multipart turns in browser-worker. Applying the legacy byte cap here silently
   // discarded context that the staged transport can carry; preserve it and let browser preflight
   // fail explicitly if any atomic record is genuinely too large for one stage.
-  if (compiled.multipart) return compiled;
+  if (compiled.multipart || options?.preserveCompactionHistory === true) return compiled;
 
   const exceedsCompactionBudget = (): boolean => (
     chatGptPromptJsonBytes(compiled.text) > CHATGPT_COMPACTION_PROMPT_JSON_BYTE_BUDGET

--- a/src/config.ts
+++ b/src/config.ts
@@ -120,6 +120,8 @@ export interface AppConfig {
   solAvailable: boolean;
   proAvailable: boolean;
   experimentalBiggerContext: boolean;
+  /** Optional empirical ChatGPT page/composer character ceiling. */
+  chatGptWebMaxMessageChars?: number;
   /** Explicitly install the additional Pro-sized model row while Zero Risk is active. */
   zeroRiskProEnabled: boolean;
   /** Optional adapter-silence budget for the Responses watchdog. */
@@ -520,6 +522,10 @@ function parseConfig(value: unknown, path: string): AppConfig {
     && typeof parsed.experimentalBiggerContext !== "boolean") {
     throw new Error(`Invalid experimentalBiggerContext in ${path}`);
   }
+  if (parsed.chatGptWebMaxMessageChars !== undefined
+    && (!Number.isSafeInteger(parsed.chatGptWebMaxMessageChars) || parsed.chatGptWebMaxMessageChars <= 0)) {
+    throw new Error(`Invalid chatGptWebMaxMessageChars in ${path}`);
+  }
   if (parsed.zeroRiskProEnabled !== undefined && typeof parsed.zeroRiskProEnabled !== "boolean") {
     throw new Error(`Invalid zeroRiskProEnabled in ${path}`);
   }
@@ -601,6 +607,9 @@ export function providerConfig(config: AppConfig): CodexProviderConfig {
       solAvailable: manual ? false : config.solAvailable,
       proAvailable: manual ? false : config.proAvailable,
       experimentalBiggerContext: manual ? false : config.experimentalBiggerContext,
+      ...(config.chatGptWebMaxMessageChars !== undefined
+        ? { maxMessageChars: config.chatGptWebMaxMessageChars }
+        : {}),
       ...(config.stallTimeoutSec !== undefined ? { stallTimeoutSec: config.stallTimeoutSec } : {}),
       autoApproveToolCalls: manual ? false : config.autoApproveToolCalls,
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -301,6 +301,8 @@ export interface CodexProviderConfig {
     proAvailable?: boolean;
     /** Authorize per-call "Allow once" confirmation clicks for this connector. */
     autoApproveToolCalls?: boolean;
+    /** Empirical per-message ChatGPT page capacity, independent of the model context window. */
+    maxMessageChars?: number;
     /** DEV-only experimental transport: adapt one context across one, two, or three ChatGPT messages. */
     experimentalBiggerContext?: boolean;
   };

--- a/tests/chatgpt-web-harness.test.ts
+++ b/tests/chatgpt-web-harness.test.ts
@@ -274,6 +274,144 @@ function toolResult(value: Record<string, unknown>): BrokerToolResult {
   };
 }
 
+test("browser page capacity keeps a prompt inline when it fits", async () => {
+  const socketPath = brokerTestEndpoint(`cgw-page-capacity-inline-${process.pid}-${Date.now()}`);
+  const provider: CodexProviderConfig = {
+    adapter: "chatgpt-web",
+    baseUrl: `browser://page-capacity-inline-${Date.now()}`,
+    chatgptWeb: {
+      brokerSocketPath: socketPath,
+      localToolsEnabled: false,
+      solAvailable: true,
+      proAvailable: true,
+      experimentalBiggerContext: false,
+      maxMessageChars: 20_000,
+    } as CodexProviderConfig["chatgptWeb"],
+  };
+  const worker = ChatGptBrowserWorker.forProvider(provider);
+  const originalRun = worker.run.bind(worker);
+  (worker as unknown as { run: (turn: BrowserTurn) => Promise<string> }).run = async turn => {
+    const prepared = await turn.prepare();
+    try {
+      expect(prepared.multipart).toBeUndefined();
+      const answer = "inline capacity accepted";
+      turn.onTextDelta(answer);
+      return answer;
+    } finally {
+      prepared.release();
+    }
+  };
+  try {
+    const events: AdapterEvent[] = [];
+    await createChatGptWebAdapter(provider).runTurn!(
+      rawWireRequest(environmentXml),
+      { headers: new Headers() },
+      event => events.push(event),
+    );
+    expect(events.at(-1)).toMatchObject({ type: "done" });
+  } finally {
+    (worker as unknown as { run: (turn: BrowserTurn) => Promise<string> }).run = originalRun;
+    await TurnBroker.forSocket(socketPath).close();
+  }
+});
+
+test("browser page capacity uses multipart even when Bigger Context is disabled", async () => {
+  const socketPath = brokerTestEndpoint(`cgw-page-capacity-multipart-${process.pid}-${Date.now()}`);
+  const provider: CodexProviderConfig = {
+    adapter: "chatgpt-web",
+    baseUrl: `browser://page-capacity-multipart-${Date.now()}`,
+    chatgptWeb: {
+      brokerSocketPath: socketPath,
+      localToolsEnabled: false,
+      solAvailable: true,
+      proAvailable: true,
+      experimentalBiggerContext: false,
+      maxMessageChars: 9_000,
+    } as CodexProviderConfig["chatgptWeb"],
+  };
+  const worker = ChatGptBrowserWorker.forProvider(provider);
+  const originalRun = worker.run.bind(worker);
+  (worker as unknown as { run: (turn: BrowserTurn) => Promise<string> }).run = async turn => {
+    const prepared = await turn.prepare();
+    try {
+      expect(prepared.multipart).toBeDefined();
+      const answer = "multipart capacity accepted";
+      turn.onTextDelta(answer);
+      return answer;
+    } finally {
+      prepared.release();
+    }
+  };
+  try {
+    const request = rawWireRequest(environmentXml);
+    request.context.messages = Array.from({ length: 12 }, (_, index) => ({
+      role: "user" as const,
+      content: `capacity-message-${index}-${"x".repeat(850)}`,
+      timestamp: index + 1,
+    }));
+    const events: AdapterEvent[] = [];
+    await createChatGptWebAdapter(provider).runTurn!(
+      request,
+      { headers: new Headers() },
+      event => events.push(event),
+    );
+    expect(events.at(-1)).toMatchObject({ type: "done" });
+  } finally {
+    (worker as unknown as { run: (turn: BrowserTurn) => Promise<string> }).run = originalRun;
+    await TurnBroker.forSocket(socketPath).close();
+  }
+});
+
+test("browser page capacity fails before send when even multipart cannot fit", async () => {
+  const socketPath = brokerTestEndpoint(`cgw-page-capacity-error-${process.pid}-${Date.now()}`);
+  const provider: CodexProviderConfig = {
+    adapter: "chatgpt-web",
+    baseUrl: `browser://page-capacity-error-${Date.now()}`,
+    chatgptWeb: {
+      brokerSocketPath: socketPath,
+      localToolsEnabled: false,
+      solAvailable: true,
+      proAvailable: true,
+      experimentalBiggerContext: false,
+      maxMessageChars: 5_000,
+    } as CodexProviderConfig["chatgptWeb"],
+  };
+  const worker = ChatGptBrowserWorker.forProvider(provider);
+  const originalRun = worker.run.bind(worker);
+  let browserPrepared = false;
+  (worker as unknown as { run: (turn: BrowserTurn) => Promise<string> }).run = async turn => {
+    await turn.prepare();
+    browserPrepared = true;
+    return "unexpected";
+  };
+  try {
+    const request = rawWireRequest(environmentXml);
+    request.context.messages = [{
+      role: "user",
+      content: `one-atomic-message-${"z".repeat(18_000)}`,
+      timestamp: 1,
+    }];
+    const events: AdapterEvent[] = [];
+    await createChatGptWebAdapter(provider).runTurn!(
+      request,
+      { headers: new Headers() },
+      event => events.push(event),
+    );
+    expect(events.at(-1)).toMatchObject({
+      type: "error",
+      status: 413,
+      code: "browser_message_too_large",
+      retryable: false,
+    });
+    expect((events.at(-1) as Extract<AdapterEvent, { type: "error" }>).message)
+      .toMatch(/\d{1,3},\d{3}.*5,000|5,000.*\d{1,3},\d{3}/);
+    expect(browserPrepared).toBeFalse();
+  } finally {
+    (worker as unknown as { run: (turn: BrowserTurn) => Promise<string> }).run = originalRun;
+    await TurnBroker.forSocket(socketPath).close();
+  }
+});
+
 function canonicalJson(value: unknown): string {
   if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
   if (value && typeof value === "object") {

--- a/tests/runtime-layout.test.ts
+++ b/tests/runtime-layout.test.ts
@@ -264,11 +264,13 @@ test("launcher browser ownership is explicit in provider configuration", () => {
   config.browserHost = "launcher";
   config.browserHostDescriptorPath = "/Users/example/.codex-chatgpt-web/runtime/launcher-browser.json";
   config.stallTimeoutSec = 900;
+  config.chatGptWebMaxMessageChars = 76_543;
   expect(providerConfig(config).chatgptWeb).toMatchObject({
     browserHost: "launcher",
     browserHostDescriptorPath: config.browserHostDescriptorPath,
     solAvailable: true,
     stallTimeoutSec: 900,
+    maxMessageChars: 76_543,
   });
 });
 

--- a/tests/zero-risk-prompt-contract.test.ts
+++ b/tests/zero-risk-prompt-contract.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import { compileChatGptWebPromptWithinPageCapacity } from "../src/adapters/chatgpt-web/capacity";
 import { compileChatGptWebPrompt } from "../src/adapters/chatgpt-web/prompt";
 import {
   activeCompactionToolResultInstruction,
@@ -65,6 +66,21 @@ test("Zero Risk prompt fails closed without Full harness or an exact manual bind
     manualControl: true,
     experimentalMultipartParts: 2,
   })).toThrow("does not support rolling or multipart browser transport");
+});
+
+test("Zero Risk reports page capacity explicitly instead of attempting multipart transport", () => {
+  const oversized = request();
+  oversized.context.messages = [{
+    role: "user",
+    content: `manual-capacity-${"x".repeat(12_000)}`,
+    timestamp: 1,
+  }];
+  expect(() => compileChatGptWebPromptWithinPageCapacity(
+    oversized,
+    capabilities,
+    requestId,
+    { manualControl: true, maxMessageChars: 5_000 },
+  )).toThrow(/Zero Risk cannot split.*5,000|5,000.*Zero Risk cannot split/);
 });
 
 test("active Zero Risk compaction returns its checkpoint through the bound completion control", () => {


### PR DESCRIPTION
ChatGPT browser page capacity is a per-message constraint, separate from the model context window. A turn can fit the model window but still freeze/fail when one browser message is too large.

This adds a pre-send capacity guard: keep inline transport when it fits, automatically use the existing 2/3-part transport when a normal Automatic turn exceeds the page limit, and fail explicitly with `browser_message_too_large` when no allowed transport fits. Manual/Zero Risk and Luna remain fail-closed instead of silently changing their transport contract.

While rebasing this onto current `main`, I fixed one compatibility regression in the original change: `experimentalBiggerContext=true` must still run through the existing Bigger Context policy, including Luna's explicit rejection, even when the inline message is below the page limit.

Validation:
- focused capacity + preparation regression run: 4 pass, 0 fail.
- `bun x tsc --noEmit` passes.
- `git diff --check` passes.
- A whole-file `chatgpt-web-harness.test.ts` run was started but did not exit on this Windows machine after the broker/named-pipe portion; I stopped it and am not counting it as a pass.
