### PR TITLE
fix: a visible stop button disproves "Stopped thinking"

### DIFF
--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -1507,11 +1507,23 @@ export function chatGptExternalProgressSuppressesDomHealth(
     && age < CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS;
 }
 
+/**
+ * How long a still-generating ChatGPT may hold the turn without any proven progress.
+ *
+ * A visible stop button is the renderer describing itself, so it is weaker evidence than a
+ * completed tool call and cannot be trusted without end. This mirrors
+ * {@link CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS}, which exists because a call that never
+ * returns would otherwise hold a turn open forever; a stop button that never clears does the same.
+ * Past this bound the DOM decides again, so a wedged tab fails instead of hanging.
+ */
+export const CHATGPT_STOPPED_THINKING_RUNNING_CEILING_MS = 10 * 60_000;
+
 export class ChatGptStoppedThinkingTracker {
   private visibleSince?: number;
+  private suppressedSince?: number;
 
   /**
-   * Forgets an in-progress "Stopped thinking" window.
+   * Forgets an in-progress "Stopped thinking" window and the suppression holding it open.
    *
    * Suppressing only the throw let the window keep accruing while a tool call was outstanding, so
    * the first observation after progress ended cancelled the turn instantly. Proven activity must
@@ -1519,12 +1531,31 @@ export class ChatGptStoppedThinkingTracker {
    */
   clear(): void {
     this.visibleSince = undefined;
+    this.suppressedSince = undefined;
   }
 
-  constructor(private readonly graceMs = CHATGPT_STOPPED_THINKING_GRACE_MS) {
+  constructor(
+    private readonly graceMs = CHATGPT_STOPPED_THINKING_GRACE_MS,
+    private readonly runningCeilingMs = CHATGPT_STOPPED_THINKING_RUNNING_CEILING_MS,
+  ) {
     if (!Number.isFinite(graceMs) || graceMs < 0) {
       throw new Error("ChatGPT Stopped thinking grace must be a non-negative finite number");
     }
+    if (!Number.isFinite(runningCeilingMs) || runningCeilingMs < 0) {
+      throw new Error("ChatGPT Stopped thinking running ceiling must be a non-negative finite number");
+    }
+  }
+
+  /**
+   * Hold the window open on unproven liveness, and report when that has gone on too long.
+   *
+   * Returns true once the claim has stood for the ceiling without one piece of proven progress to
+   * refresh it, at which point the caller may act on the label after all.
+   */
+  suppress(now = Date.now()): boolean {
+    this.visibleSince = undefined;
+    this.suppressedSince ??= now;
+    return now - this.suppressedSince >= this.runningCeilingMs;
   }
 
   update(visible: boolean, now = Date.now()): boolean {
@@ -1535,6 +1566,41 @@ export class ChatGptStoppedThinkingTracker {
     this.visibleSince ??= now;
     return now - this.visibleSince >= this.graceMs;
   }
+}
+
+/**
+ * Decide whether a visible "Stopped thinking" label may end the turn.
+ *
+ * The error this guards asserts that ChatGPT stopped producing the turn. Proven MCP activity
+ * disproves that outright and forgets the window, so the first observation after a tool call ends
+ * cannot cancel instantly. Both loops used to reach this decision before they had read the stop
+ * button and never consulted it, so a model pausing longer than the progress grace between tool
+ * calls was cancelled while it was still generating.
+ *
+ * A visible stop button is weaker evidence: the renderer describing itself, which is exactly what
+ * a wedged tab gets wrong. It therefore suspends the window under a ceiling rather than clearing
+ * it. Nothing else would end such a turn - every other DOM-health verdict requires `!running`, no
+ * absolute deadline is set by default, and the bridge's stall budget is a silence timer that this
+ * adapter refreshes with its own heartbeat - so this ceiling is the only bound that exists.
+ *
+ * `running` is undefined when the stop button could not be read. A failed read is not evidence
+ * that ChatGPT stopped, so it suspends too; only a confirmed absence lets the window run.
+ */
+export function chatGptStoppedThinkingEndsTurn(
+  tracker: ChatGptStoppedThinkingTracker,
+  state: {
+    stoppedThinkingVisible: boolean;
+    externalProgressLive: boolean;
+    running: boolean | undefined;
+  },
+  now = Date.now(),
+): boolean {
+  if (state.externalProgressLive) {
+    tracker.clear();
+    return false;
+  }
+  if (state.running !== false) return tracker.suppress(now) && state.stoppedThinkingVisible;
+  return tracker.update(state.stoppedThinkingVisible, now);
 }
 
 export interface ChatGptVisibleTraceBlock {
@@ -3372,8 +3438,13 @@ export class ChatGptBrowserWorker {
         Date.now(),
       );
       const externalToolCallsInFlight = chatGptExternalToolCallsAreInFlight(externalProgressSnapshot);
-      if (externalProgressLive) stoppedThinkingTracker.clear();
-      else if (stoppedThinkingTracker.update(snapshot.stoppedThinkingVisible)) {
+      const running = await page.locator(CHATGPT_STOP_BUTTON_SELECTOR).last().isVisible()
+        .catch((): boolean | undefined => undefined);
+      if (chatGptStoppedThinkingEndsTurn(stoppedThinkingTracker, {
+        stoppedThinkingVisible: snapshot.stoppedThinkingVisible,
+        externalProgressLive,
+        running,
+      })) {
         throw chatGptStoppedThinkingError();
       }
       if (!snapshot.responsePresent && externalProgressLive) {
@@ -3383,10 +3454,9 @@ export class ChatGptBrowserWorker {
         await new Promise(resolveSleep => setTimeout(resolveSleep, 250));
         continue;
       }
-      const running = await page.locator(CHATGPT_STOP_BUTTON_SELECTOR).last().isVisible().catch(() => false);
       const domError = domHealthTracker.update({
         responsePresent: snapshot.responsePresent,
-        running,
+        running: running === true,
         currentText: snapshot.visibleText,
         completionActionVisible: snapshot.completionActionVisible,
         externalProgressLive,
@@ -3394,7 +3464,7 @@ export class ChatGptBrowserWorker {
       if (domError) throw new Error(domError);
       if (completionTracker.update({
         responsePresent: snapshot.responsePresent,
-        running,
+        running: running === true,
         currentText: snapshot.visibleText,
         currentHtml: snapshot.fullHtml,
         completionActionVisible: snapshot.completionActionVisible,
@@ -4743,10 +4813,13 @@ export class ChatGptBrowserWorker {
           Date.now(),
         );
         const externalToolCallsInFlight = chatGptExternalToolCallsAreInFlight(externalProgressSnapshot);
-        // A stale "Stopped thinking" label is not terminal while the model is still driving tool
-        // calls, and the window must be forgotten rather than merely ignored.
-        if (externalProgressLive) stoppedThinkingTracker.clear();
-        else if (stoppedThinkingTracker.update(snapshot.stoppedThinkingVisible)) {
+        const stop = page.locator(CHATGPT_STOP_BUTTON_SELECTOR).last();
+        const running = await stop.isVisible().catch((): boolean | undefined => undefined);
+        if (chatGptStoppedThinkingEndsTurn(stoppedThinkingTracker, {
+          stoppedThinkingVisible: snapshot.stoppedThinkingVisible,
+          externalProgressLive,
+          running,
+        })) {
           throw chatGptStoppedThinkingError();
         }
         if (!snapshot.responsePresent && externalProgressLive) {
@@ -4757,8 +4830,6 @@ export class ChatGptBrowserWorker {
           await new Promise(resolveSleep => setTimeout(resolveSleep, 250));
           continue;
         }
-        const stop = page.locator(CHATGPT_STOP_BUTTON_SELECTOR).last();
-        const running = await stop.isVisible().catch(() => false);
         if (running) sawRunning = true;
         if (snapshot.responsePresent) {
           if (!capturedResponse) {
@@ -4779,7 +4850,7 @@ export class ChatGptBrowserWorker {
           if (textDelta) emitMarkdownDelta(textDelta);
           const domError = domHealthTracker.update({
             responsePresent: snapshot.responsePresent,
-            running,
+            running: running === true,
             currentText: snapshot.visibleText,
             completionActionVisible: snapshot.completionActionVisible,
             externalProgressLive,
@@ -4787,7 +4858,7 @@ export class ChatGptBrowserWorker {
           if (domError) throw new Error(domError);
           const completionReady = completionTracker.update({
             responsePresent: snapshot.responsePresent,
-            running,
+            running: running === true,
             currentText: snapshot.visibleText,
             currentHtml: snapshot.fullHtml,
             completionActionVisible: snapshot.completionActionVisible,
@@ -4857,7 +4928,7 @@ export class ChatGptBrowserWorker {
         } else {
           const domError = domHealthTracker.update({
             responsePresent: false,
-            running,
+            running: running === true,
             currentText: "",
             completionActionVisible: false,
             externalProgressLive,

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Page } from "playwright-core";
-import { CHATGPT_BROWSER_OBSERVATION_PROBE_TIMEOUT_MS, CHATGPT_COMPLETION_SETTLE_MS, CHATGPT_EXTERNAL_PROGRESS_CLOCK_SKEW_MS, CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS, ChatGptCompletionTracker, chatGptExternalProgressSuppressesDomHealth, CHATGPT_RESPONSE_DOM_GRACE_MS, MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS, CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_COMPOSER_SELECT_ALL_KEY, CHATGPT_STOPPED_THINKING_GRACE_MS, ChatGptBrowserObservationTimeoutError, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_PAGE_REBINDS, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, assertChatGptWebMultipartInputWithinLimits, browserDiagnosticCheckpoint, chatGptConnectorAttachmentMode, chatGptNewTurnIdentity, chatGptReboundTurnIdentity, chatGptSubmissionEvidence, connectAfterClosingBrowserConnection, dismissChatGptTemporaryChatOnboarding, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, resolveChatGptWebMultipartStagingMode, sanitizeChatGptBrowserDiagnosticState, setChatGptThinkMode, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert, withChatGptBrowserObservationTimeout, CHATGPT_MULTIPART_RESPONSE_DOM_GRACE_MS, browserStageTimeouts, ChatGptSuspensionClock, remainingStageBudgetMs } from "../src/adapters/chatgpt-web/browser-worker";
+import { CHATGPT_BROWSER_OBSERVATION_PROBE_TIMEOUT_MS, CHATGPT_COMPLETION_SETTLE_MS, CHATGPT_EXTERNAL_PROGRESS_CLOCK_SKEW_MS, CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS, ChatGptCompletionTracker, chatGptExternalProgressSuppressesDomHealth, CHATGPT_RESPONSE_DOM_GRACE_MS, MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS, CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_COMPOSER_SELECT_ALL_KEY, CHATGPT_STOPPED_THINKING_GRACE_MS, CHATGPT_STOPPED_THINKING_RUNNING_CEILING_MS, chatGptStoppedThinkingEndsTurn, ChatGptBrowserObservationTimeoutError, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_PAGE_REBINDS, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, assertChatGptWebMultipartInputWithinLimits, browserDiagnosticCheckpoint, chatGptConnectorAttachmentMode, chatGptNewTurnIdentity, chatGptReboundTurnIdentity, chatGptSubmissionEvidence, connectAfterClosingBrowserConnection, dismissChatGptTemporaryChatOnboarding, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, resolveChatGptWebMultipartStagingMode, sanitizeChatGptBrowserDiagnosticState, setChatGptThinkMode, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert, withChatGptBrowserObservationTimeout, CHATGPT_MULTIPART_RESPONSE_DOM_GRACE_MS, browserStageTimeouts, ChatGptSuspensionClock, remainingStageBudgetMs } from "../src/adapters/chatgpt-web/browser-worker";
 import { ensureChatGptPersonalizedConnectorAccess } from "../src/adapters/chatgpt-web/browser-worker";
 import { chatGptStoppedThinkingError } from "../src/adapters/chatgpt-web/adapter-error";
 import { CHATGPT_WEB_MODEL_ID } from "../src/adapters/chatgpt-web/model";
@@ -3236,9 +3236,14 @@ test("the launcher helper transport carries MCP progress into the out-of-process
 
 test("turn cancellation heuristics defer to proven MCP progress in both wait loops", () => {
   const worker = readFileSync("src/adapters/chatgpt-web/browser-worker.ts", "utf8");
-  // A stale "Stopped thinking" label must not cancel a turn that is still driving tool calls, and
-  // the multipart staging loop must not be the one place that skips the liveness guard.
-  expect((worker.match(/stoppedThinkingTracker\.clear\(\)/g) ?? []).length).toBe(2);
+  // A stale "Stopped thinking" label must not cancel a turn that is still driving tool calls or is
+  // still visibly generating, and the multipart staging loop must not be the one place that skips
+  // the liveness guard. Both loops route that decision through the one shared helper, which is the
+  // only thing that clears or suspends the window, so neither loop may clear it directly.
+  // This is a source grep and cannot prove that either loop passes the freshly read stop button
+  // rather than a constant; the helper's own behaviour is covered by the unit tests above.
+  expect((worker.match(/chatGptStoppedThinkingEndsTurn\(stoppedThinkingTracker, \{/g) ?? []).length).toBe(2);
+  expect((worker.match(/stoppedThinkingTracker\.clear\(\)/g) ?? []).length).toBe(0);
   expect((worker.match(/domHealthTracker\.clearMissingResponse\(\)/g) ?? []).length).toBe(2);
 });
 
@@ -3372,6 +3377,152 @@ test("the daemon prefers the browser helper that shipped beside its own entrypoi
   expect(helper).toContain("discarded an invalid MCP progress frame");
 });
 
+
+test("the production 65s cancellation is replayed and gone, at the real constants", () => {
+  // The turn this fixes: last MCP tool result at t=0, ChatGPT still generating with a stale
+  // "Stopped thinking" label and no further tool calls. Production cancelled it at 65.5s. This
+  // drives the real gate at the loop's real 250ms cadence rather than asserting on constants.
+  const replay = (
+    decide: (
+      tracker: ChatGptStoppedThinkingTracker,
+      state: { stoppedThinkingVisible: boolean; externalProgressLive: boolean; running: boolean | undefined },
+      now: number,
+    ) => boolean,
+    running: boolean | undefined,
+    untilMs: number,
+  ): number | undefined => {
+    const tracker = new ChatGptStoppedThinkingTracker();
+    for (let now = 0; now <= untilMs; now += 250) {
+      const externalProgressLive = chatGptExternalProgressSuppressesDomHealth(
+        { revision: 1, lastToolBatchRevision: 1, activeToolCalls: 0, lastProgressAt: 0 },
+        now,
+      );
+      if (decide(tracker, { stoppedThinkingVisible: true, externalProgressLive, running }, now)) return now;
+    }
+    return undefined;
+  };
+
+  // The v5.0.4 decision verbatim: the stop button existed in the loop but was read afterwards.
+  const preFix = (
+    tracker: ChatGptStoppedThinkingTracker,
+    state: { stoppedThinkingVisible: boolean; externalProgressLive: boolean; running: boolean | undefined },
+    now: number,
+  ): boolean => {
+    if (state.externalProgressLive) {
+      tracker.clear();
+      return false;
+    }
+    return tracker.update(state.stoppedThinkingVisible, now);
+  };
+
+  // What shipped in v5.0.4: cancelled while ChatGPT was still generating.
+  expect(replay(preFix, true, 20 * 60_000)).toBe(
+    CHATGPT_RESPONSE_DOM_GRACE_MS + CHATGPT_STOPPED_THINKING_GRACE_MS,
+  );
+  expect(replay(preFix, true, 20 * 60_000)).toBe(65_000);
+
+  // The same turn now survives the window that killed it, and keeps surviving.
+  expect(replay(chatGptStoppedThinkingEndsTurn, true, 65_000)).toBeUndefined();
+  expect(replay(chatGptStoppedThinkingEndsTurn, true, 9 * 60_000)).toBeUndefined();
+
+  // A wedged tab still dies. Suspension starts when proven progress goes stale at the 60s grace,
+  // not at turn start, so the total bound is that grace plus the ceiling.
+  expect(replay(chatGptStoppedThinkingEndsTurn, true, 30 * 60_000)).toBe(
+    CHATGPT_RESPONSE_DOM_GRACE_MS + CHATGPT_STOPPED_THINKING_RUNNING_CEILING_MS,
+  );
+
+  // A ChatGPT that genuinely stopped is still cancelled on the original timeline.
+  expect(replay(chatGptStoppedThinkingEndsTurn, false, 20 * 60_000)).toBe(65_000);
+
+  // An unreadable stop button is suspended rather than read as stopped, under the same bound.
+  expect(replay(chatGptStoppedThinkingEndsTurn, undefined, 9 * 60_000)).toBeUndefined();
+  expect(replay(chatGptStoppedThinkingEndsTurn, undefined, 30 * 60_000)).toBe(
+    CHATGPT_RESPONSE_DOM_GRACE_MS + CHATGPT_STOPPED_THINKING_RUNNING_CEILING_MS,
+  );
+});
+
+test("a visible stop button suspends Stopped thinking instead of cancelling a live turn", () => {
+  const tracker = new ChatGptStoppedThinkingTracker(5_000, 600_000);
+  const decide = (
+    state: { stoppedThinkingVisible: boolean; externalProgressLive: boolean; running: boolean | undefined },
+    now: number,
+  ): boolean => chatGptStoppedThinkingEndsTurn(tracker, state, now);
+
+  // ChatGPT is between steps: the last tool result is older than the progress grace, so MCP no
+  // longer vouches for the turn, but its own stop button says the model has not stopped. This is
+  // the production timeline, which cancelled at 65s.
+  const between = { stoppedThinkingVisible: true, externalProgressLive: false, running: true };
+  expect(decide(between, 1_000)).toBeFalse();
+  expect(decide(between, 65_000)).toBeFalse();
+  expect(decide(between, 599_999)).toBeFalse();
+
+  // Suspension is not a licence to hang: unproven liveness expires a ceiling after it began,
+  // which is the first suspended observation at 1_000, not the turn's start.
+  expect(decide(between, 600_999)).toBeFalse();
+  expect(decide(between, 601_000)).toBeTrue();
+
+  // One completed tool call refreshes the claim, so a working turn never reaches the ceiling.
+  const working = { stoppedThinkingVisible: true, externalProgressLive: true, running: true };
+  expect(decide(working, 601_001)).toBeFalse();
+  expect(decide(between, 700_000)).toBeFalse();
+  expect(decide(between, 1_299_999)).toBeFalse();
+  expect(decide(between, 1_300_000)).toBeTrue();
+});
+
+test("the running ceiling is the only bound on a wedged tab, so it must be finite", () => {
+  // Every other DOM-health verdict requires !running, no absolute turn deadline is set by default,
+  // and the bridge's stall budget is a silence timer this adapter refreshes with its own heartbeat.
+  expect(Number.isFinite(CHATGPT_STOPPED_THINKING_RUNNING_CEILING_MS)).toBeTrue();
+  expect(CHATGPT_STOPPED_THINKING_RUNNING_CEILING_MS).toBeGreaterThan(CHATGPT_STOPPED_THINKING_GRACE_MS);
+  expect(CHATGPT_STOPPED_THINKING_RUNNING_CEILING_MS).toBe(600_000);
+
+  // A stop button stuck visible forever, with no proven progress, still ends the turn.
+  const wedged = new ChatGptStoppedThinkingTracker();
+  const stuck = { stoppedThinkingVisible: true, externalProgressLive: false, running: true };
+  expect(chatGptStoppedThinkingEndsTurn(wedged, stuck, 0)).toBeFalse();
+  expect(chatGptStoppedThinkingEndsTurn(wedged, stuck, CHATGPT_STOPPED_THINKING_RUNNING_CEILING_MS))
+    .toBeTrue();
+});
+
+test("an unreadable stop button never counts as evidence that ChatGPT stopped", () => {
+  // The read is wrapped in .catch(); a fault there used to read as "not running", which re-armed
+  // the guard exactly when the page handle was least trustworthy, such as during a rebind.
+  const tracker = new ChatGptStoppedThinkingTracker(5_000, 600_000);
+  const unreadable = {
+    stoppedThinkingVisible: true,
+    externalProgressLive: false,
+    running: undefined,
+  };
+  expect(chatGptStoppedThinkingEndsTurn(tracker, unreadable, 1_000)).toBeFalse();
+  expect(chatGptStoppedThinkingEndsTurn(tracker, unreadable, 30_000)).toBeFalse();
+
+  // It is suspension, not immunity: the same ceiling applies.
+  expect(chatGptStoppedThinkingEndsTurn(tracker, unreadable, 601_001)).toBeTrue();
+});
+
+test("Stopped thinking still cancels a turn ChatGPT has genuinely abandoned", () => {
+  const tracker = new ChatGptStoppedThinkingTracker(5_000);
+  const stopped = { stoppedThinkingVisible: true, externalProgressLive: false, running: false };
+  expect(chatGptStoppedThinkingEndsTurn(tracker, stopped, 1_000)).toBeFalse();
+  expect(chatGptStoppedThinkingEndsTurn(tracker, stopped, 5_999)).toBeFalse();
+  expect(chatGptStoppedThinkingEndsTurn(tracker, stopped, 6_000)).toBeTrue();
+
+  // Proven MCP activity keeps its existing veto even with no stop button on screen.
+  const working = { stoppedThinkingVisible: true, externalProgressLive: true, running: false };
+  expect(chatGptStoppedThinkingEndsTurn(new ChatGptStoppedThinkingTracker(5_000), working, 60_000))
+    .toBeFalse();
+
+  // A turn with no label is never cancelled by this guard, however long it runs.
+  const quiet = { stoppedThinkingVisible: false, externalProgressLive: false, running: false };
+  expect(chatGptStoppedThinkingEndsTurn(new ChatGptStoppedThinkingTracker(5_000), quiet, 600_000))
+    .toBeFalse();
+
+  // Nor is a suspended turn cancelled at the ceiling when the label is not actually up.
+  const ceilinged = new ChatGptStoppedThinkingTracker(5_000, 1_000);
+  const quietRunning = { stoppedThinkingVisible: false, externalProgressLive: false, running: true };
+  expect(chatGptStoppedThinkingEndsTurn(ceilinged, quietRunning, 0)).toBeFalse();
+  expect(chatGptStoppedThinkingEndsTurn(ceilinged, quietRunning, 5_000)).toBeFalse();
+});
 
 test("proven progress forgets a Stopped thinking window rather than merely ignoring it", () => {
   const tracker = new ChatGptStoppedThinkingTracker(5_000);


### PR DESCRIPTION
## The failure

A turn is cancelled while ChatGPT is still generating:

```
18:16:20.371  broker completed call_p7mXWBrgHCks pending=0   <- last tool result
              ... 65s of heartbeats, no tool calls ...
18:17:25.910  failed: ChatGPT remained in 'Stopped thinking' for 5 seconds
```

The turn had been running six minutes and was driving tool calls throughout. The launcher sampled
`running=true` at three points before the cancellation, and the model returned another tool call
after each one.

## Cause

Both wait loops reached this decision **before** they had read the stop button, and never consulted
it — even though every other DOM-health verdict in the same loops takes `running` as an input.

Once the last tool result aged past `CHATGPT_RESPONSE_DOM_GRACE_MS` (60s),
`chatGptExternalProgressSuppressesDomHealth` went false, the window stopped being cleared, and
`CHATGPT_STOPPED_THINKING_GRACE_MS` (5s) later the guard threw. 60 + 5 against an observed 65.5.

So a model that pauses longer than a minute between tool calls is cancelled while a stale label
says it stopped.

## The change

Read the stop button before deciding, through one shared helper rather than the identical copy each
loop carried.

Proven MCP activity and a visible stop button are deliberately **not** treated as the same evidence:

| evidence | strength | effect |
|---|---|---|
| completed tool call | proves work happened | forgets the window outright |
| visible stop button | the renderer describing itself, which is what a wedged tab gets wrong | *suspends* under a ceiling |

The ceiling is not belt-and-braces, it is the only bound that exists: every other
`ChatGptTurnDomHealthTracker` verdict requires `!running`, `turnTimeoutMs` is undefined unless a
caller sets it, the main response loop runs outside any stage timeout, and the bridge's stall budget
is a silence timer this adapter refreshes with its own 10s heartbeat. Suppressing the guard without
a ceiling would trade a 5s false cancellation for a turn that never ends.

A failed stop-button read now reads as `undefined` rather than `false`. The call is wrapped in
`.catch()`, and treating a fault as "not running" re-armed the guard precisely when the page handle
was least trustworthy, such as during a rebind.

## Tests

`tests/browser-worker-contract.test.ts` replays the production timeline against the real constants
at the loop's real 250ms cadence, driving the real gate rather than asserting on constants:

| scenario | v5.0.4 | with this change |
|---|---|---|
| still generating, 65s | **cancels at 65,000 ms** | survives |
| still generating, 9 min | cancels | survives |
| wedged tab, 30 min | cancels at 65,000 ms | cancels at 660,000 ms |
| ChatGPT genuinely stopped | cancels at 65,000 ms | unchanged |
| stop button unreadable | cancels | suspended, same bound |

Each test was verified to fail against the specific line it guards.

`bun x tsc --noEmit` clean. `tests/browser-worker-contract.test.ts` passes. The full suite has a
large pre-existing failure set on the `v5.0.4` tag in my Windows environment; I captured it before
and after and diffed — identical, no new failures. `bun run verify` fails for that same
pre-existing reason, so I did not use it as evidence.

## Note on an existing test

`turn cancellation heuristics defer to proven MCP progress in both wait loops` is a source grep. Its
counts are updated for the shared helper. It cannot prove either loop passes the freshly read stop
button rather than a constant — I confirmed that by sabotaging the main loop with `running: false`
and getting a clean run — so the helper's behaviour is covered by unit tests instead, and the
comment no longer claims otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
