### PR TITLE
fix: read ChatGPT's deferral notice before calling a turn stalled

### DIFF
--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -769,6 +769,61 @@ export async function throwIfChatGptTerminalErrorAlert(scope: ChatGptTextScope):
   );
 }
 
+/**
+ * ChatGPT's own notice that it has queued the request behind its normal latency.
+ *
+ * It renders outside the assistant turn, so the response-DOM snapshot never sees it: the turn just
+ * looks like a model that produced no text and exposed no completion action. Every stall verdict
+ * here means "ChatGPT stopped producing this turn", and this notice is ChatGPT stating the exact
+ * opposite, so it has to be read before any of them fire.
+ */
+const chatGptDeferredResponseNotice = (scope: ChatGptTextScope): Locator => scope
+  .getByText(/systems are thinking a bit more about this request/i)
+  .last();
+
+export async function chatGptDeferredResponseVisible(scope: ChatGptTextScope): Promise<boolean> {
+  return chatGptDeferredResponseNotice(scope).isVisible().catch(() => false);
+}
+
+export function chatGptDeferredResponseError(): ChatGptWebAdapterError {
+  return new ChatGptWebAdapterError(
+    "ChatGPT deferred this request (\"Our systems are thinking a bit more about this request before "
+    + "responding\") and never started answering. Retry, or pick a faster reasoning effort.",
+    { status: 504, errorType: "server_error", code: "chatgpt_response_deferred", retryable: true },
+  );
+}
+
+/** How long ChatGPT may claim it is still deliberating without producing anything. */
+export const CHATGPT_DEFERRED_RESPONSE_CEILING_MS = 10 * 60_000;
+
+/**
+ * Bound a deferral the same way liveness is bounded elsewhere: the notice keeps the turn alive,
+ * but it cannot keep it alive forever, and it is forgotten as soon as ChatGPT starts producing.
+ */
+export class ChatGptDeferredResponseTracker {
+  private since?: number;
+
+  constructor(private readonly ceilingMs = CHATGPT_DEFERRED_RESPONSE_CEILING_MS) {
+    if (!Number.isFinite(ceilingMs) || ceilingMs < 0) {
+      throw new Error("ChatGPT deferred response ceiling must be a non-negative finite number");
+    }
+  }
+
+  clear(): void {
+    this.since = undefined;
+  }
+
+  /** Record a deferred observation; true once it has outlived the ceiling. */
+  observe(now = Date.now()): boolean {
+    this.since ??= now;
+    return now - this.since >= this.ceilingMs;
+  }
+
+  get active(): boolean {
+    return this.since !== undefined;
+  }
+}
+
 export async function resolveChatGptToolConfirmation(
   page: Page,
   appName: string,
@@ -4707,6 +4762,8 @@ export class ChatGptBrowserWorker {
       };
       const domHealthTracker = new ChatGptTurnDomHealthTracker();
       const stoppedThinkingTracker = new ChatGptStoppedThinkingTracker();
+      const deferredResponseTracker = new ChatGptDeferredResponseTracker();
+      let announcedDeferral = false;
       const responseDomCache: ChatGptResponseDomCache = {};
       let consecutiveObservationRebinds = 0;
       let internalObservationFaults = 0;
@@ -4815,6 +4872,27 @@ export class ChatGptBrowserWorker {
         const externalToolCallsInFlight = chatGptExternalToolCallsAreInFlight(externalProgressSnapshot);
         const stop = page.locator(CHATGPT_STOP_BUTTON_SELECTOR).last();
         const running = await stop.isVisible().catch((): boolean | undefined => undefined);
+        // Only a turn that looks stalled is worth a DOM query for the notice, which keeps this off
+        // the hot path: a turn producing text or showing its completion action is never deferred.
+        if (!snapshot.completionActionVisible && snapshot.visibleText.length === 0
+          && await chatGptDeferredResponseVisible(page)) {
+          if (deferredResponseTracker.observe()) throw chatGptDeferredResponseError();
+          if (!announcedDeferral) {
+            announcedDeferral = true;
+            // Silence is the actual complaint here: without this the turn shows tool calls, then an
+            // error, and never says ChatGPT was the one waiting.
+            console.warn(`[chatgpt-web] browser turn ${turn.traceId} deferred by ChatGPT; still waiting`);
+            turn.onCommentary?.(
+              "ChatGPT queued this request behind its normal latency and has not started answering yet.",
+              false,
+            );
+          }
+          stoppedThinkingTracker.clear();
+          domHealthTracker.clearMissingResponse();
+          await new Promise(resolveSleep => setTimeout(resolveSleep, 250));
+          continue;
+        }
+        deferredResponseTracker.clear();
         if (chatGptStoppedThinkingEndsTurn(stoppedThinkingTracker, {
           stoppedThinkingVisible: snapshot.stoppedThinkingVisible,
           externalProgressLive,

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -1507,11 +1507,23 @@ export function chatGptExternalProgressSuppressesDomHealth(
     && age < CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS;
 }
 
+/**
+ * How long a still-generating ChatGPT may hold the turn without any proven progress.
+ *
+ * A visible stop button is the renderer describing itself, so it is weaker evidence than a
+ * completed tool call and cannot be trusted without end. This mirrors
+ * {@link CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS}, which exists because a call that never
+ * returns would otherwise hold a turn open forever; a stop button that never clears does the same.
+ * Past this bound the DOM decides again, so a wedged tab fails instead of hanging.
+ */
+export const CHATGPT_STOPPED_THINKING_RUNNING_CEILING_MS = 10 * 60_000;
+
 export class ChatGptStoppedThinkingTracker {
   private visibleSince?: number;
+  private suppressedSince?: number;
 
   /**
-   * Forgets an in-progress "Stopped thinking" window.
+   * Forgets an in-progress "Stopped thinking" window and the suppression holding it open.
    *
    * Suppressing only the throw let the window keep accruing while a tool call was outstanding, so
    * the first observation after progress ended cancelled the turn instantly. Proven activity must
@@ -1519,12 +1531,31 @@ export class ChatGptStoppedThinkingTracker {
    */
   clear(): void {
     this.visibleSince = undefined;
+    this.suppressedSince = undefined;
   }
 
-  constructor(private readonly graceMs = CHATGPT_STOPPED_THINKING_GRACE_MS) {
+  constructor(
+    private readonly graceMs = CHATGPT_STOPPED_THINKING_GRACE_MS,
+    private readonly runningCeilingMs = CHATGPT_STOPPED_THINKING_RUNNING_CEILING_MS,
+  ) {
     if (!Number.isFinite(graceMs) || graceMs < 0) {
       throw new Error("ChatGPT Stopped thinking grace must be a non-negative finite number");
     }
+    if (!Number.isFinite(runningCeilingMs) || runningCeilingMs < 0) {
+      throw new Error("ChatGPT Stopped thinking running ceiling must be a non-negative finite number");
+    }
+  }
+
+  /**
+   * Hold the window open on unproven liveness, and report when that has gone on too long.
+   *
+   * Returns true once the claim has stood for the ceiling without one piece of proven progress to
+   * refresh it, at which point the caller may act on the label after all.
+   */
+  suppress(now = Date.now()): boolean {
+    this.visibleSince = undefined;
+    this.suppressedSince ??= now;
+    return now - this.suppressedSince >= this.runningCeilingMs;
   }
 
   update(visible: boolean, now = Date.now()): boolean {
@@ -1535,6 +1566,41 @@ export class ChatGptStoppedThinkingTracker {
     this.visibleSince ??= now;
     return now - this.visibleSince >= this.graceMs;
   }
+}
+
+/**
+ * Decide whether a visible "Stopped thinking" label may end the turn.
+ *
+ * The error this guards asserts that ChatGPT stopped producing the turn. Proven MCP activity
+ * disproves that outright and forgets the window, so the first observation after a tool call ends
+ * cannot cancel instantly. Both loops used to reach this decision before they had read the stop
+ * button and never consulted it, so a model pausing longer than the progress grace between tool
+ * calls was cancelled while it was still generating.
+ *
+ * A visible stop button is weaker evidence: the renderer describing itself, which is exactly what
+ * a wedged tab gets wrong. It therefore suspends the window under a ceiling rather than clearing
+ * it. Nothing else would end such a turn - every other DOM-health verdict requires `!running`, no
+ * absolute deadline is set by default, and the bridge's stall budget is a silence timer that this
+ * adapter refreshes with its own heartbeat - so this ceiling is the only bound that exists.
+ *
+ * `running` is undefined when the stop button could not be read. A failed read is not evidence
+ * that ChatGPT stopped, so it suspends too; only a confirmed absence lets the window run.
+ */
+export function chatGptStoppedThinkingEndsTurn(
+  tracker: ChatGptStoppedThinkingTracker,
+  state: {
+    stoppedThinkingVisible: boolean;
+    externalProgressLive: boolean;
+    running: boolean | undefined;
+  },
+  now = Date.now(),
+): boolean {
+  if (state.externalProgressLive) {
+    tracker.clear();
+    return false;
+  }
+  if (state.running !== false) return tracker.suppress(now) && state.stoppedThinkingVisible;
+  return tracker.update(state.stoppedThinkingVisible, now);
 }
 
 export interface ChatGptVisibleTraceBlock {
@@ -3372,8 +3438,13 @@ export class ChatGptBrowserWorker {
         Date.now(),
       );
       const externalToolCallsInFlight = chatGptExternalToolCallsAreInFlight(externalProgressSnapshot);
-      if (externalProgressLive) stoppedThinkingTracker.clear();
-      else if (stoppedThinkingTracker.update(snapshot.stoppedThinkingVisible)) {
+      const running = await page.locator(CHATGPT_STOP_BUTTON_SELECTOR).last().isVisible()
+        .catch((): boolean | undefined => undefined);
+      if (chatGptStoppedThinkingEndsTurn(stoppedThinkingTracker, {
+        stoppedThinkingVisible: snapshot.stoppedThinkingVisible,
+        externalProgressLive,
+        running,
+      })) {
         throw chatGptStoppedThinkingError();
       }
       if (!snapshot.responsePresent && externalProgressLive) {
@@ -3383,10 +3454,9 @@ export class ChatGptBrowserWorker {
         await new Promise(resolveSleep => setTimeout(resolveSleep, 250));
         continue;
       }
-      const running = await page.locator(CHATGPT_STOP_BUTTON_SELECTOR).last().isVisible().catch(() => false);
       const domError = domHealthTracker.update({
         responsePresent: snapshot.responsePresent,
-        running,
+        running: running === true,
         currentText: snapshot.visibleText,
         completionActionVisible: snapshot.completionActionVisible,
         externalProgressLive,
@@ -3394,7 +3464,7 @@ export class ChatGptBrowserWorker {
       if (domError) throw new Error(domError);
       if (completionTracker.update({
         responsePresent: snapshot.responsePresent,
-        running,
+        running: running === true,
         currentText: snapshot.visibleText,
         currentHtml: snapshot.fullHtml,
         completionActionVisible: snapshot.completionActionVisible,
@@ -4743,10 +4813,13 @@ export class ChatGptBrowserWorker {
           Date.now(),
         );
         const externalToolCallsInFlight = chatGptExternalToolCallsAreInFlight(externalProgressSnapshot);
-        // A stale "Stopped thinking" label is not terminal while the model is still driving tool
-        // calls, and the window must be forgotten rather than merely ignored.
-        if (externalProgressLive) stoppedThinkingTracker.clear();
-        else if (stoppedThinkingTracker.update(snapshot.stoppedThinkingVisible)) {
+        const stop = page.locator(CHATGPT_STOP_BUTTON_SELECTOR).last();
+        const running = await stop.isVisible().catch((): boolean | undefined => undefined);
+        if (chatGptStoppedThinkingEndsTurn(stoppedThinkingTracker, {
+          stoppedThinkingVisible: snapshot.stoppedThinkingVisible,
+          externalProgressLive,
+          running,
+        })) {
           throw chatGptStoppedThinkingError();
         }
         if (!snapshot.responsePresent && externalProgressLive) {
@@ -4757,8 +4830,6 @@ export class ChatGptBrowserWorker {
           await new Promise(resolveSleep => setTimeout(resolveSleep, 250));
           continue;
         }
-        const stop = page.locator(CHATGPT_STOP_BUTTON_SELECTOR).last();
-        const running = await stop.isVisible().catch(() => false);
         if (running) sawRunning = true;
         if (snapshot.responsePresent) {
           if (!capturedResponse) {
@@ -4779,7 +4850,7 @@ export class ChatGptBrowserWorker {
           if (textDelta) emitMarkdownDelta(textDelta);
           const domError = domHealthTracker.update({
             responsePresent: snapshot.responsePresent,
-            running,
+            running: running === true,
             currentText: snapshot.visibleText,
             completionActionVisible: snapshot.completionActionVisible,
             externalProgressLive,
@@ -4787,7 +4858,7 @@ export class ChatGptBrowserWorker {
           if (domError) throw new Error(domError);
           const completionReady = completionTracker.update({
             responsePresent: snapshot.responsePresent,
-            running,
+            running: running === true,
             currentText: snapshot.visibleText,
             currentHtml: snapshot.fullHtml,
             completionActionVisible: snapshot.completionActionVisible,
@@ -4857,7 +4928,7 @@ export class ChatGptBrowserWorker {
         } else {
           const domError = domHealthTracker.update({
             responsePresent: false,
-            running,
+            running: running === true,
             currentText: "",
             completionActionVisible: false,
             externalProgressLive,

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Page } from "playwright-core";
-import { CHATGPT_BROWSER_OBSERVATION_PROBE_TIMEOUT_MS, CHATGPT_COMPLETION_SETTLE_MS, CHATGPT_EXTERNAL_PROGRESS_CLOCK_SKEW_MS, CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS, ChatGptCompletionTracker, chatGptExternalProgressSuppressesDomHealth, CHATGPT_RESPONSE_DOM_GRACE_MS, MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS, CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_COMPOSER_SELECT_ALL_KEY, CHATGPT_STOPPED_THINKING_GRACE_MS, ChatGptBrowserObservationTimeoutError, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_PAGE_REBINDS, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, assertChatGptWebMultipartInputWithinLimits, browserDiagnosticCheckpoint, chatGptConnectorAttachmentMode, chatGptNewTurnIdentity, chatGptReboundTurnIdentity, chatGptSubmissionEvidence, connectAfterClosingBrowserConnection, dismissChatGptTemporaryChatOnboarding, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, resolveChatGptWebMultipartStagingMode, sanitizeChatGptBrowserDiagnosticState, setChatGptThinkMode, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert, withChatGptBrowserObservationTimeout, CHATGPT_MULTIPART_RESPONSE_DOM_GRACE_MS, browserStageTimeouts, ChatGptSuspensionClock, remainingStageBudgetMs } from "../src/adapters/chatgpt-web/browser-worker";
+import { CHATGPT_BROWSER_OBSERVATION_PROBE_TIMEOUT_MS, CHATGPT_COMPLETION_SETTLE_MS, CHATGPT_EXTERNAL_PROGRESS_CLOCK_SKEW_MS, CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS, ChatGptCompletionTracker, chatGptExternalProgressSuppressesDomHealth, CHATGPT_RESPONSE_DOM_GRACE_MS, MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS, CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_COMPOSER_SELECT_ALL_KEY, CHATGPT_STOPPED_THINKING_GRACE_MS, CHATGPT_STOPPED_THINKING_RUNNING_CEILING_MS, chatGptStoppedThinkingEndsTurn, ChatGptBrowserObservationTimeoutError, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_PAGE_REBINDS, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, assertChatGptWebMultipartInputWithinLimits, browserDiagnosticCheckpoint, chatGptConnectorAttachmentMode, chatGptNewTurnIdentity, chatGptReboundTurnIdentity, chatGptSubmissionEvidence, connectAfterClosingBrowserConnection, dismissChatGptTemporaryChatOnboarding, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, resolveChatGptWebMultipartStagingMode, sanitizeChatGptBrowserDiagnosticState, setChatGptThinkMode, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert, withChatGptBrowserObservationTimeout, CHATGPT_MULTIPART_RESPONSE_DOM_GRACE_MS, browserStageTimeouts, ChatGptSuspensionClock, remainingStageBudgetMs } from "../src/adapters/chatgpt-web/browser-worker";
 import { ensureChatGptPersonalizedConnectorAccess } from "../src/adapters/chatgpt-web/browser-worker";
 import { chatGptStoppedThinkingError } from "../src/adapters/chatgpt-web/adapter-error";
 import { CHATGPT_WEB_MODEL_ID } from "../src/adapters/chatgpt-web/model";
@@ -3236,9 +3236,14 @@ test("the launcher helper transport carries MCP progress into the out-of-process
 
 test("turn cancellation heuristics defer to proven MCP progress in both wait loops", () => {
   const worker = readFileSync("src/adapters/chatgpt-web/browser-worker.ts", "utf8");
-  // A stale "Stopped thinking" label must not cancel a turn that is still driving tool calls, and
-  // the multipart staging loop must not be the one place that skips the liveness guard.
-  expect((worker.match(/stoppedThinkingTracker\.clear\(\)/g) ?? []).length).toBe(2);
+  // A stale "Stopped thinking" label must not cancel a turn that is still driving tool calls or is
+  // still visibly generating, and the multipart staging loop must not be the one place that skips
+  // the liveness guard. Both loops route that decision through the one shared helper, which is the
+  // only thing that clears or suspends the window, so neither loop may clear it directly.
+  // This is a source grep and cannot prove that either loop passes the freshly read stop button
+  // rather than a constant; the helper's own behaviour is covered by the unit tests above.
+  expect((worker.match(/chatGptStoppedThinkingEndsTurn\(stoppedThinkingTracker, \{/g) ?? []).length).toBe(2);
+  expect((worker.match(/stoppedThinkingTracker\.clear\(\)/g) ?? []).length).toBe(0);
   expect((worker.match(/domHealthTracker\.clearMissingResponse\(\)/g) ?? []).length).toBe(2);
 });
 
@@ -3372,6 +3377,152 @@ test("the daemon prefers the browser helper that shipped beside its own entrypoi
   expect(helper).toContain("discarded an invalid MCP progress frame");
 });
 
+
+test("the production 65s cancellation is replayed and gone, at the real constants", () => {
+  // The turn this fixes: last MCP tool result at t=0, ChatGPT still generating with a stale
+  // "Stopped thinking" label and no further tool calls. Production cancelled it at 65.5s. This
+  // drives the real gate at the loop's real 250ms cadence rather than asserting on constants.
+  const replay = (
+    decide: (
+      tracker: ChatGptStoppedThinkingTracker,
+      state: { stoppedThinkingVisible: boolean; externalProgressLive: boolean; running: boolean | undefined },
+      now: number,
+    ) => boolean,
+    running: boolean | undefined,
+    untilMs: number,
+  ): number | undefined => {
+    const tracker = new ChatGptStoppedThinkingTracker();
+    for (let now = 0; now <= untilMs; now += 250) {
+      const externalProgressLive = chatGptExternalProgressSuppressesDomHealth(
+        { revision: 1, lastToolBatchRevision: 1, activeToolCalls: 0, lastProgressAt: 0 },
+        now,
+      );
+      if (decide(tracker, { stoppedThinkingVisible: true, externalProgressLive, running }, now)) return now;
+    }
+    return undefined;
+  };
+
+  // The v5.0.4 decision verbatim: the stop button existed in the loop but was read afterwards.
+  const preFix = (
+    tracker: ChatGptStoppedThinkingTracker,
+    state: { stoppedThinkingVisible: boolean; externalProgressLive: boolean; running: boolean | undefined },
+    now: number,
+  ): boolean => {
+    if (state.externalProgressLive) {
+      tracker.clear();
+      return false;
+    }
+    return tracker.update(state.stoppedThinkingVisible, now);
+  };
+
+  // What shipped in v5.0.4: cancelled while ChatGPT was still generating.
+  expect(replay(preFix, true, 20 * 60_000)).toBe(
+    CHATGPT_RESPONSE_DOM_GRACE_MS + CHATGPT_STOPPED_THINKING_GRACE_MS,
+  );
+  expect(replay(preFix, true, 20 * 60_000)).toBe(65_000);
+
+  // The same turn now survives the window that killed it, and keeps surviving.
+  expect(replay(chatGptStoppedThinkingEndsTurn, true, 65_000)).toBeUndefined();
+  expect(replay(chatGptStoppedThinkingEndsTurn, true, 9 * 60_000)).toBeUndefined();
+
+  // A wedged tab still dies. Suspension starts when proven progress goes stale at the 60s grace,
+  // not at turn start, so the total bound is that grace plus the ceiling.
+  expect(replay(chatGptStoppedThinkingEndsTurn, true, 30 * 60_000)).toBe(
+    CHATGPT_RESPONSE_DOM_GRACE_MS + CHATGPT_STOPPED_THINKING_RUNNING_CEILING_MS,
+  );
+
+  // A ChatGPT that genuinely stopped is still cancelled on the original timeline.
+  expect(replay(chatGptStoppedThinkingEndsTurn, false, 20 * 60_000)).toBe(65_000);
+
+  // An unreadable stop button is suspended rather than read as stopped, under the same bound.
+  expect(replay(chatGptStoppedThinkingEndsTurn, undefined, 9 * 60_000)).toBeUndefined();
+  expect(replay(chatGptStoppedThinkingEndsTurn, undefined, 30 * 60_000)).toBe(
+    CHATGPT_RESPONSE_DOM_GRACE_MS + CHATGPT_STOPPED_THINKING_RUNNING_CEILING_MS,
+  );
+});
+
+test("a visible stop button suspends Stopped thinking instead of cancelling a live turn", () => {
+  const tracker = new ChatGptStoppedThinkingTracker(5_000, 600_000);
+  const decide = (
+    state: { stoppedThinkingVisible: boolean; externalProgressLive: boolean; running: boolean | undefined },
+    now: number,
+  ): boolean => chatGptStoppedThinkingEndsTurn(tracker, state, now);
+
+  // ChatGPT is between steps: the last tool result is older than the progress grace, so MCP no
+  // longer vouches for the turn, but its own stop button says the model has not stopped. This is
+  // the production timeline, which cancelled at 65s.
+  const between = { stoppedThinkingVisible: true, externalProgressLive: false, running: true };
+  expect(decide(between, 1_000)).toBeFalse();
+  expect(decide(between, 65_000)).toBeFalse();
+  expect(decide(between, 599_999)).toBeFalse();
+
+  // Suspension is not a licence to hang: unproven liveness expires a ceiling after it began,
+  // which is the first suspended observation at 1_000, not the turn's start.
+  expect(decide(between, 600_999)).toBeFalse();
+  expect(decide(between, 601_000)).toBeTrue();
+
+  // One completed tool call refreshes the claim, so a working turn never reaches the ceiling.
+  const working = { stoppedThinkingVisible: true, externalProgressLive: true, running: true };
+  expect(decide(working, 601_001)).toBeFalse();
+  expect(decide(between, 700_000)).toBeFalse();
+  expect(decide(between, 1_299_999)).toBeFalse();
+  expect(decide(between, 1_300_000)).toBeTrue();
+});
+
+test("the running ceiling is the only bound on a wedged tab, so it must be finite", () => {
+  // Every other DOM-health verdict requires !running, no absolute turn deadline is set by default,
+  // and the bridge's stall budget is a silence timer this adapter refreshes with its own heartbeat.
+  expect(Number.isFinite(CHATGPT_STOPPED_THINKING_RUNNING_CEILING_MS)).toBeTrue();
+  expect(CHATGPT_STOPPED_THINKING_RUNNING_CEILING_MS).toBeGreaterThan(CHATGPT_STOPPED_THINKING_GRACE_MS);
+  expect(CHATGPT_STOPPED_THINKING_RUNNING_CEILING_MS).toBe(600_000);
+
+  // A stop button stuck visible forever, with no proven progress, still ends the turn.
+  const wedged = new ChatGptStoppedThinkingTracker();
+  const stuck = { stoppedThinkingVisible: true, externalProgressLive: false, running: true };
+  expect(chatGptStoppedThinkingEndsTurn(wedged, stuck, 0)).toBeFalse();
+  expect(chatGptStoppedThinkingEndsTurn(wedged, stuck, CHATGPT_STOPPED_THINKING_RUNNING_CEILING_MS))
+    .toBeTrue();
+});
+
+test("an unreadable stop button never counts as evidence that ChatGPT stopped", () => {
+  // The read is wrapped in .catch(); a fault there used to read as "not running", which re-armed
+  // the guard exactly when the page handle was least trustworthy, such as during a rebind.
+  const tracker = new ChatGptStoppedThinkingTracker(5_000, 600_000);
+  const unreadable = {
+    stoppedThinkingVisible: true,
+    externalProgressLive: false,
+    running: undefined,
+  };
+  expect(chatGptStoppedThinkingEndsTurn(tracker, unreadable, 1_000)).toBeFalse();
+  expect(chatGptStoppedThinkingEndsTurn(tracker, unreadable, 30_000)).toBeFalse();
+
+  // It is suspension, not immunity: the same ceiling applies.
+  expect(chatGptStoppedThinkingEndsTurn(tracker, unreadable, 601_001)).toBeTrue();
+});
+
+test("Stopped thinking still cancels a turn ChatGPT has genuinely abandoned", () => {
+  const tracker = new ChatGptStoppedThinkingTracker(5_000);
+  const stopped = { stoppedThinkingVisible: true, externalProgressLive: false, running: false };
+  expect(chatGptStoppedThinkingEndsTurn(tracker, stopped, 1_000)).toBeFalse();
+  expect(chatGptStoppedThinkingEndsTurn(tracker, stopped, 5_999)).toBeFalse();
+  expect(chatGptStoppedThinkingEndsTurn(tracker, stopped, 6_000)).toBeTrue();
+
+  // Proven MCP activity keeps its existing veto even with no stop button on screen.
+  const working = { stoppedThinkingVisible: true, externalProgressLive: true, running: false };
+  expect(chatGptStoppedThinkingEndsTurn(new ChatGptStoppedThinkingTracker(5_000), working, 60_000))
+    .toBeFalse();
+
+  // A turn with no label is never cancelled by this guard, however long it runs.
+  const quiet = { stoppedThinkingVisible: false, externalProgressLive: false, running: false };
+  expect(chatGptStoppedThinkingEndsTurn(new ChatGptStoppedThinkingTracker(5_000), quiet, 600_000))
+    .toBeFalse();
+
+  // Nor is a suspended turn cancelled at the ceiling when the label is not actually up.
+  const ceilinged = new ChatGptStoppedThinkingTracker(5_000, 1_000);
+  const quietRunning = { stoppedThinkingVisible: false, externalProgressLive: false, running: true };
+  expect(chatGptStoppedThinkingEndsTurn(ceilinged, quietRunning, 0)).toBeFalse();
+  expect(chatGptStoppedThinkingEndsTurn(ceilinged, quietRunning, 5_000)).toBeFalse();
+});
 
 test("proven progress forgets a Stopped thinking window rather than merely ignoring it", () => {
   const tracker = new ChatGptStoppedThinkingTracker(5_000);

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Page } from "playwright-core";
-import { CHATGPT_BROWSER_OBSERVATION_PROBE_TIMEOUT_MS, CHATGPT_COMPLETION_SETTLE_MS, CHATGPT_EXTERNAL_PROGRESS_CLOCK_SKEW_MS, CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS, ChatGptCompletionTracker, chatGptExternalProgressSuppressesDomHealth, CHATGPT_RESPONSE_DOM_GRACE_MS, MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS, CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_COMPOSER_SELECT_ALL_KEY, CHATGPT_STOPPED_THINKING_GRACE_MS, CHATGPT_STOPPED_THINKING_RUNNING_CEILING_MS, chatGptStoppedThinkingEndsTurn, ChatGptBrowserObservationTimeoutError, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_PAGE_REBINDS, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, assertChatGptWebMultipartInputWithinLimits, browserDiagnosticCheckpoint, chatGptConnectorAttachmentMode, chatGptNewTurnIdentity, chatGptReboundTurnIdentity, chatGptSubmissionEvidence, connectAfterClosingBrowserConnection, dismissChatGptTemporaryChatOnboarding, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, resolveChatGptWebMultipartStagingMode, sanitizeChatGptBrowserDiagnosticState, setChatGptThinkMode, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert, withChatGptBrowserObservationTimeout, CHATGPT_MULTIPART_RESPONSE_DOM_GRACE_MS, browserStageTimeouts, ChatGptSuspensionClock, remainingStageBudgetMs } from "../src/adapters/chatgpt-web/browser-worker";
+import { CHATGPT_BROWSER_OBSERVATION_PROBE_TIMEOUT_MS, CHATGPT_COMPLETION_SETTLE_MS, CHATGPT_EXTERNAL_PROGRESS_CLOCK_SKEW_MS, CHATGPT_EXTERNAL_PROGRESS_STALL_CEILING_MS, ChatGptCompletionTracker, chatGptExternalProgressSuppressesDomHealth, CHATGPT_RESPONSE_DOM_GRACE_MS, MAX_CHATGPT_INTERNAL_OBSERVATION_FAULTS, CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_COMPOSER_SELECT_ALL_KEY, CHATGPT_STOPPED_THINKING_GRACE_MS, CHATGPT_STOPPED_THINKING_RUNNING_CEILING_MS, CHATGPT_DEFERRED_RESPONSE_CEILING_MS, ChatGptDeferredResponseTracker, chatGptDeferredResponseError, chatGptStoppedThinkingEndsTurn, ChatGptBrowserObservationTimeoutError, ChatGptBrowserWorker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_PAGE_REBINDS, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, assertChatGptWebMultipartInputWithinLimits, browserDiagnosticCheckpoint, chatGptConnectorAttachmentMode, chatGptNewTurnIdentity, chatGptReboundTurnIdentity, chatGptSubmissionEvidence, connectAfterClosingBrowserConnection, dismissChatGptTemporaryChatOnboarding, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, resolveChatGptWebMultipartStagingMode, sanitizeChatGptBrowserDiagnosticState, setChatGptThinkMode, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert, withChatGptBrowserObservationTimeout, CHATGPT_MULTIPART_RESPONSE_DOM_GRACE_MS, browserStageTimeouts, ChatGptSuspensionClock, remainingStageBudgetMs } from "../src/adapters/chatgpt-web/browser-worker";
 import { ensureChatGptPersonalizedConnectorAccess } from "../src/adapters/chatgpt-web/browser-worker";
 import { chatGptStoppedThinkingError } from "../src/adapters/chatgpt-web/adapter-error";
 import { CHATGPT_WEB_MODEL_ID } from "../src/adapters/chatgpt-web/model";
@@ -3238,13 +3238,16 @@ test("turn cancellation heuristics defer to proven MCP progress in both wait loo
   const worker = readFileSync("src/adapters/chatgpt-web/browser-worker.ts", "utf8");
   // A stale "Stopped thinking" label must not cancel a turn that is still driving tool calls or is
   // still visibly generating, and the multipart staging loop must not be the one place that skips
-  // the liveness guard. Both loops route that decision through the one shared helper, which is the
-  // only thing that clears or suspends the window, so neither loop may clear it directly.
+  // the liveness guard. Both loops route that cancellation decision through the one shared helper.
+  // Exactly one direct clear is allowed: the main loop's deferral path, where ChatGPT has said in
+  // plain language that it is still working, which is proof of life rather than a verdict.
   // This is a source grep and cannot prove that either loop passes the freshly read stop button
   // rather than a constant; the helper's own behaviour is covered by the unit tests above.
   expect((worker.match(/chatGptStoppedThinkingEndsTurn\(stoppedThinkingTracker, \{/g) ?? []).length).toBe(2);
-  expect((worker.match(/stoppedThinkingTracker\.clear\(\)/g) ?? []).length).toBe(0);
-  expect((worker.match(/domHealthTracker\.clearMissingResponse\(\)/g) ?? []).length).toBe(2);
+  expect((worker.match(/stoppedThinkingTracker\.clear\(\)/g) ?? []).length).toBe(1);
+  // Three clears: proven MCP progress in each loop, plus the main loop's deferral path, where
+  // ChatGPT has explicitly said it is still working on a turn that otherwise looks abandoned.
+  expect((worker.match(/domHealthTracker\.clearMissingResponse\(\)/g) ?? []).length).toBe(3);
 });
 
 test("proven MCP progress vetoes every terminal DOM conclusion, not just a missing response", () => {
@@ -3377,6 +3380,56 @@ test("the daemon prefers the browser helper that shipped beside its own entrypoi
   expect(helper).toContain("discarded an invalid MCP progress frame");
 });
 
+
+test("a deferred ChatGPT keeps its turn alive, is announced, and is still bounded", () => {
+  // ChatGPT renders "Our systems are thinking a bit more about this request before responding"
+  // outside the assistant turn, so the response snapshot sees no text and no completion action --
+  // indistinguishable, to every stall verdict here, from a model that gave up. It is the opposite.
+  const tracker = new ChatGptDeferredResponseTracker(600_000);
+  expect(tracker.active).toBeFalse();
+
+  expect(tracker.observe(1_000)).toBeFalse();
+  expect(tracker.active).toBeTrue();
+  expect(tracker.observe(300_000)).toBeFalse();
+  expect(tracker.observe(600_999)).toBeFalse();
+
+  // A deferral cannot hold a turn open forever any more than a stuck stop button can.
+  expect(tracker.observe(601_000)).toBeTrue();
+
+  // Once ChatGPT starts producing, the deferral is forgotten rather than merely paused.
+  tracker.clear();
+  expect(tracker.active).toBeFalse();
+  expect(tracker.observe(700_000)).toBeFalse();
+  expect(tracker.observe(1_299_999)).toBeFalse();
+  expect(tracker.observe(1_300_000)).toBeTrue();
+});
+
+test("the deferral ceiling is finite and its error says what ChatGPT actually did", () => {
+  expect(Number.isFinite(CHATGPT_DEFERRED_RESPONSE_CEILING_MS)).toBeTrue();
+  expect(CHATGPT_DEFERRED_RESPONSE_CEILING_MS).toBe(600_000);
+  expect(() => new ChatGptDeferredResponseTracker(Number.POSITIVE_INFINITY)).toThrow();
+  expect(() => new ChatGptDeferredResponseTracker(-1)).toThrow();
+
+  const error = chatGptDeferredResponseError();
+  expect(error).toMatchObject({ status: 504, code: "chatgpt_response_deferred", retryable: true });
+  // The old failure blamed the DOM for a condition ChatGPT had stated in plain language.
+  expect(error.message).toContain("deferred this request");
+  expect(error.message).not.toContain("DOM may have changed");
+});
+
+test("the deferral probe runs only on a turn that already looks stalled", () => {
+  // Normalised: the checkout's line endings are a git setting, not a property of this contract.
+  const worker = readFileSync("src/adapters/chatgpt-web/browser-worker.ts", "utf8")
+    .split(String.fromCharCode(13)).join("");
+  // The page is large; querying it every 250ms would be a real cost. The guard conditions must
+  // short-circuit before the DOM query, and the query must precede every stall verdict.
+  expect(worker).toContain("!snapshot.completionActionVisible && snapshot.visibleText.length === 0\n"
+    + "          && await chatGptDeferredResponseVisible(page)");
+  const probe = worker.indexOf("await chatGptDeferredResponseVisible(page)");
+  const stoppedThinking = worker.indexOf("throw chatGptStoppedThinkingError();", probe);
+  expect(probe).toBeGreaterThan(0);
+  expect(stoppedThinking).toBeGreaterThan(probe);
+});
 
 test("the production 65s cancellation is replayed and gone, at the real constants", () => {
   // The turn this fixes: last MCP tool result at t=0, ChatGPT still generating with a stale


### PR DESCRIPTION
> Stacked on #395 — the first commit here is that PR's. Review or merge #395 first; the second
> commit is this change.

## The failure

A turn does 28 tool calls over 28 minutes, produces **no assistant message at all**, and ends with:

```
ChatGPT stopped generating but did not expose its completed-turn action; the ChatGPT DOM may have changed
```

Codex surfaces that as `stream disconnected before completion: ChatGPT stopped responding after the
task started`, discards the turn, and the user is left with collapsed tool cards and an error box —
never a reply.

## Cause

The DOM did not change. `button[data-testid="copy-turn-action-button"]` is intact; I probed a live
page and it appears exactly as expected on a healthy turn.

What is missing is any handling of ChatGPT's own deferral notice:

> Our systems are thinking a bit more about this request before responding. You can retry with a
> faster model for a quicker response, though it may be less capable of handling complex requests.

```
$ grep -ril "thinking a bit more" src/     ->  (no matches)
$ grep -ril "retry with a faster model" src/  ->  (no matches)
```

The adapter knows about the rate-limit dialog and `Something went wrong`, but not this. The notice
renders **outside** the assistant turn, so the response-DOM snapshot never sees it — the diagnostics
from a failing turn show a response element of only 12–26 characters. To every stall verdict in the
loop the turn is indistinguishable from a model that gave up, which is the exact opposite of what
ChatGPT is saying.

## The change

Read the notice before any stall verdict fires. While it shows, forget the stall windows, and say so
once through commentary so the wait is visible rather than silent. Past
`CHATGPT_DEFERRED_RESPONSE_CEILING_MS` the turn fails with what ChatGPT actually did, not with a
guess about the DOM.

The probe is deliberately lazy — it only runs on a turn that already looks stalled
(`!completionActionVisible && visibleText.length === 0`). The page is large (I measured 817,935
characters of body text on a real failing turn), so querying it every 250ms would be a real cost. A
turn producing text or showing its completion action is never deferred, so it never pays for this.

## Tests

- The deferral is bounded, forgotten as soon as ChatGPT starts producing, and the ceiling is finite —
  the same shape as every other liveness signal here.
- The error names the real condition; it no longer blames the DOM.
- A source assertion pins the short-circuit ordering: the probe must precede the stall verdict, and
  must sit behind the cheap guard conditions.

`bun x tsc --noEmit` clean, `tests/browser-worker-contract.test.ts` passes, full-suite failure set
identical to the `v5.0.4` baseline in my environment.

## What this does not fix

I could not confirm the notice was on screen during the specific 28-minute failure that prompted
this — the diagnostics do not capture text outside the response element, which is precisely why the
condition was invisible. So this is a real unhandled state with a plausible link to that failure,
not a proven root cause for it, and I would rather say so than overclaim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
