### PR TITLE
fix(chatgpt-web): normalize Windows namespaced rollout paths; require exactly one native environment_context claim

### DIFF
--- a/src/adapters/chatgpt-web/codex-rollout-environment.ts
+++ b/src/adapters/chatgpt-web/codex-rollout-environment.ts
@@ -42,7 +42,13 @@ function record(value: unknown): Record<string, unknown> | undefined {
 
 function pathIdentity(value: string): string {
   const normalized = resolve(value);
-  return process.platform === "win32" ? normalized.toLowerCase() : normalized;
+  if (process.platform !== "win32") return normalized;
+  const comparable = normalized.startsWith("\\\\?\\UNC\\")
+    ? `\\\\${normalized.slice(8)}`
+    : normalized.startsWith("\\\\?\\")
+      ? normalized.slice(4)
+      : normalized;
+  return comparable.toLowerCase();
 }
 
 function contains(root: string, path: string): boolean {

--- a/src/adapters/chatgpt-web/environment.ts
+++ b/src/adapters/chatgpt-web/environment.ts
@@ -134,7 +134,7 @@ export function hasCurrentChatGptEnvironmentContext(parsed: CodexParsedRequest):
 
 function contextualUserMessage(value: Record<string, unknown>): boolean {
   const text = rawMessageText(value).trim();
-  return /^<environment_context>[\s\S]*<\/environment_context>$/.test(text)
+  return /<environment_context>[\s\S]*?<\/environment_context>/.test(text)
     || /^<subagent_notification>[\s\S]*<\/subagent_notification>$/.test(text)
     || isReadableCompactionSummaryText(text)
     || text === OPAQUE_COMPACTION_NOTE;
@@ -249,7 +249,7 @@ export function extractChatGptContinuationEnvironmentClaim(parsed: CodexParsedRe
     if (item?.type !== "message" || item.role !== "user" || itemTurnId(item) !== turnId
       || typeof item.id !== "string" || !item.id) return [];
     const text = rawMessageText(item).trim();
-    return /^<environment_context>[\s\S]*<\/environment_context>$/.test(text) ? [text] : [];
+    return text.match(/<environment_context>[\s\S]*?<\/environment_context>/g) ?? [];
   });
   if (updates.length !== 1) throw new Error("Compaction continuation requires one current native environment claim");
   return parseChatGptEnvironmentText(parsed, updates[0]!);

--- a/tests/environment.test.ts
+++ b/tests/environment.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { Database } from "bun:sqlite";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, resolve, toNamespacedPath } from "node:path";
 import { extractChatGptTurnEnvironment, extractChatGptTurnIdentity } from "../src/adapters/chatgpt-web/environment";
 import { rememberCompactionContinuation } from "../src/adapters/chatgpt-web/compaction-continuation";
 import { encodeCompactionSummary, SUMMARY_PREFIX } from "../src/responses/compaction";
@@ -798,6 +798,11 @@ describe("trusted Codex task environment continuity", () => {
     body.input.push(current, checkpoint);
     const store = new ChatGptThreadEnvironmentStore(undefined, Date.now, codexHome);
     expect(store.resolve(request).cwd).toBe(root);
+    current.content[0]!.text = `project context before\n${environmentXml}\nproject context after`;
+    expect(store.resolve(request).cwd).toBe(root);
+    current.content[0]!.text = `${environmentXml}\n${environmentXml}`;
+    expect(() => store.resolve(request)).toThrow("Compaction continuation requires one current native environment claim");
+    current.content[0]!.text = environmentXml;
     for (const text of [
       environmentXml.replaceAll(root, resolve(root, "another-workspace")),
       environmentXml.replace('<permission_profile type="disabled"><file_system type="unrestricted" /></permission_profile>',
@@ -881,6 +886,18 @@ describe("trusted Codex task environment continuity", () => {
     database.close();
     expect(() => new ChatGptThreadEnvironmentStore(undefined, Date.now, codexHome).resolve(request))
       .toThrow("does not authenticate");
+  });
+
+  test("root rollout lookup accepts a Windows namespaced path inside sessions", () => {
+    if (process.platform !== "win32") return;
+    const { codexHome, request, rolloutPath } = resumedRootFixture();
+    const databasePath = join(codexHome, "state_5.sqlite");
+    createRolloutState(databasePath, toNamespacedPath(rolloutPath));
+    const database = new Database(databasePath);
+    database.exec("DELETE FROM thread_spawn_edges");
+    database.query("UPDATE threads SET agent_path = NULL WHERE id = ?").run(rolloutThreadId);
+    database.close();
+    expect(new ChatGptThreadEnvironmentStore(undefined, Date.now, codexHome).resolve(request).cwd).toBe(root);
   });
 
   test("compaction authenticates the latest native turn as current or source, never an arbitrary ancestor", () => {


### PR DESCRIPTION
## Summary

Two Windows-only correctness fixes in the chatgpt-web adapter:

1. **Rollout path containment false-negative on Windows.** `pathIdentity()` lowercased the raw `resolve()`d path for comparison, but `fs.realpathSync` on Windows can return an extended-length (`\\?\C:\...`) or UNC (`\\?\UNC\server\share\...`) form. Comparing that verbatim against a normally-formed sessions root always failed containment, throwing `Codex rollout path escapes the sessions directory` for legitimate rollouts. Fix strips the `\\?\` / `\\?\UNC\` prefix before lowercasing; a path genuinely outside the sessions root is still rejected.
2. **Compaction continuation broke on an embedded or duplicated `<environment_context>` claim.** Both the "is this a native environment message" check and the continuation-claim extractor required the *entire* trimmed message to be exactly one `<environment_context>...</environment_context>` block (anchored `^...$`). A claim embedded in a larger message (e.g. with surrounding project context) was invisible to matching, and a message containing two concatenated claims collapsed to a single anchor-mismatch instead of the intended "zero or multiple claims" rejection. Fix matches the tag as a substring/`g`-extracted list instead of the whole string; the "exactly one" invariant (`Compaction continuation requires one current native environment claim`) is unchanged and still enforced.

## Root cause

Both bugs share a root cause: environment-claim/path recognition assumed a single canonical string form (case, delimiter, prefix) that Windows APIs and larger message payloads don't guarantee. Neither fix loosens the actual security/authentication invariant (sessions-directory containment; exactly-one-claim authentication) — both only fix the string normalization/matching around it.

## Tests

`tests/environment.test.ts` adds:
- A `<environment_context>` claim embedded inside a larger message resolves normally.
- Two concatenated claims in one message throws `Compaction continuation requires one current native environment claim` (previously this exact input hit a different, ambiguous failure path).
- (Windows-only) A `\\?\`-namespaced rollout path resolves against the sessions root correctly.

`bun test tests/environment.test.ts`: 49/49 pass. `bun run typecheck`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
