### PR TITLE
Localize launcher connector diagnostics in Japanese

### DIFF
--- a/launcher/src/App.tsx
+++ b/launcher/src/App.tsx
@@ -9,7 +9,7 @@ import {
   type ReactNode,
 } from "react";
 import { createPortal } from "react-dom";
-import { copyFor, type Copy } from "./i18n";
+import { copyFor, localizeRuntimeMessage, type Copy } from "./i18n";
 import { Icon, type IconName } from "./icons";
 import type {
   BrowserInteractionMode,
@@ -681,6 +681,7 @@ function LauncherShell({
                 copy={copy}
                 devProfile={devProfile}
                 interactionMode={mcpTargetMode ?? snapshot.state.browserInteractionMode}
+                language={language}
                 onDone={() => {
                   setMcpTargetMode(null);
                   setSurface("browser");
@@ -1227,6 +1228,7 @@ function McpSurface({
   copy,
   devProfile,
   interactionMode,
+  language,
   onDone,
   operation,
   setError,
@@ -1236,6 +1238,7 @@ function McpSurface({
   copy: Copy;
   devProfile: boolean;
   interactionMode: BrowserInteractionMode;
+  language: Language;
   onDone: () => void;
   operation: OperationState | null;
   setError: (error: string | null) => void;
@@ -1480,7 +1483,7 @@ function McpSurface({
                     {copy.openConnectors}
                   </SecondaryButton>
                 </div>
-                {doctor ? <DoctorSummary copy={copy} report={doctor} /> : null}
+                {doctor ? <DoctorSummary copy={copy} language={language} report={doctor} /> : null}
               </div>
             ) : null}
           </motion.section>
@@ -1517,7 +1520,7 @@ function McpSurface({
             >
               {busy
                 ? operation?.name === "mcp-verification" && operation.status === "running"
-                  ? operation.message
+                  ? localizeRuntimeMessage(copy, operation.message, undefined, language)
                   : copy.running
                 : verified ? copy.done : copy.verifyRuntime}
             </PrimaryButton>
@@ -1748,7 +1751,7 @@ function SettingsSurface({
         </span>
         <Icon name="chevron" />
       </button> : null}
-      {doctor ? <DoctorSummary copy={copy} report={doctor} /> : null}
+      {doctor ? <DoctorSummary copy={copy} language={language} report={doctor} /> : null}
 
       <div className="about-row">
         <BrandMark small />
@@ -2128,7 +2131,7 @@ function FieldRow({ children, label }: { children: ReactNode; label: string }) {
   );
 }
 
-function DoctorSummary({ copy, report }: { copy: Copy; report: DoctorReport }) {
+function DoctorSummary({ copy, language, report }: { copy: Copy; language: Language; report: DoctorReport }) {
   const visibleChecks = report.ok
     ? report.checks.slice(-6)
     : report.checks.filter((check) => check.status !== "ok");
@@ -2142,7 +2145,9 @@ function DoctorSummary({ copy, report }: { copy: Copy; report: DoctorReport }) {
         {visibleChecks.map((check) => (
           <p key={check.id}>
             <StateDot state={check.status === "ok" ? "ready" : check.status === "warning" ? "busy" : "error"} />
-            <span>{check.message}</span>
+            <span>{check.status === "ok"
+              ? localizeRuntimeMessage(copy, check.message, check.id, language)
+              : check.message}</span>
           </p>
         ))}
       </div>

--- a/launcher/src/i18n.ts
+++ b/launcher/src/i18n.ts
@@ -137,6 +137,13 @@ const en = {
   openConnectors: "Open ChatGPT Plugins",
   connectorName: "Connector name",
   verifyRuntime: "Verify runtime",
+  checkingChatGptConnector: "Checking ChatGPT connector",
+  doctorProxyHealthy: "Responses proxy is healthy on {endpoint}",
+  doctorTunnelBinaryInstalled: "Pinned openai/tunnel-client binary is installed",
+  doctorTunnelKeyStored: "Tunnel runtime key is stored privately",
+  doctorTunnelRuntimeOwned: "Launcher owns the tunnel runtime",
+  doctorTunnelRuntimeReady: "Tunnel runtime reports healthy and ready",
+  doctorConnectorAvailable: "ChatGPT connector \"{name}\" is available",
   activityTitle: "Runtime activity",
   activitySubtitle: "Local diagnostics. Export a privacy-safe copy before sharing; raw logs stay on this device.",
   recentActivity: "Recent events",
@@ -322,6 +329,13 @@ const zh: Record<keyof typeof en, string> = {
   openConnectors: "打开 ChatGPT Plugins",
   connectorName: "连接器名称",
   verifyRuntime: "验证运行时",
+  checkingChatGptConnector: "Checking ChatGPT connector",
+  doctorProxyHealthy: "Responses proxy is healthy on {endpoint}",
+  doctorTunnelBinaryInstalled: "Pinned openai/tunnel-client binary is installed",
+  doctorTunnelKeyStored: "Tunnel runtime key is stored privately",
+  doctorTunnelRuntimeOwned: "Launcher owns the tunnel runtime",
+  doctorTunnelRuntimeReady: "Tunnel runtime reports healthy and ready",
+  doctorConnectorAvailable: "ChatGPT connector \"{name}\" is available",
   activityTitle: "运行时活动",
   activitySubtitle: "本地诊断。分享前请导出隐私安全副本；原始日志仅保留在此设备上。",
   recentActivity: "最近事件",
@@ -507,6 +521,13 @@ const ja: Record<keyof typeof en, string> = {
   openConnectors: "ChatGPT Plugins を開く",
   connectorName: "コネクタ名",
   verifyRuntime: "ランタイムを検証",
+  checkingChatGptConnector: "ChatGPT コネクタを確認中",
+  doctorProxyHealthy: "Responses プロキシは {endpoint} で正常に動作しています",
+  doctorTunnelBinaryInstalled: "固定バージョンの openai/tunnel-client バイナリがインストールされています",
+  doctorTunnelKeyStored: "トンネルのランタイムキーは安全に保存されています",
+  doctorTunnelRuntimeOwned: "ランチャーがトンネルランタイムを管理しています",
+  doctorTunnelRuntimeReady: "トンネルランタイムは正常で、使用可能です",
+  doctorConnectorAvailable: "ChatGPT コネクタ「{name}」を利用できます",
   activityTitle: "ランタイムアクティビティ",
   activitySubtitle: "ローカル診断です。共有する前にプライバシー保護済みのコピーをエクスポートしてください。生のログはこのデバイスにのみ保存されます。",
   recentActivity: "最近のイベント",
@@ -561,4 +582,45 @@ export function copyFor(language: Language): Copy {
   if (language === "zh-CN") return zh as Copy;
   if (language === "ja") return ja as Copy;
   return en;
+}
+
+export function localizeRuntimeMessage(
+  copy: Copy,
+  message: string,
+  checkId: string | undefined,
+  language: Language,
+): string {
+  if (language !== "ja") return message;
+  if (checkId === undefined && message === "Checking ChatGPT connector") return copy.checkingChatGptConnector;
+
+  if (checkId === "proxy") {
+    const match = /^Responses proxy is healthy on (127\.0\.0\.1:\d+)$/.exec(message);
+    if (match) return copy.doctorProxyHealthy.replace("{endpoint}", () => match[1]);
+  }
+  if (checkId === "tunnel-binary" && message === "Pinned openai/tunnel-client binary is installed") {
+    return copy.doctorTunnelBinaryInstalled;
+  }
+  if (checkId === "tunnel-key" && message === "Tunnel runtime key is stored privately") {
+    return copy.doctorTunnelKeyStored;
+  }
+  if (checkId === "tunnel-service" && message === "Launcher owns the tunnel runtime") {
+    return copy.doctorTunnelRuntimeOwned;
+  }
+  if (checkId === "tunnel-runtime" && message === "Tunnel runtime reports healthy and ready") {
+    return copy.doctorTunnelRuntimeReady;
+  }
+  if (checkId === "connector") {
+    const match = /^ChatGPT connector (".*") is available$/s.exec(message);
+    if (match) {
+      try {
+        const connectorName = JSON.parse(match[1]);
+        if (typeof connectorName === "string") {
+          return copy.doctorConnectorAvailable.replace("{name}", () => connectorName);
+        }
+      } catch {
+        return message;
+      }
+    }
+  }
+  return message;
 }

--- a/launcher/tests/localization.test.cjs
+++ b/launcher/tests/localization.test.cjs
@@ -2,6 +2,7 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const path = require("node:path");
+const ts = require("typescript");
 
 const launcherRoot = path.resolve(__dirname, "..");
 const repositoryRoot = path.resolve(launcherRoot, "..");
@@ -10,6 +11,20 @@ const read = (...parts) => fs.readFileSync(path.join(repositoryRoot, ...parts), 
 const englishReadme = read("README.md");
 const chineseReadme = read("README.zh-CN.md");
 const japaneseReadme = read("README.ja.md");
+const appSource = read("launcher", "src", "App.tsx");
+
+function loadI18nModule() {
+  const source = read("launcher", "src", "i18n.ts");
+  const output = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2023,
+    },
+  }).outputText;
+  const loaded = { exports: {} };
+  Function("module", "exports", "require", output)(loaded, loaded.exports, require);
+  return loaded.exports;
+}
 
 function commandFences(source) {
   return [...source.matchAll(/```(bash|powershell)\n([\s\S]*?)```/g)]
@@ -27,4 +42,112 @@ test("localized READMEs preserve every command block and link target from Englis
     assert.deepEqual(commandFences(source), commandFences(englishReadme));
     assert.deepEqual(linkTargets(source), linkTargets(englishReadme));
   }
+});
+
+test("Japanese launcher runtime messages localize connector verification and doctor success checks", () => {
+  const { copyFor, localizeRuntimeMessage } = loadI18nModule();
+  const copy = copyFor("ja");
+
+  assert.equal(localizeRuntimeMessage(copy, "Checking ChatGPT connector", undefined, "ja"), "ChatGPT コネクタを確認中");
+  assert.equal(
+    localizeRuntimeMessage(copy, "Responses proxy is healthy on 127.0.0.1:7841", "proxy", "ja"),
+    "Responses プロキシは 127.0.0.1:7841 で正常に動作しています",
+  );
+  assert.equal(
+    localizeRuntimeMessage(copy, "Pinned openai/tunnel-client binary is installed", "tunnel-binary", "ja"),
+    "固定バージョンの openai/tunnel-client バイナリがインストールされています",
+  );
+  assert.equal(
+    localizeRuntimeMessage(copy, "Tunnel runtime key is stored privately", "tunnel-key", "ja"),
+    "トンネルのランタイムキーは安全に保存されています",
+  );
+  assert.equal(
+    localizeRuntimeMessage(copy, "Launcher owns the tunnel runtime", "tunnel-service", "ja"),
+    "ランチャーがトンネルランタイムを管理しています",
+  );
+  assert.equal(
+    localizeRuntimeMessage(copy, "Tunnel runtime reports healthy and ready", "tunnel-runtime", "ja"),
+    "トンネルランタイムは正常で、使用可能です",
+  );
+  assert.equal(
+    localizeRuntimeMessage(copy, 'ChatGPT connector "Codex Native2" is available', "connector", "ja"),
+    "ChatGPT コネクタ「Codex Native2」を利用できます",
+  );
+});
+
+test("Japanese runtime localization preserves literal connector names and endpoints", () => {
+  const { copyFor, localizeRuntimeMessage } = loadI18nModule();
+  const copy = copyFor("ja");
+  const connectorNames = [
+    "Codex Native2",
+    "Native $&",
+    "Native $'",
+    "Native $`",
+    "Native $1",
+    'Native "quoted"',
+    "Native \\path",
+    "Native \u2028X",
+    "Native \u2029X",
+  ];
+
+  for (const connectorName of connectorNames) {
+    const message = `ChatGPT connector ${JSON.stringify(connectorName)} is available`;
+    assert.equal(
+      localizeRuntimeMessage(copy, message, "connector", "ja"),
+      `ChatGPT コネクタ「${connectorName}」を利用できます`,
+    );
+  }
+
+  assert.equal(
+    localizeRuntimeMessage(copy, "Responses proxy is healthy on 127.0.0.1:17841", "proxy", "ja"),
+    "Responses プロキシは 127.0.0.1:17841 で正常に動作しています",
+  );
+});
+
+test("runtime message localization preserves other languages and unknown backend messages", () => {
+  const { copyFor, localizeRuntimeMessage } = loadI18nModule();
+  const connectorNames = ["Codex Native2", "Native $&", "Native $'", "Native $`", 'Native "quoted"', "Native \\path"];
+
+  for (const language of ["en", "zh-CN"]) {
+    for (const connectorName of connectorNames) {
+      const connector = `ChatGPT connector ${JSON.stringify(connectorName)} is available`;
+      assert.equal(localizeRuntimeMessage(copyFor(language), connector, "connector", language), connector);
+    }
+    assert.equal(
+      localizeRuntimeMessage(copyFor(language), "Checking ChatGPT connector", undefined, language),
+      "Checking ChatGPT connector",
+    );
+  }
+  assert.equal(
+    localizeRuntimeMessage(copyFor("ja"), "Tunnel runtime is not ready", "tunnel-runtime", "ja"),
+    "Tunnel runtime is not ready",
+  );
+  assert.equal(
+    localizeRuntimeMessage(copyFor("ja"), "Unexpected connector diagnostic", "connector", "ja"),
+    "Unexpected connector diagnostic",
+  );
+  assert.equal(
+    localizeRuntimeMessage(copyFor("ja"), 'ChatGPT connector "unterminated is available', "connector", "ja"),
+    'ChatGPT connector "unterminated is available',
+  );
+  assert.equal(
+    localizeRuntimeMessage(copyFor("ja"), 'ChatGPT connector "Codex Native2" is available', "wrong-id", "ja"),
+    'ChatGPT connector "Codex Native2" is available',
+  );
+  assert.equal(
+    localizeRuntimeMessage(copyFor("ja"), "Checking ChatGPT connector", "unknown-check", "ja"),
+    "Checking ChatGPT connector",
+  );
+  assert.equal(
+    localizeRuntimeMessage(copyFor("ja"), 'ChatGPT connector "Codex Native2" is available (warning)', "connector", "ja"),
+    'ChatGPT connector "Codex Native2" is available (warning)',
+  );
+});
+
+test("launcher UI localizes MCP verification progress and doctor check messages", () => {
+  assert.match(appSource, /localizeRuntimeMessage\(copy, operation\.message, undefined, language\)/);
+  assert.match(
+    appSource,
+    /check\.status === "ok"\s*\?\s*localizeRuntimeMessage\(copy, check\.message, check\.id, language\)\s*:\s*check\.message/,
+  );
 });


### PR DESCRIPTION
## Summary

- Localize MCP connector verification progress and successful Doctor diagnostics when the launcher language is Japanese.
- Preserve dynamic values such as the Responses proxy endpoint and connector name literally, including replacement-token and Unicode line-separator edge cases.
- Keep English, Chinese, unknown backend messages, warning/error diagnostics, and backend/CLI output unchanged.

Replacement for #343, following the requirements in #358. Maintainer feedback on the coordination request is pending.

## Tests

- Bun 1.4.0 (the exact version pinned by the repository)
- `bun test launcher/tests/localization.test.cjs launcher/tests/renderer-wiring.test.cjs` — 24 passed
- `bun run typecheck` — passed
- `cd launcher && bun run build:renderer` — passed
- `git diff --check` — passed
- Fork CI for head `0d389e9`: [run](https://github.com/cXSHoz/codex-chatgpt-web/actions/runs/34183323095)
  - macOS 15, Ubuntu, and Windows: `bun run verify` passed
  - Ubuntu: `app:package` and `app:smoke` passed
  - Windows: `app:package` and `app:smoke` passed on rerun
- macOS: `verify` passed; packaging failed at `codesign` verification after code signing was skipped for the PR build. Packaging scripts are unchanged. Package smoke was not run.