### PR TITLE
fix: recognize Chinese temporary-chat personalization controls

### DIFF
--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -522,10 +522,10 @@ async function ensureChatGptPersonalizedConnectorAccessWithinDeadline(
   // The visible sheet can be aria-hidden during hydration. Include those controls in the role
   // query but still require visibility; never select a hidden duplicate or switch locator rules.
   const personalized = page
-    .getByRole("button", { name: "Personalized", exact: true, includeHidden: true })
+    .getByRole("button", { name: /^(?:Personalized|个性化)$/, exact: true, includeHidden: true })
     .filter({ visible: true });
   const unpersonalized = page
-    .getByRole("button", { name: "Unpersonalized", exact: true, includeHidden: true })
+    .getByRole("button", { name: /^(?:Unpersonalized|非个性化)$/, exact: true, includeHidden: true })
     .filter({ visible: true });
   let personalizedCount = await runChatGptPersonalizationStep(() => personalized.count(), deadline, abortSignal);
   let unpersonalizedCount = await runChatGptPersonalizationStep(() => unpersonalized.count(), deadline, abortSignal);
@@ -600,7 +600,7 @@ async function ensureChatGptPersonalizedConnectorAccessWithinDeadline(
     );
     const choice = menu
       .locator(CHATGPT_PERSONALIZATION_CHOICE_SELECTOR)
-      .filter({ hasText: /^Personalized/ });
+      .filter({ hasText: /^(?:Personalized|个性化)/ });
     if (await runChatGptPersonalizationStep(() => choice.count(), deadline, abortSignal) !== 1) {
       throw chatGptConnectorUnavailableError(
         "ChatGPT personalization menu did not expose one exact Personalized choice",

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -23,7 +23,9 @@ function personalizedTemporaryChatRole(
 ) {
   const locator = {
     filter: (_filter: { visible: boolean }) => ({
-      count: async () => options.name === "Personalized" ? 1 : 0,
+      count: async () => (typeof options.name === "string"
+        ? options.name === "Personalized"
+        : options.name.test("Personalized")) ? 1 : 0,
     }),
   };
   return locator;
@@ -313,8 +315,10 @@ test("a mutating stage timeout preserves a failed cleanup integrity error", asyn
     },
   };
   const page = {
-    getByRole: (_role: string, options: { name: string }) => (
-      options.name === "Personalized" ? personalized : unpersonalized
+    getByRole: (_role: string, options: { name: string | RegExp }) => (
+      (typeof options.name === "string"
+        ? options.name === "Personalized"
+        : options.name.test("Personalized")) ? personalized : unpersonalized
     ),
     locator: (selector: string) => selector === "body"
       ? { press: async () => { throw new Error("menu cleanup failed"); } }

--- a/tests/personalization-connector-preflight.test.ts
+++ b/tests/personalization-connector-preflight.test.ts
@@ -1,6 +1,15 @@
 import { expect, test } from "bun:test";
 import { ensureChatGptPersonalizedConnectorAccess } from "../src/adapters/chatgpt-web/browser-worker";
 
+function matchesName(name: string | RegExp, label: string): boolean {
+  return typeof name === "string" ? name === label : name.test(label);
+}
+
+const personalizationLabels = [
+  { personalized: "Personalized", unpersonalized: "Unpersonalized" },
+  { personalized: "个性化", unpersonalized: "非个性化" },
+];
+
 function visibleLocator(count: () => number, overrides: Record<string, unknown> = {}) {
   const locator = {
     filter: () => locator,
@@ -10,13 +19,13 @@ function visibleLocator(count: () => number, overrides: Record<string, unknown> 
   return locator;
 }
 
-for (const ariaHidden of [false, true]) test(`a visible Personalized control is a preflight no-op (aria-hidden=${ariaHidden})`, async () => {
+for (const labels of personalizationLabels) for (const ariaHidden of [false, true]) test(`a visible ${labels.personalized} control is a preflight no-op (aria-hidden=${ariaHidden})`, async () => {
   const diagnostics: string[] = [];
   const personalized = visibleLocator(() => 1);
   const unpersonalized = visibleLocator(() => 0);
   const page = {
-    getByRole: (_role: string, options: { name: string; includeHidden?: boolean }) => (
-      options.name === "Personalized" && (!ariaHidden || options.includeHidden) ? personalized : unpersonalized
+    getByRole: (_role: string, options: { name: string | RegExp; includeHidden?: boolean }) => (
+      matchesName(options.name, labels.personalized) && (!ariaHidden || options.includeHidden) ? personalized : unpersonalized
     ),
   } as any;
 
@@ -43,7 +52,7 @@ test("a missing personalization control fails closed before connector selection"
   expect(diagnostics).toEqual(["personalization-control-missing"]);
 });
 
-test("an Unpersonalized Temporary Chat is switched through its owned radio menu and re-proved", async () => {
+for (const labels of personalizationLabels) test(`an ${labels.unpersonalized} Temporary Chat is switched through its owned radio menu and re-proved`, async () => {
   let enabled = false;
   let menuOpen = false;
   const events: string[] = [];
@@ -85,16 +94,23 @@ test("an Unpersonalized Temporary Chat is switched through its owned radio menu 
       expect(selector).toBe('[role="menuitemradio"], [role="radio"]');
       return {
         filter: ({ hasText }: { hasText: RegExp }) => {
-          expect(hasText.test("PersonalizedThis chat can reference plugins")).toBeTrue();
+          expect(hasText.test(`${labels.personalized}This chat can reference plugins`)).toBeTrue();
+          expect(hasText.test(`${labels.unpersonalized}This chat ignores plugins`)).toBeFalse();
           return choice;
         },
       };
     },
   };
   const page = {
-    getByRole: (_role: string, options: { name: string }) => (
-      options.name === "Personalized" ? personalized : unpersonalized
-    ),
+    getByRole: (_role: string, options: { name: string | RegExp }) => {
+      if (matchesName(options.name, labels.personalized)) {
+        expect(matchesName(options.name, labels.unpersonalized)).toBeFalse();
+        expect(matchesName(options.name, `${labels.personalized} settings`)).toBeFalse();
+        return personalized;
+      }
+      if (matchesName(options.name, labels.unpersonalized)) return unpersonalized;
+      return visibleLocator(() => 0);
+    },
     locator: (selector: string) => {
       expect(selector).toBe('[id="personalization-menu"]');
       return menu;
@@ -544,8 +560,8 @@ test("the labeled Unpersonalized path never hides an unclosed menu", async () =>
     getAttribute: async () => "labeled-cleanup-menu",
   });
   const page = {
-    getByRole: (_role: string, options: { name: string }) => (
-      options.name === "Personalized" ? personalized : unpersonalized
+    getByRole: (_role: string, options: { name: string | RegExp }) => (
+      matchesName(options.name, "Personalized") ? personalized : unpersonalized
     ),
     locator: (selector: string) => {
       if (selector === "body") return {


### PR DESCRIPTION
## Summary

Recognize the observed Simplified Chinese Temporary Chat personalization labels in the existing labeled preflight path:

- `个性化` alongside `Personalized`
- `非个性化` alongside `Unpersonalized`
- the corresponding Personalized choice within the control's owned radio menu

Button patterns remain anchored; visibility, includeHidden hydration handling, menu ownership, state re-proof, deadline, abort and cleanup behavior remain unchanged. Unknown locales still use the existing fallback. This PR does not change proxies, tunnel startup, permissions or timeouts.

## Reproduction / cause

On a Chinese-language ChatGPT Temporary Chat, the visible control was `非个性化` and the page explicitly said plugins were unavailable in that state. Exact English-only locators missed both controls. Connector proof then found no menu, and the structural fallback exhausted the personalization deadline:

`ChatGPT personalization preflight exceeded its readiness deadline`

This is a bounded fix for the labels actually observed, not a general claim of support for every locale.

## Tests

- Parameterize the labeled no-op and owned-menu transition tests for English and Simplified Chinese, including aria-hidden hydration.
- Assert the Personalized selector cannot match Unpersonalized or a settings-suffixed label, and that the menu selector cannot select the opposite state.
- Update existing browser-worker contract mocks to support Playwright's `string | RegExp` name query.
- Red/green: the three new Chinese cases fail before the source change and pass after it.
- `bun test tests/personalization-connector-preflight.test.ts tests/browser-worker-contract.test.ts`: **141 passed, 0 failed**.
- TypeScript `tsc --noEmit` and `git diff --check`: passed.
- Full suite from a durable checkout: **680 passed, 1 skipped, 3 failed** (684 total). The three failures are Zero Risk compaction tests importing the Electron launcher: first Electron was absent from the root-only install; after installing launcher packages with binary download skipped, the same three tests stop at `Electron failed to install correctly`. A working Electron test runtime is still required; this is **not** a claim of a green full suite.
- An initial `/tmp` checkout triggered the repository's ephemeral-runtime-path guard on both the unchanged baseline and this branch. The durable-checkout result above supersedes that environment-invalid run.

## Installed integration evidence

The same three selector changes were applied to a real installed macOS 5.0.5 browser helper. Its normal verification flow automatically enabled personalization, opened the connector menu, selected the exact `Codex Native2` connector, cleared the verification selection, and emitted `connector.verified`. The launcher displayed healthy / connector available. Neither Codex nor the launcher was restarted for that selector verification.

Scope of that evidence: real browser preflight and connector selection passed. It was not an arbitrary shell-tool round trip or a full research task. The installed validation predates rebasing this source patch onto current main; main's newer includeHidden behavior is preserved here.
