### PR TITLE
fix: bound collaboration agent waits

### DIFF
--- a/src/adapters/chatgpt-web/mcp-server.ts
+++ b/src/adapters/chatgpt-web/mcp-server.ts
@@ -27,9 +27,10 @@ const BRIDGE_TOOL_NAMES = new Set([
   "codex_turn_complete",
 ]);
 
-const GATEWAY_AGENT_WAIT_TOOL_NAMES = new Set([
+const AGENT_WAIT_TOOL_WIRE_NAMES = new Set([
   "multi_agent_v1__wait_agent",
   "multi_agent_v2__wait_agent",
+  "collaboration__wait_agent",
 ]);
 
 const turnTokenSchema = z.string().min(20).max(256);
@@ -135,12 +136,11 @@ function safeVisibleTools(environment: ChatGptTurnEnvironment, contract: ChatGpt
 }
 
 function isAgentWaitTool(tool: CodexTool): boolean {
-  return tool.name === "wait_agent"
-    && (tool.namespace === "multi_agent_v1" || tool.namespace === "multi_agent_v2");
+  return AGENT_WAIT_TOOL_WIRE_NAMES.has(wireName(tool));
 }
 
 function isGatewayAgentWaitTool(name: string): boolean {
-  return GATEWAY_AGENT_WAIT_TOOL_NAMES.has(name);
+  return AGENT_WAIT_TOOL_WIRE_NAMES.has(name);
 }
 
 function browserToolDescription(tool: CodexTool): string {
@@ -161,6 +161,7 @@ function browserToolParameters(tool: CodexTool): Record<string, unknown> {
   const timeout = properties.timeout_ms && typeof properties.timeout_ms === "object" && !Array.isArray(properties.timeout_ms)
     ? properties.timeout_ms as Record<string, unknown>
     : {};
+  const { default: _timeoutDefault, ...transportSafeTimeout } = timeout;
   const required = Array.isArray(parameters.required)
     ? parameters.required.filter((value): value is string => typeof value === "string")
     : [];
@@ -169,7 +170,7 @@ function browserToolParameters(tool: CodexTool): Record<string, unknown> {
     properties: {
       ...properties,
       timeout_ms: {
-        ...timeout,
+        ...transportSafeTimeout,
         type: "number",
         const: CHATGPT_WEB_AGENT_WAIT_POLL_MS,
         minimum: CHATGPT_WEB_AGENT_WAIT_POLL_MS,
@@ -373,7 +374,7 @@ function transportBoundRawExecProgram(input: string, blockedExecName: string): s
     input,
     "})((() => {",
     "  const source = tools;",
-    `  const waitNames = new Set(${JSON.stringify([...GATEWAY_AGENT_WAIT_TOOL_NAMES])});`,
+    `  const waitNames = new Set(${JSON.stringify([...AGENT_WAIT_TOOL_WIRE_NAMES])});`,
     `  const blockedExecName = ${JSON.stringify(blockedExecName)};`,
     `  const pollMs = ${CHATGPT_WEB_AGENT_WAIT_POLL_MS};`,
     "  const registryNames = new Set(Reflect.ownKeys(source));",

--- a/tests/chatgpt-web-harness.test.ts
+++ b/tests/chatgpt-web-harness.test.ts
@@ -2560,6 +2560,20 @@ describe("ChatGPT outer-native harness v4", () => {
           additionalProperties: false,
         },
       },
+      {
+        name: "wait_agent",
+        namespace: "collaboration",
+        description: "Wait for agents to reach a final status.",
+        parameters: {
+          type: "object",
+          properties: {
+            targets: { type: "array", items: { type: "string" } },
+            timeout_ms: { type: "number", minimum: 10_000, maximum: 180_000, default: 180_000 },
+          },
+          required: ["targets"],
+          additionalProperties: false,
+        },
+      },
     ];
     const token = await broker.register(gatewayOnlyEnvironment, 60_000);
     const transport = new StdioClientTransport({
@@ -2762,6 +2776,46 @@ describe("ChatGPT outer-native harness v4", () => {
       });
       expect((await rejectedRawGateway).isError).toBe(true);
 
+      const rejectedRawCollaborationWait = call("codex_tool_call", {
+        turn_token: token,
+        wire_name: "exec",
+        input: "await tools.collaboration__wait_agent({ targets: ['agent_test'], timeout_ms: 180000 });",
+      });
+      const [rejectedRawCollaborationRequest] = await broker.nextToolBatch(token);
+      expect(rejectedRawCollaborationRequest).toMatchObject({ wireName: "exec", freeform: true });
+      const rejectedRawCollaborationCalls: GatewayProgramCall[] = [];
+      await expect(executeGatewayProgram(
+        rejectedRawCollaborationRequest!.input!,
+        ["collaboration__wait_agent"],
+        rejectedRawCollaborationCalls,
+      )).rejects.toThrow("requires timeout_ms=10000");
+      expect(rejectedRawCollaborationCalls).toEqual([]);
+      broker.completeTool(token, rejectedRawCollaborationRequest!.callId, {
+        content: [{ type: "text", text: guardedError }],
+        isError: true,
+      });
+      expect((await rejectedRawCollaborationWait).isError).toBe(true);
+
+      const rawCollaborationWait = call("codex_tool_call", {
+        turn_token: token,
+        wire_name: "exec",
+        input: "const value = await tools.collaboration__wait_agent({ targets: ['agent_test'], timeout_ms: 10000 }); text(value);",
+      });
+      const [rawCollaborationRequest] = await broker.nextToolBatch(token);
+      expect(rawCollaborationRequest).toMatchObject({ wireName: "exec", freeform: true });
+      const rawCollaborationCalls: GatewayProgramCall[] = [];
+      const rawCollaborationContent = await executeGatewayProgram(
+        rawCollaborationRequest!.input!,
+        ["collaboration__wait_agent"],
+        rawCollaborationCalls,
+      );
+      expect(rawCollaborationCalls).toEqual([{
+        name: "collaboration__wait_agent",
+        input: { targets: ["agent_test"], timeout_ms: 10_000 },
+      }]);
+      broker.completeTool(token, rawCollaborationRequest!.callId, { content: rawCollaborationContent });
+      expect((await rawCollaborationWait).isError).not.toBe(true);
+
       const rawWeb = call("codex_tool_call", {
         turn_token: token,
         wire_name: "exec",
@@ -2887,7 +2941,7 @@ describe("ChatGPT outer-native harness v4", () => {
       expect((await waitPromise).structuredContent).toEqual({ output: "completed" });
 
       const agentInventory = await inventoryThroughGateway(
-        "wait_agent",
+        "multi_agent_v1__wait_agent",
         true,
         ["multi_agent_v1__wait_agent"],
       );
@@ -2925,6 +2979,47 @@ describe("ChatGPT outer-native harness v4", () => {
       });
       broker.completeTool(token, agentWaitRequest!.callId, toolResult({ statuses: {} }));
       expect((await agentWait).structuredContent).toEqual({ statuses: {} });
+
+      const collaborationInventory = await inventoryThroughGateway(
+        "collaboration__wait_agent",
+        true,
+        ["collaboration__wait_agent"],
+      );
+      expect(collaborationInventory.structuredContent).toMatchObject({
+        total: 1,
+        tools: [{
+          wire_name: "collaboration__wait_agent",
+          description: expect.stringContaining("exactly 10 seconds"),
+          parameters: {
+            properties: {
+              timeout_ms: { const: 10_000, minimum: 10_000, maximum: 10_000 },
+            },
+            required: ["targets", "timeout_ms"],
+          },
+        }],
+      });
+      expect(JSON.stringify(collaborationInventory.structuredContent)).not.toContain('"default"');
+
+      const rejectedCollaborationWait = await call("codex_tool_call", {
+        turn_token: token,
+        wire_name: "collaboration__wait_agent",
+        arguments: { targets: ["agent_test"], timeout_ms: 180_000 },
+      });
+      expect(rejectedCollaborationWait.isError).toBe(true);
+      expect(JSON.stringify(rejectedCollaborationWait.content)).toContain("requires timeout_ms=10000");
+
+      const collaborationWait = call("codex_tool_call", {
+        turn_token: token,
+        wire_name: "collaboration__wait_agent",
+        arguments: { targets: ["agent_test"], timeout_ms: 10_000 },
+      });
+      const [collaborationWaitRequest] = await broker.nextToolBatch(token);
+      expect(collaborationWaitRequest).toMatchObject({
+        wireName: "collaboration__wait_agent",
+        arguments: { targets: ["agent_test"], timeout_ms: 10_000 },
+      });
+      broker.completeTool(token, collaborationWaitRequest!.callId, toolResult({ statuses: {} }));
+      expect((await collaborationWait).structuredContent).toEqual({ statuses: {} });
 
       const rejectedNestedLongWait = await call("codex_tool_call", {
         turn_token: token,


### PR DESCRIPTION
## What this changes

Adds collaboration__wait_agent to the existing 10 second wait guard used by the older multi-agent wait tools.

The same guard now applies to both direct calls and the raw exec gateway. It also drops any inherited timeout_ms default before exposing the schema, so the contract stays fixed at 10000 ms.

Related: #276

## Evidence

Added regression coverage for direct and raw calls. A 180000 ms wait is rejected before the outer tool runs, while a 10000 ms wait is forwarded. The exposed schema requires 10000 ms and has no default.

Focused harness test: 81 passed, 0 failed.

bun run verify passes.

Also tested with Codex 0.153.4 against the packaged 5.0.5 runtime built from this commit. A spawned collaboration child completed after repeated 10 second polls, and the parent could still run a tool afterward.

## Scope and invariants

- [x] I read and followed CONTRIBUTING.md.
- [x] This is a small, focused change with no unrelated cleanup or generated rewrite.
- [x] The change stays focused on ChatGPT web-backed Codex models; it does not add a generic provider or unrelated product surface.
- [x] Model, route, effort, connector, and capability selection remain explicit with no silent fallback or false-success path.
- [x] If this touches Full harness or MCP, every available Web effort retains the same turn-bound capability and Browser-only gains no broker or connector.
- [x] Terms and trademark claims remain factual; this change is not marketed as a quota or rate-limit bypass.

## Verification

- [x] I ran bun install --frozen-lockfile in the repository root and launcher/.
- [x] I ran bun run verify with the Bun version pinned by package.json.
- [x] I added or updated a focused regression test for behavior changes.
- [x] I manually tested the affected behavior.
- [x] If this changes local tools, MCP execution, or the outer Codex agent loop, I tested it through a real installed Codex integration; DEV mode alone is acceptable only when execution is not affected.
- [x] If this changes ChatGPT browser UI handling, I included observed DOM evidence and a reproducible fixture instead of broadening selectors speculatively.
- [x] If this changes the launcher, I preserved macOS, Windows, and Linux packaging and named the platform packages actually built below.
- [x] I did not commit browser state, credentials, Tunnel IDs, raw logs, generated artifacts, or private paths.
- [x] I did not include an unrelated dependency update, release artifact, or version change.

## Platform or account validation

macOS arm64
Plus
Full harness / MCP
Codex CLI 0.153.4
Packaged 5.0.5 runtime

Browser-only: not run
Windows: not run
Linux: not run
Other account tiers: not run
