### PR TITLE
docs(reporting): add Zero Risk mode and troubleshooting guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -68,7 +68,8 @@ body:
       label: Integration mode
       options:
         - Browser-only
-        - Full harness (MCP)
+        - Full harness (With Automation / MCP)
+        - Zero Risk (manual handoff)
         - Setup / sign-in (no model turn yet)
     validations:
       required: true
@@ -77,7 +78,7 @@ body:
     id: model
     attributes:
       label: Selected model
-      description: Use the exact Codex model-picker name, or write "not applicable" for setup failures.
+      description: Use the exact Codex model-picker name. For Zero Risk, also include the model and effort you manually selected in ChatGPT. Write "not applicable" for setup failures.
       placeholder: ChatGPT Web — High
     validations:
       required: true

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -96,7 +96,8 @@ Video walkthroughs:
 - [Create an OpenAI tunnel and API key](launcher/src/assets/mcp-create-tunnel.mp4)
 - [Connect the local harness and attach the ChatGPT connector](launcher/src/assets/mcp-connect-connector.mp4)
 
-Browser-only mode needs no connector. Full harness mode requires all of the following:
+Browser-only mode needs no connector. For Zero Risk, see the [manual handoff guidance](#zero-risk-manual-handoff-fails)
+below. Full harness (With Automation) mode requires all of the following:
 
 - a newly created connector named exactly **Codex Native2**;
 - **Developer Mode** enabled in ChatGPT;
@@ -123,6 +124,26 @@ approval review**, disable that optional Codex review setting and restart Codex.
 sandbox and explicit approvals still apply; this only prevents an unavailable native model from
 being inserted as an extra reviewer after the Web tool call already completed.
 
+## Zero Risk manual handoff fails
+
+Zero Risk uses a separate OpenAI tunnel and the **Codex Zero Risk** connector. **Codex Native2** is
+for Full harness (With Automation). Check that the connector you select in ChatGPT matches the mode.
+
+The launcher prepares and copies the prompt, but does not read or change the ChatGPT page or send
+the prompt for you. Select the ChatGPT model, effort, and **Codex Zero Risk** connector yourself,
+paste and send the prepared prompt, then confirm **Sent** in the launcher.
+
+When reporting a failure, include both the exact Codex model-picker entry and the model and effort
+you manually selected in ChatGPT. Identify where the handoff stopped:
+
+- preparing or copying the prompt in the launcher;
+- manually pasting and sending it in ChatGPT;
+- confirming **Sent** in the launcher; or
+- subsequent MCP tool execution or completion back in Codex.
+
+Include the complete error and a fresh **Activity → Export safe log** export. Describe the stage
+without pasting the prepared prompt, credentials, Tunnel IDs, or raw browser state.
+
 ## `Reconnecting`, `stream disconnected`, or `ChatGPT failed`
 
 These are result boundaries, not one diagnosis. The bridge uses them when it cannot prove a complete
@@ -135,8 +156,9 @@ its bounded MCP deadline.
 - Retry once in a fresh Codex task. State whether the fresh task works and whether the failure is
   consistent.
 - Run **Settings → Run doctor** and export a safe log immediately after the failure.
-- Include the exact model, Browser-only or Full harness mode, whether tools ran, and whether the
-  ChatGPT page showed a final answer.
+- Include the exact model, integration mode (Browser-only, Full harness, or Zero Risk), whether
+  tools ran, and whether the ChatGPT page showed a final answer. For Zero Risk, include the manually
+  selected ChatGPT model and effort and the handoff stage described above.
 
 Do not assume that a generic 502 means the Tunnel is broken. Since v4.0.7, a native tool that
 outlives its turn binding is reported explicitly as `codex_tool_timeout` and retired rather than
@@ -226,7 +248,9 @@ safe log**. A useful report contains:
 - Codex Desktop and/or CLI version;
 - OS and architecture;
 - ChatGPT account tier;
-- Browser-only or Full harness mode and the exact selected model;
+- integration mode: Browser-only, Full harness (With Automation), or Zero Risk (manual handoff);
+- the exact Codex model-picker entry; for Zero Risk, also the manually selected ChatGPT model and
+  effort, and the handoff stage that failed;
 - exact reproduction steps and complete final error;
 - whether it reproduces in a fresh Codex task; and
 - a safe log captured immediately after that reproduction.


### PR DESCRIPTION
﻿## What this changes

Zero Risk users currently have to choose an ambiguous integration mode in the bug-report form. Add a dedicated manual-handoff option, ask for both the Codex picker entry and the manually selected ChatGPT model/effort, and document which handoff stage failed.

Fixes #411.

## Evidence

- The required integration-mode dropdown now includes `Zero Risk (manual handoff)` and labels the automatic option `Full harness (With Automation / MCP)`.
- The troubleshooting guide distinguishes `Codex Zero Risk` from `Codex Native2` and covers prompt preparation/copying, manual submission, confirming **Sent**, and subsequent MCP execution/completion.
- Reviewed the instructions against the README and the existing launcher **Copy prompt** / **Sent** controls. Parsed the issue form as YAML and checked its required fields.

## Scope and invariants

- [x] Read `CONTRIBUTING.md`; this is a focused issue-form and documentation change.
- [x] Model, route, effort, connector, capability, and approval behavior are unchanged.
- [x] Existing privacy-safe reporting guidance is preserved.
- [x] No dependency, version, runtime, or generated-artifact changes.

## Verification

- [x] `bun install --frozen-lockfile` in the root and `launcher/`, using Bun 1.4.0.
- [x] Issue-form YAML validation and `git diff --check`.
- `bun run verify` was run and stopped at `bun audit`: the existing pinned `hono@4.12.34` reports three moderate advisories (GHSA-gqvv-2mrq-wpjv, GHSA-g6gw-c38x-mqfc, GHSA-crvj-82cr-hjcx). Dependency files are unchanged.

- [x] `bun run typecheck` and `bun run launcher:typecheck` passed.
- [x] `bun run launcher:test`: 294 passed, 2 skipped, 0 failed.
- `bun run test`: 552 passed, 142 failed. Observed failures include the runtime check requiring a durable Bun executable outside temporary directories, and a context-planning timeout. The local Bun executable was staged in a temporary directory; no runtime source was changed. The core suite is not green.

## Platform or account validation

Windows. Reviewed the document and form changes locally; GitHub's live issue-form rendering and account-bound execution were not run. No runtime behavior changes or new regression tests. Packaging and release smoke checks were not run.

