### PR TITLE
fix: expose read-only Codex task access

### DIFF
--- a/src/adapters/chatgpt-web/mcp-server.ts
+++ b/src/adapters/chatgpt-web/mcp-server.ts
@@ -22,6 +22,7 @@ const BRIDGE_TOOL_NAMES = new Set([
   "codex_write_stdin",
   "codex_apply_patch",
   "codex_view_image",
+  "codex_read_thread",
   "codex_tool_inventory",
   "codex_tool_call",
   "codex_turn_complete",
@@ -116,6 +117,10 @@ function wireName(tool: CodexTool): string {
 
 function exactTool(environment: ChatGptTurnEnvironment, name: string): CodexTool | undefined {
   return environment.tools.find(tool => !tool.namespace && tool.name === name);
+}
+
+function exactCodexAppTool(environment: ChatGptTurnEnvironment, name: string): CodexTool | undefined {
+  return environment.tools.find(tool => tool.namespace === "mcp__codex_app" && tool.name === name);
 }
 
 function gatewayToolNameIsValid(name: string): boolean {
@@ -741,6 +746,47 @@ export async function runChatGptMcpServer(options: {
         return tool
           ? invoke(claimed.bindingId, bound, tool, payload, extra.signal)
           : invokeNestedNative(claimed.bindingId, bound, "view_image", false, payload, extra.signal);
+      },
+    ),
+  );
+
+  server.registerTool(
+    "codex_read_thread",
+    {
+      title: "Read a referenced Codex task",
+      description: afterSafeStart(
+        contract,
+        "Invoke the outer Codex read_thread tool for a referenced task. This action is read-only and cannot continue, archive, or otherwise modify the task.",
+      ),
+      inputSchema: {
+        ...turnReferenceInput(contract),
+        threadId: z.string().min(1).max(256),
+        cursor: z.string().max(16_384).optional(),
+        hostId: z.string().max(256).optional(),
+        includeOutputs: z.boolean().optional(),
+        maxOutputCharsPerItem: z.number().int().min(1).max(1_000_000).optional(),
+        turnLimit: z.number().int().min(1).max(10).optional(),
+      },
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    },
+    async (input, extra) => withClaimedTurn(
+      "codex_read_thread",
+      turnReference(contract, input),
+      extra,
+      async claimed => {
+        const { threadId, cursor, hostId, includeOutputs, maxOutputCharsPerItem, turnLimit } = input;
+        const tool = exactCodexAppTool(claimed.environment, "read_thread");
+        if (!tool) throw new Error("The current outer Codex turn does not advertise read_thread");
+        return invoke(claimed.bindingId, claimed.environment, tool, {
+          arguments: {
+            threadId,
+            ...(cursor !== undefined ? { cursor } : {}),
+            ...(hostId !== undefined ? { hostId } : {}),
+            ...(includeOutputs !== undefined ? { includeOutputs } : {}),
+            ...(maxOutputCharsPerItem !== undefined ? { maxOutputCharsPerItem } : {}),
+            ...(turnLimit !== undefined ? { turnLimit } : {}),
+          },
+        }, extra.signal);
       },
     ),
   );

--- a/tests/chatgpt-web-harness.test.ts
+++ b/tests/chatgpt-web-harness.test.ts
@@ -2603,6 +2603,24 @@ describe("ChatGPT outer-native harness v4", () => {
           properties: { timeout_ms: { type: "number", default: 180_000 } },
         },
       },
+      {
+        name: "read_thread",
+        namespace: "mcp__codex_app",
+        description: "Read recent status and turn summaries for one task.",
+        parameters: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            threadId: { type: "string" },
+            cursor: { type: "string" },
+            hostId: { type: "string" },
+            turnLimit: { type: "number", maximum: 10 },
+            includeOutputs: { type: "boolean" },
+            maxOutputCharsPerItem: { type: "number" },
+          },
+          required: ["threadId"],
+        },
+      },
     ];
     const token = await broker.register(gatewayOnlyEnvironment, 60_000);
     const transport = new StdioClientTransport({
@@ -2620,6 +2638,7 @@ describe("ChatGPT outer-native harness v4", () => {
       expect(listed.tools.map(tool => tool.name).sort()).toEqual([
         "codex_apply_patch",
         "codex_exec",
+        "codex_read_thread",
         "codex_tool_call",
         "codex_tool_inventory",
         "codex_view_image",
@@ -2636,7 +2655,7 @@ describe("ChatGPT outer-native harness v4", () => {
       // ChatGPT caches the complete tools/list contract under a connector identity.
       // An intentional hash change therefore requires an explicit connector refresh or identity migration.
       expect(createHash("sha256").update(canonicalJson(publicConnectorAbi)).digest("hex"))
-        .toBe("5cb59b378c7d1939e260a2b4a60f58e22da31208fe09c2cc17a2cf31eb5ff3ad");
+        .toBe("1cb13b0e64755256391e91c109f35917bd6dbc9c48f8668ff803f91af4d6ecd8");
       for (const tool of listed.tools) {
         const properties = tool.inputSchema.properties as Record<string, unknown>;
         expect(properties.turn_token).toEqual({ type: "string", minLength: 20, maxLength: 256 });
@@ -2667,6 +2686,12 @@ describe("ChatGPT outer-native harness v4", () => {
         idempotentHint: true,
         openWorldHint: false,
       });
+      expect(listed.tools.find(tool => tool.name === "codex_read_thread")?.annotations).toMatchObject({
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      });
       expect(listed.tools.find(tool => tool.name === "codex_tool_inventory")?.annotations).toMatchObject({
         readOnlyHint: true,
         destructiveHint: false,
@@ -2679,6 +2704,47 @@ describe("ChatGPT outer-native harness v4", () => {
         idempotentHint: false,
         openWorldHint: true,
       });
+
+      const threadRead = call("codex_read_thread", {
+        turn_token: token,
+        threadId: "thread_test",
+        cursor: "cursor_test",
+        hostId: "local",
+        turnLimit: 10,
+        includeOutputs: false,
+        maxOutputCharsPerItem: 2_048,
+      });
+      const [threadReadRequest] = await broker.nextToolBatch(token);
+      expect(threadReadRequest).toMatchObject({
+        wireName: "mcp__codex_app__read_thread",
+        freeform: false,
+        arguments: {
+          threadId: "thread_test",
+          cursor: "cursor_test",
+          hostId: "local",
+          turnLimit: 10,
+          includeOutputs: false,
+          maxOutputCharsPerItem: 2_048,
+        },
+      });
+      broker.completeTool(token, threadReadRequest!.callId, toolResult({ title: "Referenced task" }));
+      expect((await threadRead).structuredContent).toEqual({ title: "Referenced task" });
+
+      const environmentWithoutThreadRead = {
+        ...gatewayOnlyEnvironment,
+        tools: gatewayOnlyEnvironment.tools.filter(tool => (
+          tool.namespace !== "mcp__codex_app" || tool.name !== "read_thread"
+        )),
+      };
+      const tokenWithoutThreadRead = await broker.register(environmentWithoutThreadRead, 60_000);
+      const missingThreadRead = await call("codex_read_thread", {
+        turn_token: tokenWithoutThreadRead,
+        threadId: "thread_test",
+      });
+      expect(missingThreadRead.isError).toBe(true);
+      expect(JSON.stringify(missingThreadRead.content)).toContain(
+        "The current outer Codex turn does not advertise read_thread",
+      );
 
       const firstExec = call("codex_exec", {
         turn_token: token,

--- a/tests/zero-risk-mcp-lifecycle.test.ts
+++ b/tests/zero-risk-mcp-lifecycle.test.ts
@@ -266,6 +266,7 @@ describe("Zero Risk public MCP ABI", () => {
       { name: "codex_exec", namespace: ownNamespace, description: "Recursive bridge", parameters: { type: "object" } },
       { name: "codex_turn_complete", namespace: ownNamespace, description: "Recursive completion", parameters: { type: "object" } },
       { name: "shadow_tool", namespace: ownNamespace, description: "Same recursive namespace", parameters: { type: "object" } },
+      { name: "read_thread", namespace: "mcp__codex_app", description: "Read a Codex task", parameters: { type: "object" } },
       { name: "useful_tool", namespace: "mcp__useful", description: "Useful external tool", parameters: { type: "object" } },
     ]), nonceA, 60_000, "safe-stdio");
     const transport = new StdioClientTransport({
@@ -283,6 +284,7 @@ describe("Zero Risk public MCP ABI", () => {
       expect(listed.tools.map(tool => tool.name).sort()).toEqual([
         "codex_apply_patch",
         "codex_exec",
+        "codex_read_thread",
         "codex_tool_call",
         "codex_tool_inventory",
         "codex_turn_complete",
@@ -332,9 +334,10 @@ describe("Zero Risk public MCP ABI", () => {
       });
       const inventory = await inventoryAfterStart;
       expect(inventory.structuredContent).toMatchObject({
-        total: 2,
+        total: 3,
         tools: [
           { wire_name: "exec_command" },
+          { wire_name: "mcp__codex_app__read_thread" },
           { wire_name: "mcp__useful__useful_tool" },
         ],
       });
@@ -342,6 +345,30 @@ describe("Zero Risk public MCP ABI", () => {
       expect(JSON.stringify(inventory)).not.toContain("Top-level recursive bridge");
       expect(JSON.stringify(inventory)).not.toContain("Recursive freeform gateway");
       expect(JSON.stringify(inventory)).not.toContain(CODEX_COMPACTION_CONTROL_WIRE_NAME);
+
+      const threadRead = client.callTool({
+        name: "codex_read_thread",
+        arguments: {
+          request_id: requestId,
+          threadId: "thread_test",
+          hostId: "local",
+          turnLimit: 1,
+          includeOutputs: false,
+        },
+      });
+      const [threadReadRequest] = await broker.nextToolBatch(requestId);
+      expect(threadReadRequest).toMatchObject({
+        wireName: "mcp__codex_app__read_thread",
+        freeform: false,
+        arguments: {
+          threadId: "thread_test",
+          hostId: "local",
+          turnLimit: 1,
+          includeOutputs: false,
+        },
+      });
+      broker.completeTool(requestId, threadReadRequest!.callId, toolResult({ title: "Referenced task" }));
+      expect((await threadRead).structuredContent).toEqual({ title: "Referenced task" });
 
       const recursive = await client.callTool({
         name: "codex_tool_call",


### PR DESCRIPTION
## What this changes

A read-only `mcp__codex_app__read_thread` request currently has to pass through the generic `codex_tool_call` action, whose public MCP annotations correctly describe arbitrary calls as destructive and open-world. ChatGPT can therefore reject a harmless task read before it reaches the bridge.

This adds a dedicated, turn-bound `codex_read_thread` action. It forwards only to the exact advertised `mcp__codex_app__read_thread` tool, preserves the native argument surface, reports an explicit error when that tool is unavailable, and advertises read-only, non-destructive, idempotent, closed-world annotations. The action is available through both the automatic Full harness and Zero Risk contracts.

Related to #342.

## Evidence

Before this change, ChatGPT Web High rejected both the generic task-read request and a minimal retry with only the task ID. The rejection happened before connector dispatch.

After installing the patched runtime and explicitly refreshing the existing `Codex Native2` connector, ChatGPT exposed `codex_read_thread`. A real installed Codex task successfully used it to retrieve one turn from a referenced Codex task with `includeOutputs: false`; the request reached the outer `read_thread` tool and returned its structured result.

The connector ABI hash changes because this is an additive public action. The existing ABI test documents explicit connector refresh or identity migration as the two supported responses; this patch was accepted end-to-end after an explicit refresh. It intentionally does not add a broader connector-identity migration.

## Scope and invariants

- [x] I read and followed `CONTRIBUTING.md`.
- [x] This is a small, focused change with no unrelated cleanup or generated rewrite.
- [x] The change stays focused on ChatGPT web-backed Codex models; it does not add a generic provider or unrelated product surface.
- [x] Model, route, effort, connector, and capability selection remain explicit with no silent fallback or false-success path.
- [x] If this touches Full harness or MCP, every available Web effort retains the same turn-bound capability and Browser-only gains no broker or connector.
- [x] Terms and trademark claims remain factual; this change is not marketed as a quota or rate-limit bypass.

## Verification

- [x] I ran `bun install --frozen-lockfile` in the repository root and `launcher/`.
- [ ] I ran `bun run verify` with the Bun version pinned by `package.json`. It currently stops at the unchanged lockfile audits: three existing Hono advisories in the root and one existing `js-yaml` advisory in `launcher/`. No dependency or lockfile changes are included. Every later verification stage was run individually and passed.
- [x] I added or updated a focused regression test for behavior changes.
- [x] I manually tested the affected behavior.
- [x] If this changes local tools, MCP execution, or the outer Codex agent loop, I tested it through a real installed Codex integration; DEV mode alone is acceptable only when execution is not affected.
- [x] If this changes ChatGPT browser UI handling, I included observed DOM evidence and a reproducible fixture instead of broadening selectors speculatively. N/A: no browser UI handling changed.
- [x] If this changes the launcher, I preserved macOS, Windows, and Linux packaging and named the platform packages actually built below. N/A: no launcher code changed.
- [x] I did not commit browser state, credentials, Tunnel IDs, raw logs, generated artifacts, or private paths.
- [x] I did not include an unrelated dependency update, release artifact, or version change.

Additional results:

- `bun run typecheck`
- `bun run test`: 693 passed, 1 platform-specific test skipped, 0 failed
- `bun run launcher:typecheck`
- `bun run launcher:test`: 295 passed, 1 skipped, 0 failed
- `bun run launcher:build`
- runtime bundle build, third-party notice generation, and relocatable runtime smoke test
- focused Full/Zero Risk MCP tests: 88 passed, 0 failed
- `git diff --check`

## Platform or account validation

- macOS 26 Tahoe, Apple silicon
- ChatGPT Plus
- Automatic Full harness with ChatGPT Web High: passed after explicitly refreshing `Codex Native2`
- Zero Risk: unit-tested request-ID routing; live account flow not run
- Browser-only: not affected
- Windows and Linux: not run
- Packaged platform installers: not built; no launcher or packaging code changed
