### PR TITLE
fix: include Pro usage-limit retry date in the adapter error

### DIFF
--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -193,9 +193,9 @@ function chatGptModelControlUnavailableError(diagnostic: string): Error {
   return new Error(CHATGPT_MODEL_CONTROL_UNAVAILABLE_MESSAGE, { cause: new Error(diagnostic) });
 }
 
-function chatGptModelControlUnavailableAdapterError(diagnostic: string): ChatGptWebAdapterError {
+function chatGptModelControlUnavailableAdapterError(diagnostic: string, userVisibleDetail?: string): ChatGptWebAdapterError {
   return new ChatGptWebAdapterError(
-    CHATGPT_MODEL_CONTROL_UNAVAILABLE_MESSAGE,
+    userVisibleDetail ? `${CHATGPT_MODEL_CONTROL_UNAVAILABLE_MESSAGE} ${userVisibleDetail}` : CHATGPT_MODEL_CONTROL_UNAVAILABLE_MESSAGE,
     {
       status: 502,
       errorType: "server_error",
@@ -204,6 +204,23 @@ function chatGptModelControlUnavailableAdapterError(diagnostic: string): ChatGpt
       cause: new Error(diagnostic),
     },
   );
+}
+
+const CHATGPT_PRO_RETRY_AFTER_RE = /Try again after [A-Z][a-z]{2} \d{1,2}, \d{4}/;
+
+async function chatGptProUsageLimitTooltip(page: Page, menu: Locator): Promise<string | undefined> {
+  const proItem = menu.locator(CHATGPT_EFFORT_ITEM_SELECTOR).filter({ hasText: /^\s*Pro\s*$/ }).last();
+  if (!await proItem.isVisible().catch(() => false)) return undefined;
+  if (!await proItem.hover({ timeout: 1_500 }).then(() => true).catch(() => false)) return undefined;
+  const hint = page.getByText(CHATGPT_PRO_RETRY_AFTER_RE).last();
+  try {
+    await hint.waitFor({ state: "visible", timeout: 1_500 });
+  } catch (error) {
+    if (!(error instanceof Error) || error.name !== "TimeoutError") throw error;
+    return undefined;
+  }
+  const text = (await hint.innerText()).trim();
+  return text || undefined;
 }
 
 export type ChatGptPersonalizationPreflight = "already-personalized" | "enabled";
@@ -2402,13 +2419,16 @@ export class ChatGptBrowserWorker {
     }
     const targetValue = sliderState.min + uiEffortIndex;
     if (targetValue > sliderState.max) {
-      const proUsageLimitHint = uiEffortIndex === 4 && sliderState.min === 0 && sliderState.max === 3
+      const proUnavailable = uiEffortIndex === 4 && sliderState.min === 0 && sliderState.max === 3;
+      const proUsageLimitTooltip = proUnavailable ? await chatGptProUsageLimitTooltip(page, activation.menu) : undefined;
+      const proUsageLimitHint = proUnavailable
         ? " If you have made many Pro requests recently, ChatGPT may have temporarily hidden Pro because you reached its usage limit."
         : "";
       throw chatGptModelControlUnavailableAdapterError(
         `ChatGPT effort slider does not expose item index ${uiEffortIndex}`
         + ` (min=${sliderState.min}; max=${sliderState.max})`
         + proUsageLimitHint,
+        proUsageLimitTooltip,
       );
     }
     const sliderControl = effortSlider.locator("xpath=ancestor::*[@role='menuitem'][1]");

--- a/tests/chatgpt-session.test.ts
+++ b/tests/chatgpt-session.test.ts
@@ -211,8 +211,9 @@ test("a transient effort control does not turn a Luna-only account into Sol", as
   expect(visibilityReads).toBe(2);
 });
 
-function reasoningPicker(options: { max?: string; delay?: number; missing?: boolean } = {}) {
+function reasoningPicker(options: { max?: string; delay?: number; missing?: boolean; proTooltip?: string } = {}) {
   let value = 0;
+  let tooltipVisible = false;
   const keys: string[] = [];
   const hidden = {
     filter() { return this; }, last() { return this; }, getByText() { return this; },
@@ -244,8 +245,28 @@ function reasoningPicker(options: { max?: string; delay?: number; missing?: bool
     getAttribute: async (name: string) => name === "aria-expanded" ? "true" : null,
   };
   const composer = { filter() { return this; }, last() { return this; }, locator: () => ({ locator: () => control }) };
-  const modelRows = { count: async () => 3, first() { return this; }, waitFor: async () => {}, nth: () => { throw new Error("Model rows are not effort choices"); } };
+  const proRow = { last() { return this; }, isVisible: async () => true, hover: async () => { tooltipVisible = true; } };
+  const modelRows = {
+    count: async () => 3, first() { return this; }, last() { return this; }, waitFor: async () => {},
+    nth: () => { throw new Error("Model rows are not effort choices"); },
+    filter: ({ hasText }: { hasText?: string | RegExp }) => {
+      const matchesPro = typeof hasText === "string" ? "Pro".includes(hasText) : hasText?.test("Pro") === true;
+      return options.proTooltip && matchesPro ? proRow : hidden;
+    },
+  };
   const menu = { filter() { return this; }, last() { return this; }, isVisible: async () => true, locator: () => modelRows };
+  const tooltip = {
+    filter() { return this; }, last() { return this; }, isVisible: async () => tooltipVisible,
+    waitFor: async ({ state }: { state: string }) => {
+      expect(state).toBe("visible");
+      if (!tooltipVisible) {
+        const error = new Error("tooltip not visible");
+        error.name = "TimeoutError";
+        throw error;
+      }
+    },
+    innerText: async () => options.proTooltip ?? "",
+  };
   const page = {
     locator: (selector: string) => {
       if (selector === CHATGPT_COMPOSER_SELECTOR) return composer;
@@ -253,9 +274,14 @@ function reasoningPicker(options: { max?: string; delay?: number; missing?: bool
       if (selector === CHATGPT_EFFORT_SLIDER_CONTAINER_SELECTOR) return container;
       return hidden;
     },
+    getByText: (pattern: string | RegExp) => {
+      const haystack = options.proTooltip ?? "";
+      const matches = typeof pattern === "string" ? haystack.includes(pattern) : pattern.test(haystack);
+      return matches ? tooltip : hidden;
+    },
     keyboard: { press: async () => {} },
   };
-  return { page, composer, keys, value: () => value };
+  return { page, composer, keys, value: () => value, tooltipVisible: () => tooltipVisible };
 }
 
 test.each([0, 50])("capabilities wait for the visible container and read its hidden semantic input (delay=%s)", async delay => {
@@ -281,4 +307,55 @@ test("Pro selection changes the hidden slider through its visible owner, never t
   await select.call({ activeComposer: async () => fixture.composer }, fixture.page, "gpt-5.6-sol", "max", { localToolsEnabled: false, solAvailable: true, proAvailable: true });
   expect(fixture.keys).toEqual(["ArrowRight", "ArrowRight", "ArrowRight", "ArrowRight"]);
   expect(fixture.value()).toBe(4);
+});
+
+test("Pro selection surfaces the usage-limit tooltip mounted by Playwright hover", async () => {
+  const tooltipText = "Limit reached. Try again after Sep 15, 2026.";
+  const fixture = reasoningPicker({ max: "3", proTooltip: tooltipText });
+  const select = (ChatGptBrowserWorker.prototype as unknown as {
+    selectModelAndEffort(...args: unknown[]): Promise<unknown>;
+  }).selectModelAndEffort;
+  await expect(select.call({ activeComposer: async () => fixture.composer }, fixture.page, "gpt-5.6-sol", "max", { localToolsEnabled: false, solAvailable: true, proAvailable: true })).rejects.toThrow(tooltipText);
+  expect(fixture.tooltipVisible()).toBe(true);
+});
+
+test("Pro selection keeps the existing model-control error when no usage-limit tooltip is available", async () => {
+  const fixture = reasoningPicker({ max: "3" });
+  const select = (ChatGptBrowserWorker.prototype as unknown as {
+    selectModelAndEffort(...args: unknown[]): Promise<unknown>;
+  }).selectModelAndEffort;
+  const error = await select.call({ activeComposer: async () => fixture.composer }, fixture.page, "gpt-5.6-sol", "max", { localToolsEnabled: false, solAvailable: true, proAvailable: true }).catch((caught: unknown) => caught);
+  expect(error).toBeInstanceOf(Error);
+  expect((error as Error).message).toBe("ChatGPT model controls are unavailable. Reload ChatGPT and retry the task.");
+  expect(fixture.tooltipVisible()).toBe(false);
+});
+
+test("Extra High never inherits the Pro usage-limit tooltip", async () => {
+  const fixture = reasoningPicker({ max: "3", proTooltip: "Limit reached. Try again after Sep 15, 2026." });
+  const select = (ChatGptBrowserWorker.prototype as unknown as {
+    selectModelAndEffort(...args: unknown[]): Promise<unknown>;
+  }).selectModelAndEffort;
+  await expect(select.call({ activeComposer: async () => fixture.composer }, fixture.page, "gpt-5.6-sol", "xhigh", { localToolsEnabled: false, solAvailable: true, proAvailable: true })).resolves.toMatchObject({ displayLabel: "Extra High", uiEffortIndex: 3 });
+  expect(fixture.keys).toEqual(["ArrowRight", "ArrowRight", "ArrowRight"]);
+  expect(fixture.tooltipVisible()).toBe(false);
+});
+
+test("missing model controls keep the existing error without a fabricated Pro retry date", async () => {
+  const effortControl = {
+    last() { return this; },
+    waitFor: async () => {
+      const error = new Error("effort control unavailable");
+      error.name = "TimeoutError";
+      throw error;
+    },
+  };
+  const composer = { locator: () => ({ locator: () => effortControl }) };
+  const hiddenSurface = { filter() { return this; }, last() { return this; }, waitFor: async () => await new Promise<void>(() => {}), isVisible: async () => false };
+  const select = (ChatGptBrowserWorker.prototype as unknown as {
+    selectModelAndEffort(...args: unknown[]): Promise<unknown>;
+  }).selectModelAndEffort;
+  const error = await select.call({ activeComposer: async () => composer }, { locator: () => hiddenSurface }, "gpt-5.6-sol", "max", { localToolsEnabled: false, solAvailable: true, proAvailable: true }).catch((caught: unknown) => caught);
+  expect(error).toBeInstanceOf(Error);
+  expect((error as Error).message).toBe("ChatGPT model controls are unavailable. Reload ChatGPT and retry the task.");
+  expect((error as Error).message).not.toContain("Try again after");
 });


### PR DESCRIPTION
## What this changes

When ChatGPT has hidden Pro behind its weekly usage cap, selecting Pro currently fails with only:

`ChatGPT model controls are unavailable. Reload ChatGPT and retry the task.`

The picker still shows a `Pro` row. Hovering it mounts a portal with the retry date, for example:

`Limit reached. Try again after Sep 15, 2026.`

This change Playwright-hovers that `Pro` menuitemradio and appends the visible retry text to the client-visible adapter error. Extra High is unchanged. Missing tooltip keeps the existing error with no fabricated date.

## Evidence

**Before.** Requested effort `max` while the slider range is `0..3`. Error message is only `ChatGPT model controls are unavailable. Reload ChatGPT and retry the task.` The date is not in `document.body.innerText` or the accessibility tree until hover.

**Observed DOM.** Intelligence picker `role="menuitemradio"` whose accessible text is exactly `Pro`. Hover mounts a portal whose visible text matches `Try again after Mon DD, YYYY`. Screenshot of the live control: tooltip `Limit reached. Try again after Sep 15, 2026.` next to the `Pro` row while Extra High is selected (`4 of 4`).

**After.** Same failure path throws that tooltip text in `ChatGptWebAdapterError.message`. Fixture: hover the Pro row, wait for the visible retry date, expect `rejects.toThrow("Limit reached. Try again after Sep 15, 2026.")`.

## Scope and invariants

- [x] I read and followed `CONTRIBUTING.md`.
- [x] This is a small, focused change with no unrelated cleanup or generated rewrite.
- [x] The change stays focused on ChatGPT web-backed Codex models; it does not add a generic provider or unrelated product surface.
- [x] Model, route, effort, connector, and capability selection remain explicit with no silent fallback or false-success path.
- [x] If this touches Full harness or MCP, every available Web effort retains the same turn-bound capability and Browser-only gains no broker or connector.
- [x] Terms and trademark claims remain factual; this change is not marketed as a quota or rate-limit bypass.

## Verification

- [x] I ran `bun install --frozen-lockfile` in the repository root and `launcher/`.
- [x] I ran `bun run verify` with the Bun version pinned by `package.json`.
- [x] I added or updated a focused regression test for behavior changes.
- [x] I manually tested the affected behavior.
- [x] If this changes local tools, MCP execution, or the outer Codex agent loop, I tested it through a real installed Codex integration; DEV mode alone is acceptable only when execution is not affected.
- [x] If this changes ChatGPT browser UI handling, I included observed DOM evidence and a reproducible fixture instead of broadening selectors speculatively.
- [x] If this changes the launcher, I preserved macOS, Windows, and Linux packaging and named the platform packages actually built below.
- [x] I did not commit browser state, credentials, Tunnel IDs, raw logs, generated artifacts, or private paths.
- [x] I did not include an unrelated dependency update, release artifact, or version change.

`bun run verify` (Bun 1.4.0): `check-version` OK; `bun audit` fails on existing `hono@4.12.34` moderate advisories (not this diff).

- `bun run typecheck`: pass
- `bun test tests/chatgpt-session.test.ts`: 15 pass
- `bun test ./tests`: **694 pass, 1 skip, 3 fail** (698 total). Failures: two Zero Risk compaction tests and `explicit setup still refuses changed hooks` — same class of environment/launcher failures reported on #402, not this change.
- `git diff --check`: pass
- Red/green: the hover→tooltip test fails without `userVisibleDetail` and passes after the source change.

## Platform or account validation

- Linux, ChatGPT Pro account, observed the live Pro tooltip on 2026-09-11. Did not replay the installed helper turn after this patch: the date is gone from the DOM until hover, and a live Pro click would fight an in-use Extra High session. Fixture covers the error path.
- Browser-only / Full / packaged launcher builds: not run.
