### PR TITLE
fix: use existing hooks.json for the Codex Interrupt hook

### DIFF
--- a/launcher/electron/runtime.cjs
+++ b/launcher/electron/runtime.cjs
@@ -475,6 +475,7 @@ class RuntimeHost {
       path.join(coreHome, "codex", "integration-journal.json"),
       path.join(coreHome, "codex", "integration-journal.recovery.json"),
       path.join(this.codexHome, "config.toml"),
+      path.join(this.codexHome, "hooks.json"),
       path.join(this.codexHome, "models_cache.json"),
       path.join(coreHome, "secrets", "tunnel-runtime.key"),
       path.join(coreHome, "secrets", "tunnel-runtime-automatic.key"),
@@ -506,7 +507,8 @@ class RuntimeHost {
       }
     }
     return [...paths].map(filePath => captureRegularFile(filePath, {
-      followSymlink: filePath === path.join(this.codexHome, "config.toml"),
+      followSymlink: filePath === path.join(this.codexHome, "config.toml")
+        || filePath === path.join(this.codexHome, "hooks.json"),
     }));
   }
 

--- a/launcher/tests/runtime-host.test.cjs
+++ b/launcher/tests/runtime-host.test.cjs
@@ -785,9 +785,13 @@ test("failed first-time setup removes its route before restoring the unconfigure
   const recoveryJournalPath = path.join(coreHome, "codex", "integration-journal.recovery.json");
   const configPath = path.join(root, "config.json");
   const codexConfigPath = path.join(codexHome, "config.toml");
+  const codexHooksPath = path.join(codexHome, "hooks.json");
+  const sharedHooksPath = path.join(root, "shared-hooks.json");
   const codexModelsCachePath = path.join(codexHome, "models_cache.json");
   fs.mkdirSync(codexHome, { recursive: true });
   fs.writeFileSync(codexConfigPath, "original codex config\n");
+  fs.writeFileSync(sharedHooksPath, "original codex hooks\n");
+  fs.symlinkSync(sharedHooksPath, codexHooksPath);
   fs.writeFileSync(codexModelsCachePath, "original codex models cache\n");
   let cleared = 0;
   let stops = 0;
@@ -820,6 +824,7 @@ test("failed first-time setup removes its route before restoring the unconfigure
     fs.writeFileSync(journalPath, "partial integration journal\n");
     fs.writeFileSync(recoveryJournalPath, "partial recovery journal\n");
     fs.writeFileSync(codexConfigPath, "partially changed codex config\n");
+    fs.writeFileSync(codexHooksPath, "partially changed codex hooks\n");
     fs.rmSync(codexModelsCachePath);
     throw new Error("synthetic setup failure");
   };
@@ -836,6 +841,9 @@ test("failed first-time setup removes its route before restoring the unconfigure
     assert.equal(fs.existsSync(journalPath), false);
     assert.equal(fs.existsSync(recoveryJournalPath), false);
     assert.equal(fs.readFileSync(codexConfigPath, "utf8"), "original codex config\n");
+    assert.equal(fs.readFileSync(codexHooksPath, "utf8"), "original codex hooks\n");
+    assert.equal(fs.lstatSync(codexHooksPath).isSymbolicLink(), true);
+    assert.equal(fs.readFileSync(sharedHooksPath, "utf8"), "original codex hooks\n");
     assert.equal(fs.readFileSync(codexModelsCachePath, "utf8"), "original codex models cache\n");
     assert.equal(stops, 2);
     assert.equal(cleared, 1);

--- a/scripts/smoke-codex-hooks-json.ts
+++ b/scripts/smoke-codex-hooks-json.ts
@@ -1,9 +1,15 @@
 import assert from "node:assert/strict";
 import { spawn, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { createInterface } from "node:readline";
+import {
+  codexJsonInterruptHookStateKey,
+  installCodexInterruptHookTrust,
+  restoreCodexInterruptHookTrust,
+  verifyCodexInterruptHookTrust,
+} from "../src/codex-interrupt-hook";
 
 // Run with: bun run scripts/smoke-codex-hooks-json.ts [absolute-path-to-codex]
 // Discovery only: no thread, model request, bridge setup, or hook execution.
@@ -184,6 +190,46 @@ try {
   assert.equal(trusted.currentHash, untrusted.currentHash);
   console.log("PASS JSON + TOML trust state: trusted after restart, no mixed-source warning");
 
+  const sharedHooksPath = join(root, "shared-hooks.json");
+  rmSync(hooksPath);
+  writeFileSync(sharedHooksPath, json);
+  symlinkSync(sharedHooksPath, hooksPath);
+  writeFileSync(configPath, config);
+  const [symlinked] = await expectHooks(1);
+  assert.equal(symlinked.sourcePath, hooksPath);
+  assert.equal(symlinked.key, codexJsonInterruptHookStateKey(hooksPath, 0, 0));
+  await withClient(request => request("config/value/write", {
+    keyPath: "hooks.state",
+    value: { [symlinked.key]: { trusted_hash: symlinked.currentHash } },
+    mergeStrategy: "replace",
+    filePath: configPath,
+  }));
+  const [symlinkedTrusted] = await expectHooks(1);
+  assert.equal(symlinkedTrusted.trustStatus, "trusted");
+  console.log("PASS symlinked JSON: Codex trusts the hooks.json source path");
+
+  writeFileSync(configPath, config);
+  const trust = installCodexInterruptHookTrust(
+    config,
+    codexJsonInterruptHookStateKey(hooksPath, 0, 0),
+    symlinked.currentHash,
+  );
+  writeFileSync(configPath, trust.text);
+  await withClient(request => request("config/value/write", {
+    keyPath: "mcp_servers.astra_review.command",
+    value: "review",
+    mergeStrategy: "replace",
+    filePath: configPath,
+  }));
+  const nativeEditedTrust = readFileSync(configPath, "utf8");
+  verifyCodexInterruptHookTrust(nativeEditedTrust, trust.installed);
+  const restoredTrust = restoreCodexInterruptHookTrust(nativeEditedTrust, trust.installed);
+  assert.match(restoredTrust, /\[mcp_servers\.astra_review\]/);
+  assert.doesNotMatch(restoredTrust, /JSON interrupt hook trust/);
+  console.log("PASS native TOML writer: trust cleanup preserves an unrelated MCP table");
+
+  rmSync(hooksPath);
+  writeFileSync(hooksPath, json);
   writeFileSync(hooksPath, json.replace(command, `${command}-changed`));
   const [modified] = await expectHooks(1);
   assert.equal(modified.key, untrusted.key);

--- a/scripts/smoke-codex-hooks-json.ts
+++ b/scripts/smoke-codex-hooks-json.ts
@@ -1,0 +1,225 @@
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { createInterface } from "node:readline";
+
+// Run with: bun run scripts/smoke-codex-hooks-json.ts [absolute-path-to-codex]
+// Discovery only: no thread, model request, bridge setup, or hook execution.
+const codex = resolve(process.argv[2] ?? "/Applications/ChatGPT.app/Contents/Resources/codex");
+assert(existsSync(codex), `Codex executable is missing: ${codex}`);
+const root = realpathSync(mkdtempSync(join(tmpdir(), "codex-hooks-json-")));
+const codexHome = join(root, "codex");
+const cwd = join(root, "workspace");
+const configPath = join(codexHome, "config.toml");
+const hooksPath = join(codexHome, "hooks.json");
+// Do not inherit credentials, config overrides, or an enclosing Codex session.
+const env = { PATH: process.env.PATH, CODEX_HOME: codexHome };
+const config = "[features]\nhooks = true\n\n[analytics]\nenabled = false\n";
+const command = "echo codex-hooks-json-discovery";
+const json = JSON.stringify({ hooks: { Interrupt: [{ hooks: [{ type: "command", command, timeout: 3 }] }] } }, null, 2);
+const toml = `\n[[hooks.Interrupt]]\n[[hooks.Interrupt.hooks]]\ntype = "command"\ncommand = ${JSON.stringify(command)}\ntimeout = 3\n`;
+const mixedWarning = /loading hooks from both .*hooks\.json.*config\.toml/;
+
+type Request = (method: string, params: unknown) => Promise<unknown>;
+
+async function withClient<T>(operation: (request: Request) => Promise<T>, allowMixed = false): Promise<T> {
+  const child = spawn(codex, ["app-server"], { cwd, env, stdio: ["pipe", "pipe", "pipe"] });
+  const lines = createInterface({ input: child.stdout });
+  const pending = new Map<number, { resolve: (value: unknown) => void; reject: (error: Error) => void }>();
+  let nextId = 1;
+  let stopping = false;
+  let failure: Error | undefined;
+  let stderr = "";
+  const fail = (error: Error): void => {
+    if (!failure) {
+      failure = error;
+    }
+    for (const waiting of pending.values()) {
+      waiting.reject(error);
+    }
+    pending.clear();
+  };
+  child.stderr.on("data", chunk => { stderr = (stderr + String(chunk)).slice(-8_000); });
+  child.on("error", fail);
+  child.stdin.on("error", fail);
+  const closed = new Promise<void>(done => child.once("close", (code, signal) => {
+    if (!stopping || (code !== 0 && signal !== "SIGTERM")) {
+      fail(new Error(`Codex app-server closed unexpectedly: code=${code}, signal=${signal}`));
+    }
+    done();
+  }));
+  lines.on("line", line => {
+    try {
+      const message: unknown = JSON.parse(line);
+      assert(message && typeof message === "object", "Invalid RPC envelope");
+      const response = message as { id?: unknown; result?: unknown; error?: unknown };
+      if (typeof response.id !== "number") {
+        return;
+      }
+      const waiting = pending.get(response.id);
+      assert(waiting, `Unexpected RPC response id: ${response.id}`);
+      pending.delete(response.id);
+      if (response.error) {
+        waiting.reject(new Error(`Codex RPC error: ${JSON.stringify(response.error)}`));
+      } else {
+        waiting.resolve(response.result);
+      }
+    } catch (error) {
+      fail(error instanceof Error ? error : new Error(String(error)));
+    }
+  });
+  const request: Request = (method, params) => new Promise((resolveRequest, reject) => {
+    if (failure) {
+      reject(failure);
+      return;
+    }
+    const id = nextId++;
+    pending.set(id, { resolve: resolveRequest, reject });
+    child.stdin.write(`${JSON.stringify({ id, method, params })}\n`);
+  });
+  const timeout = setTimeout(() => {
+    fail(new Error("Codex discovery timed out after 15 seconds"));
+    child.kill("SIGKILL");
+  }, 15_000);
+  try {
+    await request("initialize", {
+      clientInfo: { name: "codex-hooks-json-smoke", version: "1" },
+      capabilities: { experimentalApi: true },
+    });
+    child.stdin.write(`${JSON.stringify({ method: "initialized", params: {} })}\n`);
+    return await operation(request);
+  } catch (error) {
+    throw new Error(`${error instanceof Error ? error.message : String(error)}\nCodex stderr:\n${stderr}`);
+  } finally {
+    stopping = true;
+    child.kill();
+    await closed;
+    clearTimeout(timeout);
+    lines.close();
+    if (failure) {
+      throw new Error(`${failure.message}\nCodex stderr:\n${stderr}`);
+    }
+    if (!allowMixed) {
+      assert.doesNotMatch(stderr, mixedWarning, "Unexpected mixed-source warning on stderr");
+    }
+  }
+}
+
+// Narrow projection of the experimental API, checked against generated 0.153.4 bindings.
+type Hook = { key: string; currentHash: string; trustStatus: string; command: string; sourcePath: string };
+
+async function listHooks(request: Request): Promise<{ hooks: Hook[]; warnings: string[]; errors: unknown[] }> {
+  const result = await request("hooks/list", { cwds: [cwd] }) as { data?: unknown } | null;
+  assert(result && Array.isArray(result.data) && result.data.length === 1, "Expected one hooks/list result");
+  const entry = result.data[0] as { cwd?: unknown; hooks?: unknown; warnings?: unknown; errors?: unknown };
+  assert.equal(entry.cwd, cwd);
+  assert(Array.isArray(entry.hooks), "Missing hooks array");
+  assert(Array.isArray(entry.warnings) && entry.warnings.every(warning => typeof warning === "string"), "Invalid warnings");
+  assert(Array.isArray(entry.errors), "Missing errors array");
+  const hooks = entry.hooks.map((value: unknown) => {
+    assert(value && typeof value === "object", "Invalid hook metadata");
+    const hook = value as Record<string, unknown>;
+    assert.equal(hook.eventName, "interrupt");
+    assert.equal(hook.handlerType, "command");
+    assert.equal(hook.source, "user");
+    assert.equal(hook.timeoutSec, 3);
+    assert.equal(hook.enabled, true);
+    assert.equal(hook.isManaged, false);
+    assert.equal(typeof hook.key, "string");
+    assert.equal(typeof hook.currentHash, "string");
+    assert.equal(typeof hook.trustStatus, "string");
+    assert.equal(typeof hook.command, "string");
+    assert.equal(typeof hook.sourcePath, "string");
+    return hook as Hook;
+  });
+  return { hooks, warnings: entry.warnings, errors: entry.errors };
+}
+
+async function expectHooks(count: number, mixed = false): Promise<Hook[]> {
+  const result = await withClient(listHooks, mixed);
+  assert.equal(result.hooks.length, count);
+  assert.deepEqual(result.errors, []);
+  assert.equal(result.warnings.some(warning => mixedWarning.test(warning)), mixed, JSON.stringify(result.warnings));
+  if (!mixed) {
+    assert.deepEqual(result.warnings, []);
+  }
+  return result.hooks;
+}
+
+try {
+  mkdirSync(codexHome);
+  mkdirSync(cwd);
+  const version = spawnSync(codex, ["--version"], { cwd, env, encoding: "utf8", timeout: 5_000 });
+  assert.equal(version.status, 0, version.error?.message ?? version.stderr);
+  console.log(`Codex: ${version.stdout.trim()} (${codex})`);
+  writeFileSync(configPath, config);
+  await expectHooks(0);
+  console.log("PASS isolated baseline: no hooks");
+
+  writeFileSync(hooksPath, json);
+  const [untrusted] = await expectHooks(1);
+  assert.equal(untrusted.command, command);
+  assert.equal(untrusted.sourcePath, hooksPath);
+  assert.equal(untrusted.key, `${hooksPath}:interrupt:0:0`);
+  assert.equal(untrusted.trustStatus, "untrusted");
+  assert.match(untrusted.currentHash, /^sha256:[a-f0-9]{64}$/);
+  console.log("PASS JSON-only: discovered, untrusted, no mixed-source warning");
+
+  // Use Codex's writer and reported identity, rather than assuming JSON trust storage.
+  await withClient(request => request("config/value/write", {
+    keyPath: "hooks.state",
+    value: { [untrusted.key]: { trusted_hash: untrusted.currentHash } },
+    mergeStrategy: "replace",
+    filePath: configPath,
+  }));
+  const trustedConfig = readFileSync(configPath, "utf8");
+  const parsed = Bun.TOML.parse(trustedConfig) as { hooks: Record<string, unknown> };
+  assert.deepEqual(Object.keys(parsed.hooks), ["state"]);
+  assert.deepEqual(parsed.hooks.state, { [untrusted.key]: { trusted_hash: untrusted.currentHash } });
+  assert.equal(readFileSync(hooksPath, "utf8"), json);
+  const [trusted] = await expectHooks(1);
+  assert.equal(trusted.trustStatus, "trusted");
+  assert.equal(trusted.currentHash, untrusted.currentHash);
+  console.log("PASS JSON + TOML trust state: trusted after restart, no mixed-source warning");
+
+  writeFileSync(hooksPath, json.replace(command, `${command}-changed`));
+  const [modified] = await expectHooks(1);
+  assert.equal(modified.key, untrusted.key);
+  assert.equal(modified.trustStatus, "modified");
+  assert.notEqual(modified.currentHash, untrusted.currentHash);
+  console.log("PASS changed JSON command: trust invalidated");
+
+  writeFileSync(hooksPath, json);
+  writeFileSync(configPath, trustedConfig + toml);
+  const mixed = await expectHooks(2, true);
+  const inline = mixed.find(hook => hook.sourcePath === configPath);
+  assert(inline, "TOML hook was not discovered");
+  assert.equal(inline.currentHash, untrusted.currentHash);
+  assert.equal(inline.trustStatus, "untrusted");
+  assert.equal(mixed.find(hook => hook.sourcePath === hooksPath)?.trustStatus, "trusted");
+  console.log("PASS JSON + TOML definitions: both discovered, warning emitted, trust stays source-specific");
+
+  writeFileSync(hooksPath, '{"hooks":{}}');
+  await expectHooks(1);
+  console.log("PASS empty JSON + TOML definition: no mixed-source warning");
+
+  writeFileSync(configPath, trustedConfig);
+  writeFileSync(hooksPath, '{"hooks":');
+  const malformed = await withClient(listHooks);
+  assert.equal(malformed.hooks.length, 0);
+  assert(malformed.warnings.some(warning => warning.includes(hooksPath) && /failed to parse hooks config/.test(warning))
+    || malformed.errors.some(value => {
+      const error = value as { path?: unknown; message?: unknown } | null;
+      return error?.path === hooksPath && typeof error.message === "string" && error.message.length > 0;
+    }), "Malformed JSON produced no diagnostic for hooks.json");
+  console.log("PASS malformed JSON: diagnostic returned, no hook discovered");
+
+  rmSync(hooksPath);
+  await expectHooks(0);
+  console.log("PASS removed JSON: stale trust state creates no hook or mixed-source warning");
+  console.log("NATIVE_CODEX_HOOKS_JSON_DISCOVERY_SMOKE_OK");
+} finally {
+  rmSync(root, { recursive: true, force: true });
+}

--- a/scripts/smoke-codex-interrupt.ts
+++ b/scripts/smoke-codex-interrupt.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -84,7 +84,13 @@ const server = startServer(config, {
 if (server.port === undefined) throw new Error("Interrupt smoke server did not bind a port");
 config.port = server.port;
 saveConfig(config);
+writeFileSync(join(codexHome, "hooks.json"), JSON.stringify({
+  hooks: { Stop: [{ hooks: [{ type: "command", command: "true" }] }] },
+}));
 const journal = installCodexIntegration(config);
+if (journal.interruptHook.storage !== "json") {
+  throw new Error("Interrupt smoke expected an existing hooks.json to select JSON hook storage");
+}
 
 type RpcResponse = { id: number; result?: any; error?: { code?: number; message?: string; data?: unknown } };
 

--- a/src/codex-integration-journal.ts
+++ b/src/codex-integration-journal.ts
@@ -4,6 +4,7 @@ import { atomicWriteFile, stripUtf8Bom } from "./config";
 import {
   CODEX_REALTIME_WEBRTC_CALL_BASE_URL,
   getCodexConfigPath,
+  getCodexHooksPath,
   getCodexJournalPath,
   getCodexJournalRecoveryPath,
   serializeJournal,
@@ -12,6 +13,7 @@ import {
 import type {
   AnyCodexIntegrationJournal,
   CodexIntegrationJournal,
+  LegacyCodexIntegrationJournalV10,
   LegacyCodexIntegrationJournal,
   LegacyCodexIntegrationJournalV9,
   LegacyCodexIntegrationJournalV3,
@@ -22,6 +24,11 @@ import type {
   LegacyCodexIntegrationJournalV8,
 } from "./codex-integration-shared";
 import { verifyManagedJournalState } from "./codex-integration-route";
+import {
+  installCodexInterruptHookJson,
+  restoreCodexInterruptHookJson,
+  verifyCodexInterruptHookJson,
+} from "./codex-interrupt-hook-json";
 
 function isPreviousAssignment(value: unknown): boolean {
   if (!value || typeof value !== "object") return false;
@@ -41,9 +48,42 @@ function isInstalledInterruptHook(value: unknown): boolean {
     && typeof hook.fragment === "string" && hook.fragment.length > 0;
 }
 
+function isInstalledInterruptHookV11(value: unknown): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const hook = value as Record<string, unknown>;
+  if (hook.storage === "toml") return isInstalledInterruptHook(hook);
+  return hook.storage === "json"
+    && typeof hook.command === "string" && hook.command.length > 0
+    && typeof hook.hooksPath === "string" && hook.hooksPath.length > 0
+    && Number.isSafeInteger(hook.groupIndex) && (hook.groupIndex as number) >= 0
+    && Number.isSafeInteger(hook.hookIndex) && (hook.hookIndex as number) >= 0
+    && typeof hook.entryHash === "string" && /^sha256:[a-f0-9]{64}$/.test(hook.entryHash)
+    && typeof hook.stateKey === "string" && hook.stateKey.length > 0
+    && typeof hook.trustedHash === "string" && /^sha256:[a-f0-9]{64}$/.test(hook.trustedHash)
+    && typeof hook.trustFragment === "string" && hook.trustFragment.length > 0;
+}
+
 function parseJournal(path: string): AnyCodexIntegrationJournal {
   const value = JSON.parse(stripUtf8Bom(readFileSync(path, "utf8"))) as Record<string, unknown>;
   const installed = value.installed as Record<string, unknown> | undefined;
+  if (value.version === 11
+    && typeof value.active === "boolean"
+    && installed
+    && typeof installed.openai_base_url === "string"
+    && installed.experimental_realtime_webrtc_call_base_url === CODEX_REALTIME_WEBRTC_CALL_BASE_URL
+    && (installed.subagent_protocol === "compatibility-v1" || installed.subagent_protocol === "native")
+    && (installed.subagent_protocol !== "compatibility-v1"
+      || (value.previousMultiAgent && value.previousMultiAgentV2
+        && value.previousAgentMaxDepth
+        && typeof installed.agent_max_depth === "number"
+        && Number.isSafeInteger(installed.agent_max_depth)
+        && installed.agent_max_depth >= 2))
+    && value.previous
+    && isPreviousAssignment(value.previousRealtimeWebrtcCallBaseUrl)
+    && isInstalledInterruptHookV11(value.interruptHook)
+    && typeof value.configPath === "string") {
+    return value as unknown as CodexIntegrationJournal;
+  }
   if (value.version === 10
     && typeof value.active === "boolean"
     && installed
@@ -60,7 +100,7 @@ function parseJournal(path: string): AnyCodexIntegrationJournal {
     && isPreviousAssignment(value.previousRealtimeWebrtcCallBaseUrl)
     && isInstalledInterruptHook(value.interruptHook)
     && typeof value.configPath === "string") {
-    return value as unknown as CodexIntegrationJournal;
+    return value as unknown as LegacyCodexIntegrationJournalV10;
   }
   if (value.version === 9
     && typeof value.active === "boolean"
@@ -134,7 +174,7 @@ function parseJournal(path: string): AnyCodexIntegrationJournal {
   }
   throw new Error(`Invalid Codex integration journal: ${path}`);
 }
-function journalMatchesConfig(journal: AnyCodexIntegrationJournal): boolean {
+function journalConfigMatches(journal: AnyCodexIntegrationJournal): boolean {
   try {
     assertJournalTargetsConfig(journal, getCodexConfigPath());
     if (!existsSync(journal.configPath)) return false;
@@ -145,6 +185,59 @@ function journalMatchesConfig(journal: AnyCodexIntegrationJournal): boolean {
   } catch {
     return false;
   }
+}
+
+function journalExternalHooksMatch(journal: AnyCodexIntegrationJournal): boolean {
+  try {
+    if (journal.version === 11 && journal.interruptHook.storage === "json") {
+      const hook = journal.interruptHook;
+      const installed = (): boolean => {
+        if (!existsSync(hook.hooksPath)) return false;
+        try {
+          verifyCodexInterruptHookJson(readFileSync(hook.hooksPath, "utf8"), {
+            ...hook,
+            mode: "json",
+          });
+          return true;
+        } catch {
+          return false;
+        }
+      };
+      return journal.active ? installed() : !installed();
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function journalMatchesConfig(journal: AnyCodexIntegrationJournal): boolean {
+  return journalConfigMatches(journal) && journalExternalHooksMatch(journal);
+}
+
+function recoverPendingJsonHookWrite(
+  recovery: AnyCodexIntegrationJournal,
+  primary?: AnyCodexIntegrationJournal,
+): boolean {
+  if (recovery.version !== 11 || recovery.interruptHook.storage !== "json") return false;
+  if (!journalConfigMatches(recovery) || journalExternalHooksMatch(recovery)) return false;
+  let current = readFileSync(recovery.interruptHook.hooksPath, "utf8");
+  if (recovery.active && primary?.version === 11 && primary.active
+    && primary.interruptHook.storage === "json") {
+    assertJournalTargetsConfig(primary, getCodexConfigPath());
+    current = restoreCodexInterruptHookJson(current, { ...primary.interruptHook, mode: "json" });
+  }
+  const next = recovery.active
+    ? installCodexInterruptHookJson(current, recovery.interruptHook.command).text
+    : restoreCodexInterruptHookJson(current, { ...recovery.interruptHook, mode: "json" });
+  if (recovery.active) {
+    verifyCodexInterruptHookJson(next, { ...recovery.interruptHook, mode: "json" });
+  }
+  writeFilesWithCompensation([
+    { path: recovery.interruptHook.hooksPath, data: next, followSymlink: true },
+    { path: getCodexJournalPath(), data: serializeJournal(recovery) },
+  ]);
+  return true;
 }
 
 export function readJournal(): AnyCodexIntegrationJournal | undefined {
@@ -166,6 +259,7 @@ export function readJournal(): AnyCodexIntegrationJournal | undefined {
     return undefined;
   }
   if (primary && recovery && serializeJournal(primary) === serializeJournal(recovery)) return primary;
+  if (recovery && !primaryError && recoverPendingJsonHookWrite(recovery, primary)) return recovery;
   if (primary && !recovery && !recoveryError) {
     atomicWriteFile(recoveryPath, serializeJournal(primary));
     return primary;
@@ -207,6 +301,12 @@ export function assertJournalTargetsConfig(
   if (pathIdentity(journal.configPath) !== pathIdentity(configPath)) {
     throw new Error(
       `Codex integration journal belongs to ${journal.configPath}, not the active config ${configPath}`,
+    );
+  }
+  if (journal.version === 11 && journal.interruptHook.storage === "json"
+    && pathIdentity(journal.interruptHook.hooksPath) !== pathIdentity(getCodexHooksPath())) {
+    throw new Error(
+      `Codex integration journal belongs to ${journal.interruptHook.hooksPath}, not the active hooks JSON ${getCodexHooksPath()}`,
     );
   }
 }

--- a/src/codex-integration-route.ts
+++ b/src/codex-integration-route.ts
@@ -10,6 +10,7 @@ import {
 } from "./codex-integration-shared";
 import type {
   CodexIntegrationJournal,
+  LegacyCodexIntegrationJournalV10,
   LegacyCodexIntegrationJournal,
   LegacyCodexIntegrationJournalV4,
   LegacyCodexIntegrationJournalV5,
@@ -22,11 +23,15 @@ import type {
   PreviousAssignment,
   PreviousFeatureAssignment,
   PreviousAgentAssignment,
+  InstalledCodexInterruptHookJson,
 } from "./codex-integration-shared";
 import {
   restoreCodexInterruptHook,
+  restoreCodexInterruptHookTrust,
   verifyCodexInterruptHook,
   verifyCodexInterruptHookRestored,
+  verifyCodexInterruptHookTrust,
+  verifyCodexInterruptHookTrustRestored,
 } from "./codex-interrupt-hook";
 import {
   assignments,
@@ -52,7 +57,7 @@ import {
 } from "./codex-integration-document";
 
 function compatibilityV1Evidence(
-  journal: CodexIntegrationJournal | LegacyCodexIntegrationJournalV9 | LegacyCodexIntegrationJournalV8,
+  journal: CodexIntegrationJournal | LegacyCodexIntegrationJournalV10 | LegacyCodexIntegrationJournalV9 | LegacyCodexIntegrationJournalV8,
 ): {
   previousMultiAgent: PreviousFeatureAssignment;
   previousMultiAgentV2: PreviousFeatureAssignment;
@@ -74,7 +79,7 @@ function compatibilityV1Evidence(
 
 function restoreOwnedManagedFeatures(text: string, journal: ManagedRouteJournal): string {
   let restored = text;
-  if (journal.version === 8 || journal.version === 9 || journal.version === 10) {
+  if (journal.version === 8 || journal.version === 9 || journal.version === 10 || journal.version === 11) {
     const evidence = compatibilityV1Evidence(journal);
     if (evidence) {
       const depth = findAgentMaxDepthAssignment(splitLines(restored));
@@ -178,10 +183,18 @@ export function replacementBaseline(
   if (!configExists) return "";
   if (!managedJournalIsActive(journal)) return currentText;
 
-  if (journal.version === 9 || journal.version === 10) {
+  if (journal.version === 9 || journal.version === 10 || journal.version === 11) {
     const withoutHook = journal.version === 10
       ? restoreCodexInterruptHook(currentText, journal.interruptHook, { allowAbsent: true })
-      : currentText;
+      : journal.version === 11 && journal.interruptHook.storage === "toml"
+        ? restoreCodexInterruptHook(currentText, journal.interruptHook, { allowAbsent: true })
+        : journal.version === 11
+          ? restoreCodexInterruptHookTrust(currentText, {
+            stateKey: journal.interruptHook.stateKey,
+            trustedHash: journal.interruptHook.trustedHash,
+            fragment: (journal.interruptHook as InstalledCodexInterruptHookJson).trustFragment,
+          })
+          : currentText;
     const baseline = restoreOwnedManagedFeatures(withoutHook, journal);
     const document = parseDocument(baseline);
     removeManagedComment(document);
@@ -286,13 +299,13 @@ export function verifyInstalledRoute(text: string, journal: ManagedRouteJournal)
   if (current.openai_base_url.value !== journal.installed.openai_base_url) {
     throw new Error("Codex openai_base_url changed after setup; refusing to overwrite the user's newer value");
   }
-  const expectedMarker = journal.version === 9 || journal.version === 10
+  const expectedMarker = journal.version === 9 || journal.version === 10 || journal.version === 11
     ? MANAGED_ROUTE_COMMENT
     : MANAGED_COMMENT;
   if (!lines.includes(expectedMarker)) {
     throw new Error("Managed Codex route marker changed after setup; refusing to overwrite it");
   }
-  if (journal.version === 9 || journal.version === 10) {
+  if (journal.version === 9 || journal.version === 10 || journal.version === 11) {
     const realtime = findTopLevelAssignment(lines, "experimental_realtime_webrtc_call_base_url");
     const expectedLine = `experimental_realtime_webrtc_call_base_url = ${JSON.stringify(journal.installed.experimental_realtime_webrtc_call_base_url)}`;
     if (realtime.value !== journal.installed.experimental_realtime_webrtc_call_base_url
@@ -301,7 +314,18 @@ export function verifyInstalledRoute(text: string, journal: ManagedRouteJournal)
     }
   }
   if (journal.version === 10) verifyCodexInterruptHook(text, journal.interruptHook);
-  if (journal.version === 8 || journal.version === 9 || journal.version === 10) {
+  if (journal.version === 11) {
+    if (journal.interruptHook.storage === "toml") {
+      verifyCodexInterruptHook(text, journal.interruptHook);
+    } else {
+      verifyCodexInterruptHookTrust(text, {
+        stateKey: journal.interruptHook.stateKey,
+        trustedHash: journal.interruptHook.trustedHash,
+        fragment: journal.interruptHook.trustFragment,
+      });
+    }
+  }
+  if (journal.version === 8 || journal.version === 9 || journal.version === 10 || journal.version === 11) {
     const evidence = compatibilityV1Evidence(journal);
     if (evidence) {
       verifyCompatibilityV1Features(
@@ -311,7 +335,7 @@ export function verifyInstalledRoute(text: string, journal: ManagedRouteJournal)
       );
     }
   }
-  if (journal.version !== 7 && journal.version !== 8 && journal.version !== 9 && journal.version !== 10) {
+  if (journal.version !== 7 && journal.version !== 8 && journal.version !== 9 && journal.version !== 10 && journal.version !== 11) {
     if (current.model_provider.present || current.model_catalog_json.present) {
       throw new Error("Codex model_provider or model_catalog_json changed after setup; refusing to overwrite the user's newer value");
     }
@@ -331,11 +355,11 @@ function previousAssignmentMatchesExactly(current: PreviousAssignment, previous:
 
 export function verifyRestoredRoute(
   text: string,
-  journal: CodexIntegrationJournal | LegacyCodexIntegrationJournalV9 | LegacyCodexIntegrationJournalV8 | LegacyCodexIntegrationJournalV7 | LegacyCodexIntegrationJournalV6 | LegacyCodexIntegrationJournalV5 | LegacyCodexIntegrationJournalV4,
+  journal: CodexIntegrationJournal | LegacyCodexIntegrationJournalV10 | LegacyCodexIntegrationJournalV9 | LegacyCodexIntegrationJournalV8 | LegacyCodexIntegrationJournalV7 | LegacyCodexIntegrationJournalV6 | LegacyCodexIntegrationJournalV5 | LegacyCodexIntegrationJournalV4,
 ): void {
   const lines = splitLines(text);
   const current = assignments(lines);
-  const keys = journal.version === 7 || journal.version === 8 || journal.version === 9 || journal.version === 10
+  const keys = journal.version === 7 || journal.version === 8 || journal.version === 9 || journal.version === 10 || journal.version === 11
     ? (["openai_base_url"] as const)
     : (["openai_base_url", "model_provider", "model_catalog_json"] as const);
   for (const key of keys) {
@@ -346,7 +370,7 @@ export function verifyRestoredRoute(
   if (lines.includes(MANAGED_COMMENT) || lines.includes(MANAGED_ROUTE_COMMENT)) {
     throw new Error("Managed Codex route marker is present while the bridge is disconnected");
   }
-  if (journal.version === 9 || journal.version === 10) {
+  if (journal.version === 9 || journal.version === 10 || journal.version === 11) {
     const realtime = findTopLevelAssignment(lines, "experimental_realtime_webrtc_call_base_url");
     if (!previousAssignmentMatchesExactly(realtime, journal.previousRealtimeWebrtcCallBaseUrl)) {
       throw new Error(
@@ -355,6 +379,13 @@ export function verifyRestoredRoute(
     }
   }
   if (journal.version === 10) verifyCodexInterruptHookRestored(text);
+  if (journal.version === 11) {
+    if (journal.interruptHook.storage === "toml") {
+      verifyCodexInterruptHookRestored(text);
+    } else {
+      verifyCodexInterruptHookTrustRestored(text);
+    }
+  }
   if (journal.version === 5 || journal.version === 6) {
     const previousFeatures: Array<readonly [string, PreviousFeatureAssignment]> = [
       ["remote_compaction_v2", journal.previousRemoteCompactionV2],
@@ -377,7 +408,7 @@ export function verifyRestoredRoute(
       }
     }
   }
-  if (journal.version === 8 || journal.version === 9 || journal.version === 10) {
+  if (journal.version === 8 || journal.version === 9 || journal.version === 10 || journal.version === 11) {
     const evidence = compatibilityV1Evidence(journal);
     if (evidence) {
       for (const [key, previous] of [
@@ -433,7 +464,15 @@ export function restoreManagedRoute(text: string, journal: ManagedRouteJournal):
   verifyInstalledRoute(text, journal);
   const withoutHook = journal.version === 10
     ? restoreCodexInterruptHook(text, journal.interruptHook)
-    : text;
+    : journal.version === 11 && journal.interruptHook.storage === "toml"
+      ? restoreCodexInterruptHook(text, journal.interruptHook)
+      : journal.version === 11
+        ? restoreCodexInterruptHookTrust(text, {
+          stateKey: journal.interruptHook.stateKey,
+          trustedHash: journal.interruptHook.trustedHash,
+          fragment: (journal.interruptHook as InstalledCodexInterruptHookJson).trustFragment,
+        })
+        : text;
   const document = parseDocument(withoutHook);
   removeManagedComment(document);
   const currentBaseUrl = findTopLevelAssignment(document.lines, "openai_base_url");
@@ -445,7 +484,7 @@ export function restoreManagedRoute(text: string, journal: ManagedRouteJournal):
   } else {
     removeDocumentLine(document, currentBaseUrl.index);
   }
-  if (journal.version === 9 || journal.version === 10) {
+  if (journal.version === 9 || journal.version === 10 || journal.version === 11) {
     const currentRealtime = findTopLevelAssignment(document.lines, "experimental_realtime_webrtc_call_base_url");
     if (currentRealtime.index === undefined) throw new Error("Managed Codex realtime WebRTC call route is missing");
     const previousRealtime = journal.previousRealtimeWebrtcCallBaseUrl;
@@ -458,7 +497,7 @@ export function restoreManagedRoute(text: string, journal: ManagedRouteJournal):
       removeDocumentLine(document, currentRealtime.index);
     }
   }
-  if (journal.version !== 7 && journal.version !== 8 && journal.version !== 9 && journal.version !== 10) {
+  if (journal.version !== 7 && journal.version !== 8 && journal.version !== 9 && journal.version !== 10 && journal.version !== 11) {
     const removedAssignments = (["model_provider", "model_catalog_json"] as const)
       .map(key => ({ key, previous: journal.previous[key] }))
       .filter(item => item.previous.present)
@@ -470,7 +509,7 @@ export function restoreManagedRoute(text: string, journal: ManagedRouteJournal):
     }
   }
   const restoredRoute = renderDocument(document);
-  if (journal.version === 8 || journal.version === 9 || journal.version === 10) {
+  if (journal.version === 8 || journal.version === 9 || journal.version === 10 || journal.version === 11) {
     const evidence = compatibilityV1Evidence(journal);
     return evidence
       ? restoreCompatibilityV1Features(

--- a/src/codex-integration-shared.ts
+++ b/src/codex-integration-shared.ts
@@ -50,7 +50,45 @@ export interface InstalledCodexInterruptHook {
   fragment: string;
 }
 
+export interface InstalledCodexInterruptHookJson {
+  storage: "json";
+  command: string;
+  hooksPath: string;
+  groupIndex: number;
+  hookIndex: number;
+  entryHash: string;
+  stateKey: string;
+  trustedHash: string;
+  trustFragment: string;
+}
+
+export interface InstalledCodexInterruptHookToml extends InstalledCodexInterruptHook {
+  storage: "toml";
+}
+
 export interface CodexIntegrationJournal {
+  version: 11;
+  active: boolean;
+  configPath: string;
+  installed: {
+    openai_base_url: string;
+    experimental_realtime_webrtc_call_base_url: string;
+    subagent_protocol: SubagentProtocol;
+    agent_max_depth?: number;
+  };
+  previous: Record<ManagedAssignmentKey, PreviousAssignment>;
+  previousRealtimeWebrtcCallBaseUrl: PreviousAssignment;
+  interruptHook: InstalledCodexInterruptHookToml | InstalledCodexInterruptHookJson;
+  previousMultiAgent?: PreviousFeatureAssignment;
+  previousMultiAgentV2?: PreviousFeatureAssignment;
+  previousAgentMaxDepth?: PreviousAgentAssignment;
+  format?: {
+    lineEnding: "\n" | "\r\n" | "\r";
+    trailingNewline: boolean;
+  };
+}
+
+export interface LegacyCodexIntegrationJournalV10 {
   version: 10;
   active: boolean;
   configPath: string;
@@ -209,6 +247,7 @@ export interface LegacyCodexIntegrationJournal {
 
 export type ManagedRouteJournal =
   | CodexIntegrationJournal
+  | LegacyCodexIntegrationJournalV10
   | LegacyCodexIntegrationJournalV9
   | LegacyCodexIntegrationJournalV8
   | LegacyCodexIntegrationJournalV7
@@ -249,6 +288,10 @@ export function getCodexHome(): string {
 
 export function getCodexConfigPath(): string {
   return join(getCodexHome(), "config.toml");
+}
+
+export function getCodexHooksPath(): string {
+  return join(getCodexHome(), "hooks.json");
 }
 
 export function getCodexModelsCachePath(): string {
@@ -351,6 +394,7 @@ export function writeIntegrationState(
   journal: AnyCodexIntegrationJournal,
   configWrite?: { path: string; data: string },
   removals: string[] = [],
+  additionalWrites: Array<{ path: string; data: string; followSymlink?: boolean }> = [],
 ): void {
   const data = serializeJournal(journal);
   // The recovery copy records intent and the primary copy records commit. If the process stops
@@ -358,6 +402,7 @@ export function writeIntegrationState(
   writeFilesWithCompensation([
     { path: getCodexJournalRecoveryPath(), data },
     ...(configWrite ? [{ ...configWrite, followSymlink: true }] : []),
+    ...additionalWrites.map(write => ({ ...write, followSymlink: write.followSymlink ?? true })),
     { path: getCodexJournalPath(), data },
   ], removals);
 }

--- a/src/codex-integration.ts
+++ b/src/codex-integration.ts
@@ -5,7 +5,7 @@ import { getConfigPath, loadConfig, saveConfig } from "./config";
 import {
   codexInterruptHookCommand,
   codexInterruptHookHash,
-  codexInterruptHookStateKey,
+  codexJsonInterruptHookStateKey,
   installCodexInterruptHook,
   installCodexInterruptHookCommand,
   installCodexInterruptHookTrust,
@@ -109,7 +109,7 @@ function installConfiguredRoute(
     : codexInterruptHookCommand(config);
   if (hooksJson) {
     const hook = installCodexInterruptHookJson(hooksJson.text, command);
-    const stateKey = codexInterruptHookStateKey(hooksJson.path, hook.installed.groupIndex, hook.installed.hookIndex);
+    const stateKey = codexJsonInterruptHookStateKey(hooksJson.path, hook.installed.groupIndex, hook.installed.hookIndex);
     const trust = installCodexInterruptHookTrust(configured.text, stateKey, codexInterruptHookHash(command));
     return {
       ...configured,

--- a/src/codex-integration.ts
+++ b/src/codex-integration.ts
@@ -2,10 +2,24 @@ import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { dirname } from "node:path";
 import type { AppConfig } from "./config";
 import { getConfigPath, loadConfig, saveConfig } from "./config";
-import { installCodexInterruptHook, installCodexInterruptHookCommand } from "./codex-interrupt-hook";
+import {
+  codexInterruptHookCommand,
+  codexInterruptHookHash,
+  codexInterruptHookStateKey,
+  installCodexInterruptHook,
+  installCodexInterruptHookCommand,
+  installCodexInterruptHookTrust,
+  verifyCodexInterruptHook,
+} from "./codex-interrupt-hook";
+import {
+  installCodexInterruptHookJson,
+  restoreCodexInterruptHookJson,
+  verifyCodexInterruptHookJson,
+} from "./codex-interrupt-hook-json";
 import {
   CODEX_REALTIME_WEBRTC_CALL_BASE_URL,
   getCodexConfigPath,
+  getCodexHooksPath,
   getCodexJournalPath,
   getCodexJournalRecoveryPath,
   getCodexModelsCachePath,
@@ -26,6 +40,7 @@ import type {
   LegacyCodexIntegrationJournalV7,
   LegacyCodexIntegrationJournalV8,
   LegacyCodexIntegrationJournalV9,
+  LegacyCodexIntegrationJournalV10,
   SetCodexIntegrationActiveResult,
   UninstallCodexIntegrationResult,
 } from "./codex-integration-shared";
@@ -57,6 +72,7 @@ function installConfiguredRoute(
   ),
   replaceExistingRoute: boolean,
   replaceExistingRealtimeRoute: boolean,
+  hooksJson?: { path: string; text: string },
 ): {
   text: string;
   previous: CodexIntegrationJournal["previous"];
@@ -66,6 +82,7 @@ function installConfiguredRoute(
   previousAgentMaxDepth?: CodexIntegrationJournal["previousAgentMaxDepth"];
   installedAgentMaxDepth?: number;
   interruptHook: CodexIntegrationJournal["interruptHook"];
+  hooksText?: string;
 } {
   const route = installRoute(
     baseline,
@@ -87,20 +104,108 @@ function installConfiguredRoute(
         };
       })()
     : route;
+  const command = "interruptHookCommand" in config
+    ? config.interruptHookCommand
+    : codexInterruptHookCommand(config);
+  if (hooksJson) {
+    const hook = installCodexInterruptHookJson(hooksJson.text, command);
+    const stateKey = codexInterruptHookStateKey(hooksJson.path, hook.installed.groupIndex, hook.installed.hookIndex);
+    const trust = installCodexInterruptHookTrust(configured.text, stateKey, codexInterruptHookHash(command));
+    return {
+      ...configured,
+      text: trust.text,
+      hooksText: hook.text,
+      interruptHook: {
+        storage: "json",
+        command,
+        hooksPath: hooksJson.path,
+        groupIndex: hook.installed.groupIndex,
+        hookIndex: hook.installed.hookIndex,
+        entryHash: hook.installed.entryHash,
+        stateKey,
+        trustedHash: trust.installed.trustedHash,
+        trustFragment: trust.installed.fragment,
+      },
+    };
+  }
   const hook = "interruptHookCommand" in config
-    ? installCodexInterruptHookCommand(configured.text, getCodexConfigPath(), config.interruptHookCommand)
+    ? installCodexInterruptHookCommand(configured.text, getCodexConfigPath(), command)
     : installCodexInterruptHook(configured.text, getCodexConfigPath(), config);
-  return { ...configured, text: hook.text, interruptHook: hook.installed };
+  return { ...configured, text: hook.text, interruptHook: { ...hook.installed, storage: "toml" } };
+}
+
+function currentHooksJson(): { path: string; text: string } | undefined {
+  const path = getCodexHooksPath();
+  if (!existsSync(path)) {
+    return undefined;
+  }
+  return { path, text: readFileSync(path, "utf8") };
+}
+
+function verifyManagedJsonHook(journal: CodexIntegrationJournal): void {
+  if (journal.interruptHook.storage !== "json") {
+    return;
+  }
+  if (!existsSync(journal.interruptHook.hooksPath)) {
+    throw new Error(`Codex hooks JSON is missing: ${journal.interruptHook.hooksPath}`);
+  }
+  verifyCodexInterruptHookJson(readFileSync(journal.interruptHook.hooksPath, "utf8"), {
+    ...journal.interruptHook,
+    mode: "json",
+  });
+}
+
+function restoreManagedJsonHook(journal: CodexIntegrationJournal): { path: string; text: string } | undefined {
+  if (journal.interruptHook.storage !== "json") {
+    return undefined;
+  }
+  verifyManagedJsonHook(journal);
+  return {
+    path: journal.interruptHook.hooksPath,
+    text: restoreCodexInterruptHookJson(readFileSync(journal.interruptHook.hooksPath, "utf8"), {
+      ...journal.interruptHook,
+      mode: "json",
+    }),
+  };
+}
+
+function tomlInterruptHookIsFullyAbsent(text: string, stateKey: string): boolean {
+  try {
+    assertValidCodexToml(text);
+    const parsed = Bun.TOML.parse(text) as { hooks?: unknown };
+    if (parsed.hooks === undefined) {
+      return true;
+    }
+    if (!parsed.hooks || typeof parsed.hooks !== "object" || Array.isArray(parsed.hooks)) {
+      return false;
+    }
+    const hooks = parsed.hooks as Record<string, unknown>;
+    if (hooks.Interrupt !== undefined) {
+      return false;
+    }
+    if (hooks.state === undefined) {
+      return true;
+    }
+    return typeof hooks.state === "object" && hooks.state !== null && !Array.isArray(hooks.state)
+      && !Object.hasOwn(hooks.state, stateKey);
+  } catch {
+    return false;
+  }
+}
+
+function assertValidCodexToml(text: string): void {
+  Bun.TOML.parse(text);
 }
 
 function journalProtocol(journal: Exclude<AnyCodexIntegrationJournal, { version: 2 }>): AppConfig["subagentProtocol"] {
-  return journal.version === 8 || journal.version === 9 || journal.version === 10
+  return journal.version === 8 || journal.version === 9 || journal.version === 10 || journal.version === 11
     ? journal.installed.subagent_protocol
     : "native";
 }
 
 export {
   getCodexConfigPath,
+  getCodexHooksPath,
   getCodexHome,
   getCodexJournalPath,
   getCodexJournalRecoveryPath,
@@ -119,7 +224,7 @@ export function readCodexSubagentProtocol(
   fallback: AppConfig["subagentProtocol"] = "compatibility-v1",
 ): AppConfig["subagentProtocol"] {
   const journal = readJournal();
-  return journal?.version === 8 || journal?.version === 9 || journal?.version === 10
+  return journal?.version === 8 || journal?.version === 9 || journal?.version === 10 || journal?.version === 11
     ? journal.installed.subagent_protocol
     : fallback;
 }
@@ -140,10 +245,13 @@ export function setCodexSubagentProtocol(
   const snapshots = [
     getConfigPath(),
     getCodexConfigPath(),
+    getCodexHooksPath(),
     getCodexModelsCachePath(),
     getCodexJournalPath(),
     getCodexJournalRecoveryPath(),
-  ].map(path => snapshotFile(path, { followSymlink: path === getCodexConfigPath() }));
+  ].map(path => snapshotFile(path, {
+    followSymlink: path === getCodexConfigPath() || path === getCodexHooksPath(),
+  }));
   try {
     const journal = installCodexIntegration(nextConfig);
     saveConfig(nextConfig);
@@ -176,18 +284,33 @@ export function preflightCodexIntegration(
   const currentText = configSnapshot.data?.toString("utf8") ?? "";
   const existing = readJournal();
   const installedUrl = routeUrl(config);
+  let hooksJson = currentHooksJson();
   if (existing) assertJournalTargetsConfig(existing, configPath);
   if (existing && existing.version !== 2) {
     if (!configExists) {
       if (options.replaceExistingRoute !== true) {
         throw new Error(`Codex config is missing: ${configPath}`);
       }
-      installConfiguredRoute("", installedUrl, config, true, true);
+      installConfiguredRoute("", installedUrl, config, true, true, hooksJson);
       return;
     }
     try {
       verifyManagedJournalState(currentText, existing);
+      assertValidCodexToml(currentText);
+      if (existing.version === 11 && existing.active) {
+        verifyManagedJsonHook(existing);
+        if (managedJournalIsActive(existing)) {
+          hooksJson = restoreManagedJsonHook(existing) ?? hooksJson;
+        }
+      }
     } catch (error) {
+      if (existing.version === 11 && existing.interruptHook.storage === "json") throw error;
+      if (existing.version === 11 && existing.interruptHook.storage === "toml") {
+        if (!tomlInterruptHookIsFullyAbsent(currentText, existing.interruptHook.stateKey)) {
+          verifyCodexInterruptHook(currentText, existing.interruptHook);
+          assertValidCodexToml(currentText);
+        }
+      }
       if (options.replaceExistingRoute !== true) throw error;
       installConfiguredRoute(
         replacementBaseline(currentText, configExists, existing),
@@ -195,10 +318,11 @@ export function preflightCodexIntegration(
         config,
         true,
         true,
+        hooksJson,
       );
       return;
     }
-    if (existing.version === 10) return;
+    if ((existing.version === 10 || existing.version === 11) && existing.active) return;
     const baseline = managedJournalIsActive(existing)
       ? restoreManagedRoute(currentText, existing)
       : currentText;
@@ -208,6 +332,7 @@ export function preflightCodexIntegration(
       config,
       true,
       options.replaceExistingRoute === true,
+      hooksJson,
     );
     return;
   }
@@ -224,6 +349,7 @@ export function preflightCodexIntegration(
     config,
     options.replaceExistingRoute === true,
     options.replaceExistingRoute === true,
+    hooksJson,
   );
 }
 export function installCodexIntegration(
@@ -236,6 +362,7 @@ export function installCodexIntegration(
   const currentText = configExists ? readFileSync(configPath, "utf8") : "";
   const existing = readJournal();
   const installedUrl = routeUrl(config);
+  let hooksJson = currentHooksJson();
   if (existing) assertJournalTargetsConfig(existing, configPath);
 
   const hasManagedJournal = Boolean(existing && existing.version !== 2);
@@ -248,10 +375,26 @@ export function installCodexIntegration(
     let preservePrevious = true;
     try {
       verifyManagedJournalState(currentText, existing);
+      assertValidCodexToml(currentText);
+      if (existing.version === 11 && existing.active) {
+        verifyManagedJsonHook(existing);
+      }
       baseline = managedJournalIsActive(existing)
         ? restoreManagedRoute(currentText, existing)
         : currentText;
+      if (existing.version === 11 && managedJournalIsActive(existing)) {
+        hooksJson = restoreManagedJsonHook(existing) ?? hooksJson;
+      }
     } catch (error) {
+      if (existing.version === 11 && existing.interruptHook.storage === "json") {
+        throw error;
+      }
+      if (existing.version === 11 && existing.interruptHook.storage === "toml") {
+        if (!tomlInterruptHookIsFullyAbsent(currentText, existing.interruptHook.stateKey)) {
+          verifyCodexInterruptHook(currentText, existing.interruptHook);
+          assertValidCodexToml(currentText);
+        }
+      }
       if (options.replaceExistingRoute !== true) throw error;
       baseline = replacementBaseline(currentText, configExists, existing);
       preservePrevious = false;
@@ -261,11 +404,12 @@ export function installCodexIntegration(
       installedUrl,
       config,
       true,
-      !preservePrevious || existing.version === 9 || existing.version === 10 || options.replaceExistingRoute === true,
+      !preservePrevious || existing.version === 9 || existing.version === 10 || existing.version === 11 || options.replaceExistingRoute === true,
+      hooksJson,
     );
     if (preservePrevious) {
       assertPreservedPreviousAssignments(patched.previous, existing.previous);
-      if (existing.version === 9 || existing.version === 10) {
+      if (existing.version === 9 || existing.version === 10 || existing.version === 11) {
         assertPreservedPreviousRealtimeAssignment(
           patched.previousRealtimeWebrtcCallBaseUrl,
           existing.previousRealtimeWebrtcCallBaseUrl,
@@ -273,7 +417,7 @@ export function installCodexIntegration(
       }
     }
     const updated: CodexIntegrationJournal = {
-      version: 10,
+      version: 11,
       active: true,
       configPath,
       installed: {
@@ -285,7 +429,7 @@ export function installCodexIntegration(
         } : {}),
       },
       previous: preservePrevious ? existing.previous : patched.previous,
-      previousRealtimeWebrtcCallBaseUrl: preservePrevious && (existing.version === 9 || existing.version === 10)
+      previousRealtimeWebrtcCallBaseUrl: preservePrevious && (existing.version === 9 || existing.version === 10 || existing.version === 11)
         ? existing.previousRealtimeWebrtcCallBaseUrl
         : patched.previousRealtimeWebrtcCallBaseUrl,
       interruptHook: patched.interruptHook,
@@ -296,7 +440,12 @@ export function installCodexIntegration(
       } : {}),
       ...(existing.format ? { format: existing.format } : {}),
     };
-    writeIntegrationState(updated, { path: configPath, data: patched.text }, [getCodexModelsCachePath()]);
+    writeIntegrationState(
+      updated,
+      { path: configPath, data: patched.text },
+      [getCodexModelsCachePath()],
+      patched.hooksText && hooksJson ? [{ path: hooksJson.path, data: patched.hooksText, followSymlink: true }] : [],
+    );
     return updated;
   }
 
@@ -313,9 +462,10 @@ export function installCodexIntegration(
     config,
     options.replaceExistingRoute === true,
     options.replaceExistingRoute === true,
+    hooksJson,
   );
   const journal: CodexIntegrationJournal = {
-    version: 10,
+    version: 11,
     active: true,
     configPath,
     installed: {
@@ -336,7 +486,12 @@ export function installCodexIntegration(
     } : {}),
     format: textFormat(baseline),
   };
-  writeIntegrationState(journal, { path: configPath, data: patched.text }, [getCodexModelsCachePath()]);
+  writeIntegrationState(
+    journal,
+    { path: configPath, data: patched.text },
+    [getCodexModelsCachePath()],
+    patched.hooksText && hooksJson ? [{ path: hooksJson.path, data: patched.hooksText, followSymlink: true }] : [],
+  );
   if (existing?.version === 2 && existsSync(existing.catalogPath)) rmSync(existing.catalogPath);
   return journal;
 }
@@ -350,23 +505,33 @@ export function deactivateCodexIntegration(): SetCodexIntegrationActiveResult {
   assertJournalTargetsConfig(existing, getCodexConfigPath());
   if (!existsSync(existing.configPath)) throw new Error(`Codex config is missing: ${existing.configPath}`);
   const current = readFileSync(existing.configPath, "utf8");
-  if ((existing.version === 4 || existing.version === 5 || existing.version === 6 || existing.version === 7 || existing.version === 8 || existing.version === 9 || existing.version === 10) && !existing.active) {
+  if ((existing.version === 4 || existing.version === 5 || existing.version === 6 || existing.version === 7 || existing.version === 8 || existing.version === 9 || existing.version === 10 || existing.version === 11) && !existing.active) {
     verifyRestoredRoute(current, existing);
     return { changed: false, active: false };
+  }
+  if (existing.version === 11) {
+    verifyManagedJsonHook(existing);
   }
   const restored = restoreManagedRoute(current, existing);
   const disconnected:
     | CodexIntegrationJournal
+    | LegacyCodexIntegrationJournalV10
     | LegacyCodexIntegrationJournalV9
     | LegacyCodexIntegrationJournalV8
     | LegacyCodexIntegrationJournalV6
     | LegacyCodexIntegrationJournalV7
     | LegacyCodexIntegrationJournalV5
     | LegacyCodexIntegrationJournalV4 = existing.version === 6 || existing.version === 5
-      || existing.version === 7 || existing.version === 8 || existing.version === 9 || existing.version === 10
+      || existing.version === 7 || existing.version === 8 || existing.version === 9 || existing.version === 10 || existing.version === 11
       ? { ...existing, active: false }
       : { ...existing, version: 4, active: false };
-  writeIntegrationState(disconnected, { path: existing.configPath, data: restored }, [getCodexModelsCachePath()]);
+  const restoredHooks = existing.version === 11 ? restoreManagedJsonHook(existing) : undefined;
+  writeIntegrationState(
+    disconnected,
+    { path: existing.configPath, data: restored },
+    [getCodexModelsCachePath()],
+    restoredHooks ? [{ path: restoredHooks.path, data: restoredHooks.text, followSymlink: true }] : [],
+  );
   return { changed: true, active: false };
 }
 
@@ -379,12 +544,15 @@ export function activateCodexIntegration(): SetCodexIntegrationActiveResult {
   assertJournalTargetsConfig(existing, getCodexConfigPath());
   if (!existsSync(existing.configPath)) throw new Error(`Codex config is missing: ${existing.configPath}`);
   const current = readFileSync(existing.configPath, "utf8");
-  if (existing.version === 10 && existing.active) {
+  if ((existing.version === 10 || existing.version === 11) && existing.active) {
     verifyInstalledRoute(current, existing);
+    if (existing.version === 11) {
+      verifyManagedJsonHook(existing);
+    }
     return { changed: false, active: true };
   }
   let baseline: string;
-  if ((existing.version === 4 || existing.version === 5 || existing.version === 6 || existing.version === 7 || existing.version === 8 || existing.version === 9 || existing.version === 10) && !existing.active) {
+  if ((existing.version === 4 || existing.version === 5 || existing.version === 6 || existing.version === 7 || existing.version === 8 || existing.version === 9 || existing.version === 10 || existing.version === 11) && !existing.active) {
     verifyRestoredRoute(current, existing);
     baseline = current;
   } else {
@@ -392,25 +560,27 @@ export function activateCodexIntegration(): SetCodexIntegrationActiveResult {
     baseline = restoreManagedRoute(current, existing);
   }
   const protocol = journalProtocol(existing);
-  const hookConfig = existing.version === 10
+  const hookConfig = existing.version === 10 || existing.version === 11
     ? { interruptHookCommand: existing.interruptHook.command }
     : { runtimeCommand: loadConfig().runtimeCommand };
+  const hooksJson = currentHooksJson();
   const route = installConfiguredRoute(
     baseline,
     existing.installed.openai_base_url,
     { subagentProtocol: protocol, ...hookConfig },
     true,
-    existing.version === 9 || existing.version === 10,
+    existing.version === 9 || existing.version === 10 || existing.version === 11,
+    hooksJson,
   );
   assertPreservedPreviousAssignments(route.previous, existing.previous);
-  if (existing.version === 9 || existing.version === 10) {
+  if (existing.version === 9 || existing.version === 10 || existing.version === 11) {
     assertPreservedPreviousRealtimeAssignment(
       route.previousRealtimeWebrtcCallBaseUrl,
       existing.previousRealtimeWebrtcCallBaseUrl,
     );
   }
   const connected: CodexIntegrationJournal = {
-    version: 10,
+    version: 11,
     active: true,
     configPath: existing.configPath,
     installed: {
@@ -422,7 +592,7 @@ export function activateCodexIntegration(): SetCodexIntegrationActiveResult {
       } : {}),
     },
     previous: existing.previous,
-    previousRealtimeWebrtcCallBaseUrl: existing.version === 9 || existing.version === 10
+    previousRealtimeWebrtcCallBaseUrl: existing.version === 9 || existing.version === 10 || existing.version === 11
       ? existing.previousRealtimeWebrtcCallBaseUrl
       : route.previousRealtimeWebrtcCallBaseUrl,
     interruptHook: route.interruptHook,
@@ -433,13 +603,22 @@ export function activateCodexIntegration(): SetCodexIntegrationActiveResult {
     } : {}),
     ...(existing.format ? { format: existing.format } : {}),
   };
-  writeIntegrationState(connected, { path: existing.configPath, data: route.text }, [getCodexModelsCachePath()]);
+  writeIntegrationState(
+    connected,
+    { path: existing.configPath, data: route.text },
+    [getCodexModelsCachePath()],
+    route.hooksText && hooksJson ? [{ path: hooksJson.path, data: route.hooksText, followSymlink: true }] : [],
+  );
   return { changed: true, active: true };
 }
 
 export function uninstallCodexIntegration(): UninstallCodexIntegrationResult {
   const journal = readJournal();
   if (!journal) return { changed: false };
+  if (journal.version === 11 && journal.active) {
+    deactivateCodexIntegration();
+    return uninstallCodexIntegration();
+  }
   if (!existsSync(journal.configPath)) throw new Error(`Codex config is missing: ${journal.configPath}`);
   const current = readFileSync(journal.configPath, "utf8");
   let restored: string;
@@ -448,26 +627,32 @@ export function uninstallCodexIntegration(): UninstallCodexIntegrationResult {
       throw new Error(`Managed legacy catalog changed after setup: ${journal.catalogPath}`);
     }
     restored = restoreLegacyV2(current, journal);
-  } else if ((journal.version === 4 || journal.version === 5 || journal.version === 6 || journal.version === 7 || journal.version === 8 || journal.version === 9 || journal.version === 10) && !journal.active) {
+  } else if ((journal.version === 4 || journal.version === 5 || journal.version === 6 || journal.version === 7 || journal.version === 8 || journal.version === 9 || journal.version === 10 || journal.version === 11) && !journal.active) {
     verifyRestoredRoute(current, journal);
     restored = current;
   } else {
+    if (journal.version === 11) {
+      verifyManagedJsonHook(journal);
+    }
     restored = restoreManagedRoute(current, journal);
   }
+  const restoredHooks = journal.version === 11 && journal.active ? restoreManagedJsonHook(journal) : undefined;
   const configSnapshot = snapshotFile(journal.configPath, { followSymlink: true });
+  const hooksSnapshot = restoredHooks ? snapshotFile(restoredHooks.path, { followSymlink: true }) : undefined;
   const catalogSnapshot = journal.version === 2 ? snapshotFile(journal.catalogPath) : undefined;
   const modelsCacheSnapshot = snapshotFile(getCodexModelsCachePath());
   const journalSnapshot = snapshotFile(getCodexJournalPath());
   const recoverySnapshot = snapshotFile(getCodexJournalRecoveryPath());
   try {
     writeFileSnapshot(configSnapshot, restored);
+    if (restoredHooks && hooksSnapshot) writeFileSnapshot(hooksSnapshot, restoredHooks.text);
     if (catalogSnapshot?.exists) rmSync(catalogSnapshot.path);
     rmSync(modelsCacheSnapshot.path, { force: true });
     rmSync(getCodexJournalPath(), { force: true });
     rmSync(getCodexJournalRecoveryPath(), { force: true });
   } catch (error) {
     const rollbackFailures: string[] = [];
-    for (const snapshot of [recoverySnapshot, journalSnapshot, modelsCacheSnapshot, catalogSnapshot, configSnapshot]) {
+    for (const snapshot of [recoverySnapshot, journalSnapshot, modelsCacheSnapshot, catalogSnapshot, hooksSnapshot, configSnapshot]) {
       if (!snapshot) continue;
       try {
         restoreFileSnapshot(snapshot);
@@ -497,11 +682,14 @@ export function inspectCodexIntegration(): {
     try {
       assertJournalTargetsConfig(journal, getCodexConfigPath());
       const text = readFileSync(journal.configPath, "utf8");
-      if ((journal.version === 4 || journal.version === 5 || journal.version === 6 || journal.version === 7 || journal.version === 8 || journal.version === 9 || journal.version === 10) && !journal.active) {
+      if ((journal.version === 4 || journal.version === 5 || journal.version === 6 || journal.version === 7 || journal.version === 8 || journal.version === 9 || journal.version === 10 || journal.version === 11) && !journal.active) {
         verifyRestoredRoute(text, journal);
       }
-      else if (journal.version === 3 || journal.version === 4 || journal.version === 5 || journal.version === 6 || journal.version === 7 || journal.version === 8 || journal.version === 9 || journal.version === 10) {
+      else if (journal.version === 3 || journal.version === 4 || journal.version === 5 || journal.version === 6 || journal.version === 7 || journal.version === 8 || journal.version === 9 || journal.version === 10 || journal.version === 11) {
         verifyInstalledRoute(text, journal);
+        if (journal.version === 11) {
+          verifyManagedJsonHook(journal);
+        }
       }
       else {
         const lines = splitLines(text);
@@ -518,11 +706,11 @@ export function inspectCodexIntegration(): {
   }
   return {
     installed: Boolean(journal),
-    active: journal?.version === 4 || journal?.version === 5 || journal?.version === 6 || journal?.version === 7 || journal?.version === 8 || journal?.version === 9 || journal?.version === 10
+    active: journal?.version === 4 || journal?.version === 5 || journal?.version === 6 || journal?.version === 7 || journal?.version === 8 || journal?.version === 9 || journal?.version === 10 || journal?.version === 11
       ? journal.active
       : Boolean(journal),
     configPath: getCodexConfigPath(),
-    ...(journal?.version === 3 || journal?.version === 4 || journal?.version === 5 || journal?.version === 6 || journal?.version === 7 || journal?.version === 8 || journal?.version === 9 || journal?.version === 10
+    ...(journal?.version === 3 || journal?.version === 4 || journal?.version === 5 || journal?.version === 6 || journal?.version === 7 || journal?.version === 8 || journal?.version === 9 || journal?.version === 10 || journal?.version === 11
       ? { routeUrl: journal.installed.openai_base_url }
       : {}),
     ...(journal ? { journal } : {}),

--- a/src/codex-interrupt-hook-json.ts
+++ b/src/codex-interrupt-hook-json.ts
@@ -1,0 +1,209 @@
+import { createHash } from "node:crypto";
+
+type JsonObject = Record<string, unknown>;
+
+export interface InstalledCodexInterruptHookJson {
+  mode: "json";
+  command: string;
+  groupIndex: number;
+  hookIndex: number;
+  entryHash: string;
+}
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function canonicalJson(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalJson);
+  }
+  if (!isJsonObject(value)) {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, item]) => [key, canonicalJson(item)]),
+  );
+}
+
+function unsupportedShape(message: string): never {
+  throw new Error(`Codex hooks.json has an unsupported shape: ${message}`);
+}
+
+function parseHooksJson(text: string): JsonObject {
+  let document: unknown;
+  try {
+    document = JSON.parse(text);
+  } catch {
+    throw new Error("Codex hooks.json is malformed JSON");
+  }
+  if (!isJsonObject(document)) {
+    unsupportedShape("the root value must be an object");
+  }
+  if (document.hooks === undefined) {
+    return document;
+  }
+  if (!isJsonObject(document.hooks)) {
+    unsupportedShape("hooks must be an object");
+  }
+  for (const [eventName, groups] of Object.entries(document.hooks)) {
+    if (!Array.isArray(groups)) {
+      unsupportedShape(`hooks.${eventName} must be an array`);
+    }
+    for (const group of groups) {
+      if (!isJsonObject(group)) {
+        unsupportedShape(`hooks.${eventName} groups must be objects`);
+      }
+      if (!Array.isArray(group.hooks)) {
+        unsupportedShape(`hooks.${eventName} groups must contain a hooks array`);
+      }
+      for (const hook of group.hooks) {
+        if (!isJsonObject(hook) || typeof hook.type !== "string") {
+          unsupportedShape(`hooks.${eventName} hook entries must have a string type`);
+        }
+        if (hook.type === "command" && (typeof hook.command !== "string" || hook.command.length === 0)) {
+          unsupportedShape(`hooks.${eventName} command hook entries must have a non-empty command`);
+        }
+        if (hook.timeout !== undefined && (typeof hook.timeout !== "number" || !Number.isFinite(hook.timeout))) {
+          unsupportedShape(`hooks.${eventName} hook entry timeouts must be finite numbers`);
+        }
+      }
+    }
+  }
+  return document;
+}
+
+function interruptGroups(document: JsonObject): JsonObject[] | undefined {
+  if (document.hooks === undefined) {
+    return undefined;
+  }
+  const hooks = document.hooks as JsonObject;
+  if (hooks.Interrupt === undefined) {
+    return undefined;
+  }
+  return hooks.Interrupt as JsonObject[];
+}
+
+function commandEntry(command: string): JsonObject {
+  return { type: "command", command, timeout: 3 };
+}
+
+function entryHash(entry: JsonObject): string {
+  const serialized = JSON.stringify(canonicalJson(entry));
+  return `sha256:${createHash("sha256").update(serialized).digest("hex")}`;
+}
+
+function serializeHooksJson(document: JsonObject): string {
+  return `${JSON.stringify(document, null, 2)}\n`;
+}
+
+function assertInstalledRecord(installed: InstalledCodexInterruptHookJson): void {
+  if (
+    installed.mode !== "json"
+    || typeof installed.command !== "string"
+    || installed.command.length === 0
+    || !Number.isSafeInteger(installed.groupIndex)
+    || installed.groupIndex < 0
+    || !Number.isSafeInteger(installed.hookIndex)
+    || installed.hookIndex < 0
+    || !/^sha256:[a-f0-9]{64}$/.test(installed.entryHash)
+  ) {
+    throw new Error("Codex JSON interrupt hook journal entry is invalid");
+  }
+  if (entryHash(commandEntry(installed.command)) !== installed.entryHash) {
+    throw new Error("Codex JSON interrupt hook journal entry does not match its command");
+  }
+}
+
+function locateInstalledHook(
+  text: string,
+  installed: InstalledCodexInterruptHookJson,
+): { document: JsonObject; groups: JsonObject[]; hooks: JsonObject[] } {
+  assertInstalledRecord(installed);
+  const document = parseHooksJson(text);
+  const groups = interruptGroups(document);
+  if (!groups || installed.groupIndex >= groups.length) {
+    throw new Error("Codex JSON interrupt lifecycle hook changed after setup; refusing to overwrite it");
+  }
+  const group = groups[installed.groupIndex];
+  const hooks = group.hooks as JsonObject[];
+  if (installed.hookIndex >= hooks.length || entryHash(hooks[installed.hookIndex]) !== installed.entryHash) {
+    throw new Error("Codex JSON interrupt lifecycle hook changed after setup; refusing to overwrite it");
+  }
+  const occurrences = groups.flatMap(candidate => candidate.hooks as JsonObject[])
+    .filter(candidate => entryHash(candidate) === installed.entryHash).length;
+  if (occurrences !== 1) {
+    throw new Error("Codex JSON interrupt lifecycle hook changed after setup; refusing to overwrite it");
+  }
+  return { document, groups, hooks };
+}
+
+export function installCodexInterruptHookJson(
+  text: string,
+  command: string,
+): { text: string; installed: InstalledCodexInterruptHookJson } {
+  if (command.length === 0) {
+    throw new Error("Codex JSON interrupt hook command must not be empty");
+  }
+  const document = parseHooksJson(text);
+  const existingGroups = interruptGroups(document) ?? [];
+  const groupIndex = existingGroups.length;
+  for (const group of existingGroups) {
+    for (const hook of group.hooks as JsonObject[]) {
+      if (hook.type === "command" && hook.command === command) {
+        throw new Error("Codex hooks.json already contains this codex-chatgpt-web interrupt command hook");
+      }
+    }
+  }
+  const entry = commandEntry(command);
+  const group = { hooks: [entry] };
+  if (document.hooks === undefined) {
+    document.hooks = { Interrupt: [group] };
+  } else {
+    const hooks = document.hooks as JsonObject;
+    if (hooks.Interrupt === undefined) {
+      hooks.Interrupt = [group];
+    } else {
+      (hooks.Interrupt as JsonObject[]).push(group);
+    }
+  }
+  return {
+    text: serializeHooksJson(document),
+    installed: {
+      mode: "json",
+      command,
+      groupIndex,
+      hookIndex: 0,
+      entryHash: entryHash(entry),
+    },
+  };
+}
+
+export function verifyCodexInterruptHookJson(
+  text: string,
+  installed: InstalledCodexInterruptHookJson,
+): void {
+  locateInstalledHook(text, installed);
+}
+
+export function restoreCodexInterruptHookJson(
+  text: string,
+  installed: InstalledCodexInterruptHookJson,
+): string {
+  const { document, groups, hooks } = locateInstalledHook(text, installed);
+  hooks.splice(installed.hookIndex, 1);
+  const group = groups[installed.groupIndex];
+  if (hooks.length === 0 && Object.keys(group).length === 1) {
+    groups.splice(installed.groupIndex, 1);
+  }
+  if (groups.length === 0) {
+    const hookDefinitions = document.hooks as JsonObject;
+    delete hookDefinitions.Interrupt;
+    if (Object.keys(hookDefinitions).length === 0) {
+      delete document.hooks;
+    }
+  }
+  return serializeHooksJson(document);
+}

--- a/src/codex-interrupt-hook.ts
+++ b/src/codex-interrupt-hook.ts
@@ -90,6 +90,17 @@ export function codexInterruptHookStateKey(path: string, groupIndex: number, hoo
   return `${canonicalConfigPath(path)}:interrupt:${groupIndex}:${hookIndex}`;
 }
 
+export function codexJsonInterruptHookStateKey(path: string, groupIndex: number, hookIndex: number): string {
+  const absolute = resolve(path);
+  let sourcePath = absolute;
+  try {
+    sourcePath = join(realpathSync.native(dirname(absolute)), basename(absolute));
+  } catch {
+    // Codex uses the canonical hooks directory when it exists, but must also support first-time paths.
+  }
+  return `${sourcePath}:interrupt:${groupIndex}:${hookIndex}`;
+}
+
 export function installCodexInterruptHook(
   text: string,
   configPath: string,
@@ -174,22 +185,107 @@ export function installCodexInterruptHookTrust(
   return { text: `${text}${fragment}`, installed: { stateKey, trustedHash, fragment } };
 }
 
-function locateCodexInterruptHookTrust(text: string, installed: InstalledCodexInterruptHookTrust): { start: number; end: number } {
+function locateCodexInterruptHookTrust(text: string, installed: InstalledCodexInterruptHookTrust): {
+  ranges: Array<{ start: number; end: number }>;
+} {
   if (!installed.stateKey || !/^sha256:[a-f0-9]{64}$/.test(installed.trustedHash) || !installed.fragment) {
     throw new Error("Codex JSON interrupt hook trust journal entry is invalid");
   }
-  const marker = installed.fragment.indexOf(MANAGED_INTERRUPT_HOOK_TRUST_END);
-  if (marker < 0) {
-    throw new Error("Codex JSON interrupt hook trust journal fragment is invalid");
-  }
-  const pattern = new RegExp(hookTextPattern(installed.fragment), "g");
-  const match = pattern.exec(text);
-  if (!match || pattern.exec(text)
-    || text.split(MANAGED_INTERRUPT_HOOK_TRUST_START).length !== 2
-    || text.split(MANAGED_INTERRUPT_HOOK_TRUST_END).length !== 2) {
+  const ending = lineEnding(text);
+  const lineRanges = (line: string, allowComment = false): Array<{ start: number; end: number }> => {
+    const suffix = allowComment ? "[ \\t]*(?:#.*)?" : "";
+    const pattern = new RegExp(`(^|\\r\\n|\\n|\\r)${line.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&")}${suffix}(?=\\r\\n|\\n|\\r|$)`, "g");
+    return [...text.matchAll(pattern)].map(match => {
+      const start = match.index! + (match[1]?.length ?? 0);
+      const lineEnd = start + match[0].length - (match[1]?.length ?? 0);
+      return { start, end: text.startsWith(ending, lineEnd) ? lineEnd + ending.length : lineEnd };
+    });
+  };
+  const lineRange = (line: string): { start: number; end: number } | undefined => {
+    const matches = lineRanges(line);
+    return matches.length === 1 ? matches[0] : undefined;
+  };
+  const startMarker = lineRange(MANAGED_INTERRUPT_HOOK_TRUST_START);
+  const endMarker = lineRange(MANAGED_INTERRUPT_HOOK_TRUST_END);
+  if (!startMarker || !endMarker) {
     throw new Error("Codex JSON interrupt hook trust changed after setup; refusing to overwrite it");
   }
-  return { start: match.index, end: match.index + match[0].length };
+  let parsed: { hooks?: { state?: Record<string, unknown> } };
+  try {
+    parsed = Bun.TOML.parse(text) as { hooks?: { state?: Record<string, unknown> } };
+    if (JSON.stringify(canonicalJson(parsed.hooks?.state?.[installed.stateKey]))
+      !== JSON.stringify({ trusted_hash: installed.trustedHash })) {
+      throw new Error("Trust state changed");
+    }
+  } catch {
+    throw new Error("Codex JSON interrupt hook trust changed after setup; refusing to overwrite it");
+  }
+  const markerPreservesTomlValues = (marker: { start: number; end: number }): boolean => {
+    try {
+      const withoutMarker = text.slice(0, marker.start) + text.slice(marker.end);
+      return JSON.stringify(canonicalJson(Bun.TOML.parse(text)))
+        === JSON.stringify(canonicalJson(Bun.TOML.parse(withoutMarker)));
+    } catch {
+      return false;
+    }
+  };
+  if (!markerPreservesTomlValues(startMarker) || !markerPreservesTomlValues(endMarker)) {
+    throw new Error("Codex JSON interrupt hook trust changed after setup; refusing to overwrite it");
+  }
+  const stateHeaders = lineRanges(`[hooks.state.${JSON.stringify(installed.stateKey)}]`, true);
+  const trustedHashes = lineRanges(`trusted_hash = ${JSON.stringify(installed.trustedHash)}`, true);
+  const expected = structuredClone(parsed) as { hooks?: { state?: Record<string, unknown> } };
+  delete expected.hooks?.state?.[installed.stateKey];
+  const expectedValues = [expected];
+  if (expected.hooks?.state && Object.keys(expected.hooks.state).length === 0) {
+    const withoutState = structuredClone(expected) as { hooks?: { state?: Record<string, unknown> } };
+    delete withoutState.hooks?.state;
+    expectedValues.push(withoutState);
+    if (withoutState.hooks && Object.keys(withoutState.hooks).length === 0) {
+      const withoutHooks = structuredClone(withoutState);
+      delete withoutHooks.hooks;
+      expectedValues.push(withoutHooks);
+    }
+  }
+  const stateTable = stateHeaders.flatMap(header => trustedHashes
+    .filter(hash => hash.start === header.end)
+    .filter(hash => {
+      try {
+        const withoutTable = text.slice(0, header.start) + text.slice(hash.end);
+        const actual = JSON.stringify(canonicalJson(Bun.TOML.parse(withoutTable)));
+        return expectedValues.some(expectedValue => actual === JSON.stringify(canonicalJson(expectedValue)));
+      } catch {
+        return false;
+      }
+    })
+    .map(hash => ({ header, hash })));
+  if (stateTable.length !== 1) {
+    throw new Error("Codex JSON interrupt hook trust changed after setup; refusing to overwrite it");
+  }
+  const { header: stateHeader, hash: trustedHash } = stateTable[0]!;
+  const adjustedStart = startMarker.start >= ending.length * 2
+    && text.startsWith(ending, startMarker.start - ending.length)
+    && text.startsWith(ending, startMarker.start - ending.length * 2)
+    ? startMarker.start - ending.length
+    : startMarker.start;
+  const rawRanges = [
+    { start: adjustedStart, end: startMarker.end },
+    { start: stateHeader.start, end: trustedHash.end },
+    endMarker,
+  ].sort((left, right) => left.start - right.start);
+  const ranges = rawRanges.reduce<Array<{ start: number; end: number }>>((merged, range) => {
+    const previous = merged.at(-1);
+    if (!previous || range.start >= previous.end) {
+      merged.push({ ...range });
+      return merged;
+    }
+    if (range.start < previous.end - ending.length) {
+      throw new Error("Codex JSON interrupt hook trust changed after setup; refusing to overwrite it");
+    }
+    previous.end = Math.max(previous.end, range.end);
+    return merged;
+  }, []);
+  return { ranges };
 }
 
 export function verifyCodexInterruptHookTrust(text: string, installed: InstalledCodexInterruptHookTrust): void {
@@ -198,7 +294,8 @@ export function verifyCodexInterruptHookTrust(text: string, installed: Installed
 
 export function restoreCodexInterruptHookTrust(text: string, installed: InstalledCodexInterruptHookTrust): string {
   const owned = locateCodexInterruptHookTrust(text, installed);
-  return text.slice(0, owned.start) + text.slice(owned.end);
+  return owned.ranges.sort((left, right) => right.start - left.start)
+    .reduce((restored, range) => restored.slice(0, range.start) + restored.slice(range.end), text);
 }
 
 export function verifyCodexInterruptHookTrustRestored(text: string): void {

--- a/src/codex-interrupt-hook.ts
+++ b/src/codex-interrupt-hook.ts
@@ -9,6 +9,10 @@ export const MANAGED_INTERRUPT_HOOK_START =
   "# Managed by codex-chatgpt-web: release the exact Responses request when its Codex turn is interrupted.";
 export const MANAGED_INTERRUPT_HOOK_END =
   "# End codex-chatgpt-web interrupt lifecycle hook.";
+export const MANAGED_INTERRUPT_HOOK_TRUST_START =
+  "# Managed by codex-chatgpt-web: trust the Interrupt hook defined in hooks.json.";
+export const MANAGED_INTERRUPT_HOOK_TRUST_END =
+  "# End codex-chatgpt-web JSON interrupt hook trust state.";
 
 function canonicalJson(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(canonicalJson);
@@ -82,6 +86,10 @@ function canonicalConfigPath(configPath: string): string {
   }
 }
 
+export function codexInterruptHookStateKey(path: string, groupIndex: number, hookIndex: number): string {
+  return `${canonicalConfigPath(path)}:interrupt:${groupIndex}:${hookIndex}`;
+}
+
 export function installCodexInterruptHook(
   text: string,
   configPath: string,
@@ -99,7 +107,7 @@ export function installCodexInterruptHookCommand(
     throw new Error("Codex config already contains a codex-chatgpt-web interrupt hook marker");
   }
   const groupIndex = interruptGroupCount(text);
-  const stateKey = `${canonicalConfigPath(configPath)}:interrupt:${groupIndex}:0`;
+  const stateKey = codexInterruptHookStateKey(configPath, groupIndex, 0);
   const trustedHash = codexInterruptHookHash(command);
   const ending = lineEnding(text);
   const core = [
@@ -128,6 +136,75 @@ export function installCodexInterruptHookCommand(
     text: `${text}${fragment}`,
     installed: { command, groupIndex, stateKey, trustedHash, fragment },
   };
+}
+
+export interface InstalledCodexInterruptHookTrust {
+  stateKey: string;
+  trustedHash: string;
+  fragment: string;
+}
+
+export function installCodexInterruptHookTrust(
+  text: string,
+  stateKey: string,
+  trustedHash: string,
+): { text: string; installed: InstalledCodexInterruptHookTrust } {
+  if (text.includes(MANAGED_INTERRUPT_HOOK_TRUST_START) || text.includes(MANAGED_INTERRUPT_HOOK_TRUST_END)) {
+    throw new Error("Codex config already contains a codex-chatgpt-web JSON interrupt hook trust marker");
+  }
+  if (!/^sha256:[a-f0-9]{64}$/.test(trustedHash)) {
+    throw new Error("Codex JSON interrupt hook trust hash is invalid");
+  }
+  const ending = lineEnding(text);
+  const core = [
+    MANAGED_INTERRUPT_HOOK_TRUST_START,
+    `[hooks.state.${JSON.stringify(stateKey)}]`,
+    `trusted_hash = ${JSON.stringify(trustedHash)}`,
+    MANAGED_INTERRUPT_HOOK_TRUST_END,
+  ].join(ending);
+  const leading = text.length === 0
+    ? ""
+    : text.endsWith(`${ending}${ending}`)
+      ? ""
+      : text.endsWith(ending)
+        ? ending
+        : `${ending}${ending}`;
+  const trailing = text.length > 0 && text.endsWith(ending) ? ending : "";
+  const fragment = `${leading}${core}${trailing}`;
+  return { text: `${text}${fragment}`, installed: { stateKey, trustedHash, fragment } };
+}
+
+function locateCodexInterruptHookTrust(text: string, installed: InstalledCodexInterruptHookTrust): { start: number; end: number } {
+  if (!installed.stateKey || !/^sha256:[a-f0-9]{64}$/.test(installed.trustedHash) || !installed.fragment) {
+    throw new Error("Codex JSON interrupt hook trust journal entry is invalid");
+  }
+  const marker = installed.fragment.indexOf(MANAGED_INTERRUPT_HOOK_TRUST_END);
+  if (marker < 0) {
+    throw new Error("Codex JSON interrupt hook trust journal fragment is invalid");
+  }
+  const pattern = new RegExp(hookTextPattern(installed.fragment), "g");
+  const match = pattern.exec(text);
+  if (!match || pattern.exec(text)
+    || text.split(MANAGED_INTERRUPT_HOOK_TRUST_START).length !== 2
+    || text.split(MANAGED_INTERRUPT_HOOK_TRUST_END).length !== 2) {
+    throw new Error("Codex JSON interrupt hook trust changed after setup; refusing to overwrite it");
+  }
+  return { start: match.index, end: match.index + match[0].length };
+}
+
+export function verifyCodexInterruptHookTrust(text: string, installed: InstalledCodexInterruptHookTrust): void {
+  locateCodexInterruptHookTrust(text, installed);
+}
+
+export function restoreCodexInterruptHookTrust(text: string, installed: InstalledCodexInterruptHookTrust): string {
+  const owned = locateCodexInterruptHookTrust(text, installed);
+  return text.slice(0, owned.start) + text.slice(owned.end);
+}
+
+export function verifyCodexInterruptHookTrustRestored(text: string): void {
+  if (text.includes(MANAGED_INTERRUPT_HOOK_TRUST_START) || text.includes(MANAGED_INTERRUPT_HOOK_TRUST_END)) {
+    throw new Error("Codex JSON interrupt hook trust state is present while the bridge is disconnected");
+  }
 }
 
 function hookTextPattern(text: string): string {

--- a/tests/codex-integration.test.ts
+++ b/tests/codex-integration.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { existsSync, lstatSync, mkdirSync, readFileSync, readlinkSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
+import { existsSync, lstatSync, mkdirSync, readFileSync, readlinkSync, realpathSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import {
   activateCodexIntegration,
   deactivateCodexIntegration,
@@ -194,6 +194,13 @@ describe("reversible native Codex route integration", () => {
     installCodexIntegration(nativeConfig("browser-only"));
     expect(lstatSync(hooksPath).isSymbolicLink()).toBe(true);
     expect(readFileSync(target, "utf8")).toContain('"Interrupt"');
+    const journal = installCodexIntegration(nativeConfig("browser-only"));
+    expect(journal.interruptHook.storage).toBe("json");
+    if (journal.interruptHook.storage === "json") {
+      expect(journal.interruptHook.stateKey).toBe(
+        `${join(realpathSync.native(dirname(hooksPath)), "hooks.json")}:interrupt:0:0`,
+      );
+    }
 
     deactivateCodexIntegration();
     expect(lstatSync(hooksPath).isSymbolicLink()).toBe(true);

--- a/tests/codex-integration.test.ts
+++ b/tests/codex-integration.test.ts
@@ -44,6 +44,13 @@ function compatibilityV1Config(mode: "browser-only" | "full") {
   return config;
 }
 
+function tomlInterruptHook(journal: { interruptHook: { storage: string; fragment?: string } }): { fragment: string } {
+  if (journal.interruptHook.storage !== "toml" || typeof journal.interruptHook.fragment !== "string") {
+    throw new Error("Test requires a TOML-installed interrupt hook");
+  }
+  return { fragment: journal.interruptHook.fragment };
+}
+
 function fixture(): { root: string; codexHome: string; appHome: string } {
   const root = join(tmpdir(), `codex-chatgpt-web-integration-${process.pid}-${Date.now()}-${Math.random()}`);
   const codexHome = join(root, "codex");
@@ -62,6 +69,174 @@ afterEach(() => {
 });
 
 describe("reversible native Codex route integration", () => {
+  test("uses an existing hooks.json without adding an inline hook definition", () => {
+    const { codexHome } = fixture();
+    const configPath = join(codexHome, "config.toml");
+    const hooksPath = join(codexHome, "hooks.json");
+    const originalConfig = 'model = "gpt-5.6-sol"\n';
+    const originalHooks = JSON.stringify({
+      hooks: { Stop: [{ hooks: [{ type: "command", command: "user-stop" }] }] },
+    });
+    writeFileSync(configPath, originalConfig);
+    writeFileSync(hooksPath, originalHooks);
+
+    const journal = installCodexIntegration(nativeConfig("browser-only"));
+    expect(journal.version).toBe(11);
+    expect(journal.interruptHook.storage).toBe("json");
+    expect(readFileSync(configPath, "utf8")).not.toContain("[[hooks.Interrupt]]");
+    expect(readFileSync(configPath, "utf8")).toContain("[hooks.state.");
+    expect(JSON.parse(readFileSync(hooksPath, "utf8"))).toMatchObject({
+      hooks: {
+        Stop: [{ hooks: [{ type: "command", command: "user-stop" }] }],
+        Interrupt: [{ hooks: [{ type: "command", command: journal.interruptHook.command, timeout: 3 }] }],
+      },
+    });
+    expect(inspectCodexIntegration().errors).toEqual([]);
+
+    expect(deactivateCodexIntegration()).toEqual({ changed: true, active: false });
+    expect(readFileSync(configPath, "utf8")).toBe(originalConfig);
+    expect(JSON.parse(readFileSync(hooksPath, "utf8"))).toEqual(JSON.parse(originalHooks));
+
+    expect(activateCodexIntegration()).toEqual({ changed: true, active: true });
+    expect(inspectCodexIntegration().errors).toEqual([]);
+    expect(uninstallCodexIntegration()).toEqual({ changed: true });
+    expect(readFileSync(configPath, "utf8")).toBe(originalConfig);
+    expect(JSON.parse(readFileSync(hooksPath, "utf8"))).toEqual(JSON.parse(originalHooks));
+  });
+
+  test("migrates a legacy TOML hook into an existing hooks.json", () => {
+    const { codexHome } = fixture();
+    const configPath = join(codexHome, "config.toml");
+    const hooksPath = join(codexHome, "hooks.json");
+    const originalConfig = 'model = "gpt-5.6-sol"\n';
+    const originalHooks = JSON.stringify({
+      hooks: { Stop: [{ hooks: [{ type: "command", command: "user-stop" }] }] },
+    });
+    writeFileSync(configPath, originalConfig);
+    const installed = installCodexIntegration(nativeConfig("browser-only"));
+    expect(installed.interruptHook.storage).toBe("toml");
+
+    const legacy = JSON.parse(readFileSync(getCodexJournalPath(), "utf8"));
+    legacy.version = 10;
+    delete legacy.interruptHook.storage;
+    const legacyJournal = `${JSON.stringify(legacy, null, 2)}\n`;
+    writeFileSync(getCodexJournalPath(), legacyJournal);
+    writeFileSync(getCodexJournalRecoveryPath(), legacyJournal);
+    writeFileSync(hooksPath, originalHooks);
+
+    const migrated = installCodexIntegration(nativeConfig("browser-only"));
+    expect(migrated.version).toBe(11);
+    expect(migrated.interruptHook.storage).toBe("json");
+    expect(readFileSync(configPath, "utf8")).not.toContain("[[hooks.Interrupt]]");
+    expect(JSON.parse(readFileSync(hooksPath, "utf8"))).toMatchObject({
+      hooks: {
+        Stop: [{ hooks: [{ type: "command", command: "user-stop" }] }],
+        Interrupt: [{ hooks: [{ type: "command", command: migrated.interruptHook.command, timeout: 3 }] }],
+      },
+    });
+    expect(inspectCodexIntegration().errors).toEqual([]);
+
+    uninstallCodexIntegration();
+    expect(readFileSync(configPath, "utf8")).toBe(originalConfig);
+    expect(JSON.parse(readFileSync(hooksPath, "utf8"))).toEqual(JSON.parse(originalHooks));
+  });
+
+  test("can run setup again after disconnecting a JSON-backed installation", () => {
+    const { codexHome } = fixture();
+    writeFileSync(join(codexHome, "config.toml"), 'model = "gpt-5.6-sol"\n');
+    writeFileSync(join(codexHome, "hooks.json"), '{}\n');
+    const config = nativeConfig("browser-only");
+    installCodexIntegration(config);
+    deactivateCodexIntegration();
+    preflightCodexIntegration(config);
+    installCodexIntegration(config);
+    expect(inspectCodexIntegration()).toMatchObject({ active: true, errors: [] });
+  });
+
+  test("recovers a first JSON install interrupted before the JSON write", () => {
+    const { codexHome } = fixture();
+    const hooksPath = join(codexHome, "hooks.json");
+    writeFileSync(join(codexHome, "config.toml"), 'model = "gpt-5.6-sol"\n');
+    writeFileSync(hooksPath, '{}\n');
+    installCodexIntegration(nativeConfig("browser-only"));
+    rmSync(getCodexJournalPath());
+    writeFileSync(hooksPath, '{}\n');
+    expect(inspectCodexIntegration()).toMatchObject({ active: true, errors: [] });
+    expect(readFileSync(hooksPath, "utf8")).toContain('"Interrupt"');
+  });
+
+  test("recovers an interrupted JSON update when the runtime command changes", () => {
+    const { codexHome } = fixture();
+    const hooksPath = join(codexHome, "hooks.json");
+    writeFileSync(join(codexHome, "config.toml"), 'model = "gpt-5.6-sol"\n');
+    writeFileSync(hooksPath, '{}\n');
+    const config = nativeConfig("browser-only");
+    installCodexIntegration(config);
+    const previousHooks = readFileSync(hooksPath, "utf8");
+    const previousJournal = readFileSync(getCodexJournalPath(), "utf8");
+    const updated = installCodexIntegration({ ...config, runtimeCommand: ["/opt/new-runtime/bun", "/opt/new-runtime/cli.js"] });
+    writeFileSync(getCodexJournalPath(), previousJournal);
+    writeFileSync(hooksPath, previousHooks);
+    expect(inspectCodexIntegration()).toMatchObject({ active: true, errors: [] });
+    expect(readFileSync(hooksPath, "utf8")).toContain(updated.interruptHook.command);
+  });
+
+  test("preserves a symlinked hooks.json while applying and restoring the owned hook", () => {
+    const { root, codexHome } = fixture();
+    const configPath = join(codexHome, "config.toml");
+    const target = join(root, "shared-hooks.json");
+    const hooksPath = join(codexHome, "hooks.json");
+    const originalHooks = '{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"user-stop"}]}]}}\n';
+    writeFileSync(configPath, 'model = "gpt-5.6-sol"\n');
+    writeFileSync(target, originalHooks);
+    symlinkSync(target, hooksPath);
+
+    installCodexIntegration(nativeConfig("browser-only"));
+    expect(lstatSync(hooksPath).isSymbolicLink()).toBe(true);
+    expect(readFileSync(target, "utf8")).toContain('"Interrupt"');
+
+    deactivateCodexIntegration();
+    expect(lstatSync(hooksPath).isSymbolicLink()).toBe(true);
+    expect(JSON.parse(readFileSync(target, "utf8"))).toEqual(JSON.parse(originalHooks));
+    uninstallCodexIntegration();
+    expect(lstatSync(hooksPath).isSymbolicLink()).toBe(true);
+  });
+
+  test("recovers a JSON hook write interrupted after the TOML commit", () => {
+    const { codexHome } = fixture();
+    const configPath = join(codexHome, "config.toml");
+    const hooksPath = join(codexHome, "hooks.json");
+    writeFileSync(configPath, 'model = "gpt-5.6-sol"\n');
+    writeFileSync(hooksPath, '{"hooks":{}}\n');
+    installCodexIntegration(nativeConfig("browser-only"));
+    const activeConfig = readFileSync(configPath, "utf8");
+    const activeJournal = readFileSync(getCodexJournalPath(), "utf8");
+    deactivateCodexIntegration();
+    const inactiveHooks = readFileSync(hooksPath, "utf8");
+    const inactiveJournal = readFileSync(getCodexJournalPath(), "utf8");
+
+    writeFileSync(getCodexJournalRecoveryPath(), activeJournal);
+    writeFileSync(configPath, activeConfig);
+    writeFileSync(getCodexJournalPath(), inactiveJournal);
+    expect(inspectCodexIntegration()).toMatchObject({ installed: true, active: true, errors: [] });
+    expect(readFileSync(hooksPath, "utf8")).not.toBe(inactiveHooks);
+    expect(readFileSync(getCodexJournalPath(), "utf8")).toBe(activeJournal);
+  });
+
+  test("rejects a JSON hook journal that targets another Codex home", () => {
+    const { codexHome } = fixture();
+    writeFileSync(join(codexHome, "config.toml"), 'model = "gpt-5.6-sol"\n');
+    writeFileSync(join(codexHome, "hooks.json"), '{"hooks":{}}\n');
+    installCodexIntegration(nativeConfig("browser-only"));
+    const journal = JSON.parse(readFileSync(getCodexJournalPath(), "utf8"));
+    journal.interruptHook.hooksPath = join(codexHome, "elsewhere.json");
+    const tampered = `${JSON.stringify(journal, null, 2)}\n`;
+    writeFileSync(getCodexJournalPath(), tampered);
+    writeFileSync(getCodexJournalRecoveryPath(), tampered);
+
+    expect(inspectCodexIntegration().errors.join("\n")).toContain("active hooks JSON");
+  });
+
   test("route install, update, switching and removal preserve a symlinked shared Codex config", () => {
     const { root, codexHome } = fixture();
     const shared = join(root, "shared");
@@ -158,7 +333,7 @@ describe("reversible native Codex route integration", () => {
 
     const journal = installCodexIntegration(nativeConfig("browser-only"));
     const installed = readFileSync(configPath, "utf8");
-    expect(journal.version).toBe(10);
+    expect(journal.version).toBe(11);
     expect(installed).toContain('openai_base_url = "http://127.0.0.1:17841/v1"');
     expect(installed).toContain(
       `experimental_realtime_webrtc_call_base_url = ${JSON.stringify(CODEX_REALTIME_WEBRTC_CALL_BASE_URL)}`,
@@ -225,7 +400,7 @@ describe("reversible native Codex route integration", () => {
     const journal = installCodexIntegration(compatibilityV1Config("browser-only"));
     const installed = readFileSync(configPath, "utf8");
     expect(journal).toMatchObject({
-      version: 10,
+      version: 11,
       installed: { subagent_protocol: "compatibility-v1", agent_max_depth: 2 },
       previousMultiAgent: { rawLine: "multi_agent = false # user choice", value: "false" },
       previousMultiAgentV2: { rawLine: "multi_agent_v2 = true # user choice", value: "true" },
@@ -563,7 +738,7 @@ describe("reversible native Codex route integration", () => {
 
       const journal = installCodexIntegration(nativeConfig("browser-only"));
       expect(journal).toMatchObject({
-        version: 10,
+        version: 11,
         installed: {
           experimental_realtime_webrtc_call_base_url: CODEX_REALTIME_WEBRTC_CALL_BASE_URL,
         },
@@ -687,7 +862,7 @@ describe("reversible native Codex route integration", () => {
         saveConfig(config);
         const installed = installCodexIntegration(config);
         const current = keepRoute
-          ? readFileSync(configPath, "utf8").replace(installed.interruptHook.fragment, "")
+          ? readFileSync(configPath, "utf8").replace(tomlInterruptHook(installed).fragment, "")
           : original;
         writeFileSync(configPath, current);
         const journal = readFileSync(getCodexJournalPath(), "utf8");
@@ -704,7 +879,7 @@ describe("reversible native Codex route integration", () => {
         const repairedText = readFileSync(configPath, "utf8");
         expect(inspectCodexIntegration().errors).toEqual([]);
         expect(repairedText.match(/^\[\[hooks\.Interrupt\]\]/gm)).toHaveLength(1);
-        expect(repairedText).toContain(repaired.interruptHook.fragment);
+        expect(repairedText).toContain(tomlInterruptHook(repaired).fragment);
         installCodexIntegration(config, { replaceExistingRoute: true });
         expect(readFileSync(configPath, "utf8")).toBe(repairedText);
         deactivateCodexIntegration();
@@ -725,13 +900,13 @@ describe("reversible native Codex route integration", () => {
     const config = nativeConfig("full");
     const installed = installCodexIntegration(config);
     const active = readFileSync(configPath, "utf8");
-    const withoutHook = active.replace(installed.interruptHook.fragment, "");
+    const withoutHook = active.replace(tomlInterruptHook(installed).fragment, "");
     const journal = readFileSync(getCodexJournalPath(), "utf8");
     const recovery = readFileSync(getCodexJournalRecoveryPath(), "utf8");
     for (const current of [
       active.replace("timeout = 3", "timeout = 2"),
       active.replace(/^#.*interrupt.*\n/gm, ""),
-      withoutHook + installed.interruptHook.fragment.split("[[hooks.Interrupt]]")[0],
+      withoutHook + tomlInterruptHook(installed).fragment.split("[[hooks.Interrupt]]")[0],
       withoutHook + `\n[hooks.state.${JSON.stringify(installed.interruptHook.stateKey)}]\ntrusted_hash = ${JSON.stringify(installed.interruptHook.trustedHash)}\n`,
       withoutHook + '\n[[hooks.Interrupt]]\n[[hooks.Interrupt.hooks]]\ntype = "command"\ncommand = "user-modified-hook"\n',
       withoutHook + '\n[hooks]\nInterrupt = []\n',
@@ -823,8 +998,8 @@ describe("reversible native Codex route integration", () => {
     preflightCodexIntegration(nativeConfig("browser-only"));
     expect(readFileSync(configPath, "utf8")).toBe(legacyConfig);
     const upgraded = installCodexIntegration(nativeConfig("browser-only"));
-    expect(upgraded.version).toBe(10);
-    expect(readFileSync(configPath, "utf8")).toContain(upgraded.interruptHook.fragment);
+    expect(upgraded.version).toBe(11);
+    expect(readFileSync(configPath, "utf8")).toContain(tomlInterruptHook(upgraded).fragment);
     expect(uninstallCodexIntegration()).toEqual({ changed: true });
     expect(readFileSync(configPath, "utf8")).toBe(original);
   });
@@ -908,7 +1083,7 @@ describe("reversible native Codex route integration", () => {
     deactivateCodexIntegration();
 
     expect(JSON.parse(readFileSync(getCodexJournalPath(), "utf8"))).toMatchObject({
-      version: 10,
+      version: 11,
       active: false,
     });
     expect(inspectCodexIntegration()).toMatchObject({ installed: true, active: false, errors: [] });
@@ -945,7 +1120,7 @@ describe("reversible native Codex route integration", () => {
       nativeConfig("browser-only"),
       { replaceExistingRoute: true },
     );
-    expect(upgraded.version).toBe(10);
+    expect(upgraded.version).toBe(11);
     expect(upgraded.previousRealtimeWebrtcCallBaseUrl.rawLine).toBe(customVoiceLine);
     uninstallCodexIntegration();
     expect(readFileSync(configPath, "utf8")).toBe(original);
@@ -981,7 +1156,7 @@ describe("reversible native Codex route integration", () => {
     writeFileSync(configPath, currentConfig);
     writeFileSync(getCodexJournalPath(), legacyJournal);
     writeFileSync(getCodexJournalRecoveryPath(), currentJournal);
-    expect(inspectCodexIntegration().journal?.version).toBe(10);
+    expect(inspectCodexIntegration().journal?.version).toBe(11);
     expect(readFileSync(getCodexJournalPath(), "utf8")).toBe(currentJournal);
   });
 
@@ -1048,7 +1223,7 @@ describe("reversible native Codex route integration", () => {
     );
 
     const upgraded = installCodexIntegration(nativeConfig("browser-only"));
-    expect(upgraded.version).toBe(10);
+    expect(upgraded.version).toBe(11);
     expect(readFileSync(configPath, "utf8")).toContain("goals = true");
     expect(readFileSync(configPath, "utf8")).not.toContain("remote_compaction_v2");
     expect(readFileSync(configPath, "utf8")).not.toContain("multi_agent");

--- a/tests/codex-interrupt-hook-json.test.ts
+++ b/tests/codex-interrupt-hook-json.test.ts
@@ -1,0 +1,86 @@
+import { expect, test } from "bun:test";
+import {
+  installCodexInterruptHookJson,
+  restoreCodexInterruptHookJson,
+  verifyCodexInterruptHookJson,
+} from "../src/codex-interrupt-hook-json";
+
+const command = "'/opt/Codex Web/runtime/bun' 'hook' 'interrupt'";
+
+function parse(text: string): Record<string, unknown> {
+  return JSON.parse(text) as Record<string, unknown>;
+}
+
+test("installs a distinct JSON Interrupt command hook and preserves user hooks", () => {
+  const original = JSON.stringify({
+    hooks: {
+      Interrupt: [{ hooks: [{ type: "command", command: "user-interrupt", timeout: 5 }] }],
+      Stop: [{ hooks: [{ type: "command", command: "user-stop" }] }],
+    },
+    metadata: { owner: "user" },
+  });
+
+  const installed = installCodexInterruptHookJson(original, command);
+  const document = parse(installed.text) as { hooks: Record<string, unknown> };
+  const groups = document.hooks.Interrupt as Array<{ hooks: Array<Record<string, unknown>> }>;
+
+  expect(installed.installed).toMatchObject({
+    mode: "json",
+    command,
+    groupIndex: 1,
+    hookIndex: 0,
+  });
+  expect(installed.installed.entryHash).toMatch(/^sha256:[a-f0-9]{64}$/);
+  expect(groups).toHaveLength(2);
+  expect(groups[0]).toEqual({ hooks: [{ type: "command", command: "user-interrupt", timeout: 5 }] });
+  expect(groups[1]).toEqual({ hooks: [{ type: "command", command, timeout: 3 }] });
+  verifyCodexInterruptHookJson(installed.text, installed.installed);
+});
+
+test("rejects an existing codex-chatgpt-web JSON command instead of duplicating it", () => {
+  const original = JSON.stringify({
+    hooks: { Interrupt: [{ hooks: [{ type: "command", command, timeout: 3 }] }] },
+  });
+
+  expect(() => installCodexInterruptHookJson(original, command)).toThrow("already contains");
+});
+
+test("rejects malformed and unsupported JSON documents before changing them", () => {
+  for (const invalid of [
+    "{\"hooks\":",
+    "[]",
+    JSON.stringify({ hooks: [] }),
+    JSON.stringify({ hooks: { Interrupt: {} } }),
+    JSON.stringify({ hooks: { Interrupt: [{}] } }),
+    JSON.stringify({ hooks: { Interrupt: [{ hooks: [{ type: "command" }] }] } }),
+  ]) {
+    expect(() => installCodexInterruptHookJson(invalid, command)).toThrow();
+  }
+});
+
+test("refuses removal when the journaled JSON hook entry changed", () => {
+  const installed = installCodexInterruptHookJson("{}", command);
+  const modified = installed.text.replace("\"timeout\": 3", "\"timeout\": 2");
+
+  expect(() => verifyCodexInterruptHookJson(modified, installed.installed)).toThrow("changed after setup");
+  expect(() => restoreCodexInterruptHookJson(modified, installed.installed)).toThrow("changed after setup");
+});
+
+test("removes only the owned entry and keeps user hooks added later", () => {
+  const original = JSON.stringify({
+    hooks: { Interrupt: [{ hooks: [{ type: "command", command: "user-interrupt" }] }] },
+  });
+  const installed = installCodexInterruptHookJson(original, command);
+  const document = parse(installed.text) as { hooks: { Interrupt: Array<{ hooks: Array<Record<string, unknown>> }> } };
+  document.hooks.Interrupt[1].hooks.push({ type: "command", command: "later-user-hook" });
+
+  const restored = restoreCodexInterruptHookJson(JSON.stringify(document), installed.installed);
+  expect(parse(restored)).toEqual({
+    hooks: {
+      Interrupt: [
+        { hooks: [{ type: "command", command: "user-interrupt" }] },
+        { hooks: [{ type: "command", command: "later-user-hook" }] },
+      ],
+    },
+  });
+});

--- a/tests/codex-interrupt-hook.test.ts
+++ b/tests/codex-interrupt-hook.test.ts
@@ -4,11 +4,16 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import {
   MANAGED_INTERRUPT_HOOK_END,
+  MANAGED_INTERRUPT_HOOK_TRUST_START,
+  MANAGED_INTERRUPT_HOOK_TRUST_END,
   codexInterruptHookCommand,
   codexInterruptHookHash,
   installCodexInterruptHook,
+  installCodexInterruptHookTrust,
+  restoreCodexInterruptHookTrust,
   restoreCodexInterruptHook,
   verifyCodexInterruptHook,
+  verifyCodexInterruptHookTrust,
   verifyCodexInterruptHookRestored,
 } from "../src/codex-interrupt-hook";
 
@@ -46,6 +51,159 @@ test("trusts the canonical Codex config path before a new config file exists", (
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }
+});
+
+test("preserves native tables moved inside JSON hook trust markers", () => {
+  const installed = installCodexInterruptHookTrust(
+    'model = "gpt-5.6-sol"\n',
+    "/Users/test/.codex/hooks.json:interrupt:0:0",
+    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  );
+  const updated = installed.text.replace(
+    MANAGED_INTERRUPT_HOOK_TRUST_END,
+    '[mcp_servers.astra_review]\ncommand = "review"\n\n' + MANAGED_INTERRUPT_HOOK_TRUST_END,
+  );
+  verifyCodexInterruptHookTrust(updated, installed.installed);
+  const restored = restoreCodexInterruptHookTrust(updated, installed.installed);
+  expect(restored).toContain('[mcp_servers.astra_review]');
+  expect(restored).not.toContain("hooks.state");
+  expect(restored).not.toContain("JSON interrupt hook trust");
+});
+
+test("preserves explicitly declared empty trust parent tables", () => {
+  const original = '[hooks]\n[hooks.state]\n';
+  const installed = installCodexInterruptHookTrust(
+    original,
+    "/Users/test/.codex/hooks.json:interrupt:0:0",
+    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  );
+  const restored = restoreCodexInterruptHookTrust(installed.text, installed.installed);
+  expect(Bun.TOML.parse(restored)).toEqual(Bun.TOML.parse(original));
+  expect(restored).toContain("[hooks]\n[hooks.state]");
+});
+
+test("restores empty trust parent tables from equivalent TOML spellings", () => {
+  for (const original of [
+    "[ hooks ]\n[ hooks.state ]\n",
+    '["hooks"]\n["hooks"."state"]\n',
+    'description = """\n[hooks]\n"""\n',
+  ]) {
+    const installed = installCodexInterruptHookTrust(
+      original,
+      "/Users/test/.codex/hooks.json:interrupt:0:0",
+      "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    );
+    expect(Bun.TOML.parse(restoreCodexInterruptHookTrust(installed.text, installed.installed)))
+      .toEqual(Bun.TOML.parse(original));
+  }
+});
+
+test("preserves a native table with a commented header inside trust markers", () => {
+  const installed = installCodexInterruptHookTrust(
+    'model = "gpt-5.6-sol"\n',
+    "/Users/test/.codex/hooks.json:interrupt:0:0",
+    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  );
+  const updated = installed.text.replace(
+    MANAGED_INTERRUPT_HOOK_TRUST_END,
+    '[mcp_servers.astra_review] # native setting\ncommand = "review"\n\n' + MANAGED_INTERRUPT_HOOK_TRUST_END,
+  );
+  const restored = restoreCodexInterruptHookTrust(updated, installed.installed);
+  expect(restored).toContain('[mcp_servers.astra_review] # native setting\ncommand = "review"');
+});
+
+test("removes a moved JSON trust end marker without duplicating native tables", () => {
+  const installed = installCodexInterruptHookTrust(
+    'model = "gpt-5.6-sol"\n',
+    "/Users/test/.codex/hooks.json:interrupt:0:0",
+    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  );
+  const moved = installed.text
+    .replace(MANAGED_INTERRUPT_HOOK_TRUST_END, "")
+    .replace(
+      MANAGED_INTERRUPT_HOOK_TRUST_START,
+      `${MANAGED_INTERRUPT_HOOK_TRUST_START}\n${MANAGED_INTERRUPT_HOOK_TRUST_END}`,
+    )
+    .replace(
+      'trusted_hash = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"',
+      'trusted_hash = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"\n[mcp_servers.astra_review]\ncommand = "review"',
+    );
+  verifyCodexInterruptHookTrust(moved, installed.installed);
+  const restored = restoreCodexInterruptHookTrust(moved, installed.installed);
+  expect(restored).toContain('[mcp_servers.astra_review]');
+  expect(restored.match(/\[mcp_servers\.astra_review\]/g)).toHaveLength(1);
+  expect(restored).not.toContain("hooks.state");
+  expect(restored).not.toContain("JSON interrupt hook trust");
+});
+
+test("does not join adjacent user assignments when the JSON trust start marker moves", () => {
+  const installed = installCodexInterruptHookTrust(
+    'model = "gpt-5.6-sol"\n',
+    "/Users/test/.codex/hooks.json:interrupt:0:0",
+    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  );
+  const moved = installed.text
+    .replace(MANAGED_INTERRUPT_HOOK_TRUST_START, "")
+    .replace(
+      'model = "gpt-5.6-sol"\n',
+      'model = "gpt-5.6-sol"\n[mcp_servers.astra_review]\ncommand = "review"\n'
+        + `${MANAGED_INTERRUPT_HOOK_TRUST_START}\nargs = []\n`,
+    );
+  verifyCodexInterruptHookTrust(moved, installed.installed);
+  const restored = restoreCodexInterruptHookTrust(moved, installed.installed);
+  expect(restored).toContain('command = "review"\nargs = []');
+  expect(Bun.TOML.parse(restored)).toMatchObject({
+    mcp_servers: { astra_review: { command: "review", args: [] } },
+  });
+});
+
+test("refuses JSON trust markers moved into multiline TOML strings", () => {
+  const installed = installCodexInterruptHookTrust(
+    'model = "gpt-5.6-sol"\n',
+    "/Users/test/.codex/hooks.json:interrupt:0:0",
+    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  );
+  const moved = installed.text
+    .replace(MANAGED_INTERRUPT_HOOK_TRUST_START, "")
+    .replace(
+      'model = "gpt-5.6-sol"\n',
+      'model = "gpt-5.6-sol"\n[metadata]\ndescription = """\n'
+        + `${MANAGED_INTERRUPT_HOOK_TRUST_START}\nuser text\n"""\n`,
+    );
+  expect(() => restoreCodexInterruptHookTrust(moved, installed.installed)).toThrow("changed after setup");
+});
+
+test("removes only the parsed JSON trust table when matching lines appear in a string", () => {
+  const installed = installCodexInterruptHookTrust(
+    'model = "gpt-5.6-sol"\n',
+    "/Users/test/.codex/hooks.json:interrupt:0:0",
+    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  );
+  const header = `[hooks.state.${JSON.stringify(installed.installed.stateKey)}]`;
+  const hash = `trusted_hash = ${JSON.stringify(installed.installed.trustedHash)}`;
+  const changed = installed.text.replace(
+    'model = "gpt-5.6-sol"\n',
+    `model = "gpt-5.6-sol"\n[metadata]\ndescription = """\n${header}\n${hash}\n"""\n`,
+  );
+  const restored = restoreCodexInterruptHookTrust(changed, installed.installed);
+  expect(restored).toContain(`description = """\n${header}\n${hash}\n"""`);
+  expect(Bun.TOML.parse(restored)).toMatchObject({
+    metadata: { description: `${header}\n${hash}\n` },
+  });
+  expect(restored).not.toContain('trusted_hash = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"\n# End codex-chatgpt-web JSON interrupt hook trust state');
+});
+
+test("refuses extra assignments in the owned JSON trust table", () => {
+  const installed = installCodexInterruptHookTrust(
+    'model = "gpt-5.6-sol"\n',
+    "/Users/test/.codex/hooks.json:interrupt:0:0",
+    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  );
+  const changed = installed.text.replace(
+    MANAGED_INTERRUPT_HOOK_TRUST_END,
+    'approved = false\n' + MANAGED_INTERRUPT_HOOK_TRUST_END,
+  );
+  expect(() => restoreCodexInterruptHookTrust(changed, installed.installed)).toThrow("changed after setup");
 });
 
 test("Interrupt hook command is absolute, quoted, and bound to the exact application home", () => {


### PR DESCRIPTION
## What this changes

The bridge now uses an existing `$CODEX_HOME/hooks.json` for its Interrupt hook. This avoids the mixed hook-source warning caused by adding a hook to `config.toml` when JSON hooks are already present. If `hooks.json` is absent, setup keeps the existing TOML behavior and does not create the JSON file.

Version 11 journals track JSON hook ownership and TOML trust state. Setup migrates bridge-owned v10 TOML hooks into an existing JSON file, preserves user hooks and symlinks, and restores owned changes on disconnect or uninstall. Recovery handles interrupted JSON writes during first install and runtime-command upgrades. Launcher checkpoints also include the JSON file.

This PR remains a draft pending maintainer review and dependency audit resolution.

## Evidence

- Isolated Codex discovery with JSON hooks and TOML trust state produces no mixed-source warning on Codex 0.154.0 and 0.153.4.
- The real Codex interruption smoke passes with JSON storage selected.
- The built CLI reconnects simulated v10 installations into v11 with both TOML-only and existing-JSON configurations. Disconnect restores the original configuration in both cases.
- Regression tests cover user-hook preservation, legacy migration, symlinks, path tampering, setup after disconnect, and interrupted writes.

## Scope and invariants

- [x] I read `CONTRIBUTING.md`.
- [x] The change is limited to hook storage, lifecycle ownership, rollback, and regression evidence.
- [x] Model, route, effort, connector, and capability selection retain their existing behavior.
- [x] Browser-only gains no broker or connector.
- [x] No dependency updates, generated artifacts, version changes, credentials, or private paths are included.

## Verification

The following checks used the pinned Bun 1.4.0 on macOS arm64.

- [x] `bun install --frozen-lockfile` in the repository root and `launcher/`.
- [x] `bun run check-version` and `bun run typecheck`.
- [x] `bun run test`: 706 pass, one Windows-specific skip.
- [x] `bun run launcher:typecheck` and `bun run launcher:test`: 295 pass, one skip.
- [x] `bun run launcher:build`.
- [x] `bun run build` and `bun run smoke`: `RELOCATABLE_RUNTIME_SMOKE_OK`.
- [x] `bun run smoke:interrupt`: `NATIVE_CODEX_INTERRUPT_LIFECYCLE_SMOKE_OK`.
- [x] `bun run scripts/smoke-codex-hooks-json.ts <codex-executable>` against Codex 0.154.0 and 0.153.4.
- [x] Packaged CLI v10-to-v11 reconnect/disconnect simulation for both storage modes.
- [ ] `bun run verify` completes successfully. Existing dependency audit findings block it; the remaining checks were run separately.

The root audit reports three moderate advisories against the unchanged Hono 4.12.34 pin. The launcher audit reports one high advisory against unchanged js-yaml 4.3.1. Both remain unresolved and outside this change.

## Platform or account validation

The relocatable macOS arm64 runtime and launcher renderer were built and exercised. Codex smoke tests used an isolated Codex home and a local fixture server.

Not run: native macOS installer packaging, Windows/Linux packages, or authenticated ChatGPT account tests. Account-tier and authenticated Browser-only/Full coverage remain unverified.
