### PR TITLE
fix: preserve cumulative checkpoint during fallback compaction

### DIFF
--- a/src/adapters/chatgpt-web/prompt.ts
+++ b/src/adapters/chatgpt-web/prompt.ts
@@ -578,6 +578,7 @@ export function compileChatGptWebPrompt(
       "The task context is complete. Execute the latest active user request now under the capability contract above.",
       "</codex_transport_resume>",
     ];
+  let trimmedCompactionMessages = 0;
   const build = (sourceMessages: readonly CodexMessage[]): CompiledChatGptWebPrompt => {
     const images: ChatGptWebPromptImage[] = [];
     const budget: ImageBudget = {
@@ -650,7 +651,13 @@ export function compileChatGptWebPrompt(
       "<codex_context_json>",
       envelopeJson,
       "</codex_context_json>",
-      ...transportResume,
+      ...(trimmedCompactionMessages > 0 ? [
+        "<codex_transport_resume>",
+        `${trimmedCompactionMessages} older history item(s) omitted to fit the compaction transport budget; the supplied history is incomplete.`,
+        "Carry forward still-relevant progress, constraints, and pending work from the cumulative checkpoint, if present, together with the retained recent evidence. Omitted output is not evidence that earlier work never happened; do not invent missing details.",
+        "Produce the requested checkpoint summary now without calling work tools.",
+        "</codex_transport_resume>",
+      ] : transportResume),
     ].join("\n");
     return { text, images };
   };
@@ -671,22 +678,31 @@ export function compileChatGptWebPrompt(
     chatGptPromptJsonBytes(compiled.text) > CHATGPT_COMPACTION_PROMPT_JSON_BYTE_BUDGET
   );
 
-  // Match native Codex compaction recovery: discard oldest history items one at a time until the
-  // summarization request fits. Never discard the final compaction instruction itself, and rebuild
-  // image references after every trim so removed messages cannot leave orphaned attachments.
+  // The previous checkpoint may be the only surviving record of earlier work. Keep the newest
+  // one verbatim even when it precedes a large tool transcript; otherwise fallback compaction
+  // silently resets cumulative progress to the most recent tool results.
+  const checkpoint = sourceMessages.findLast(message =>
+    message.role === "user" && isReadableCompactionSummaryText(plainMessageText(message))
+  );
+  // Discard the oldest other history items, preserving order and the final instruction. Rebuild
+  // image references and the omission notice after every trim, within the same byte budget.
   while (
     exceedsCompactionBudget()
     && sourceMessages.length > 1
   ) {
-    sourceMessages = sourceMessages.slice(1);
+    const discardIndex = sourceMessages.findIndex((message, index) =>
+      message !== checkpoint && index < sourceMessages.length - 1
+    );
+    if (discardIndex < 0) break;
+    sourceMessages = sourceMessages.filter((_message, index) => index !== discardIndex);
+    trimmedCompactionMessages = initialMessageCount - sourceMessages.length;
     compiled = build(sourceMessages);
   }
   const encodedBytes = chatGptPromptJsonBytes(compiled.text);
   if (exceedsCompactionBudget()) {
     throw new Error(
-      `ChatGPT Web compaction prompt still requires ${encodedBytes.toLocaleString("en-US")} JSON bytes after all older history was trimmed; the final compaction instruction alone exceeds the browser compaction budget`,
+      `ChatGPT Web compaction prompt still requires ${encodedBytes.toLocaleString("en-US")} JSON bytes after all expendable history was trimmed; the ${checkpoint ? "cumulative checkpoint and final compaction instruction exceed" : "final compaction instruction alone exceeds"} the browser compaction budget`,
     );
   }
-  const trimmedCompactionMessages = initialMessageCount - sourceMessages.length;
   return trimmedCompactionMessages > 0 ? { ...compiled, trimmedCompactionMessages } : compiled;
 }

--- a/tests/prompt-contract.test.ts
+++ b/tests/prompt-contract.test.ts
@@ -11,6 +11,7 @@ import {
 import { CHATGPT_WEB_LUNA_MODEL_ID, CHATGPT_WEB_MODEL_ID } from "../src/adapters/chatgpt-web/model";
 import { biggerContextPartCount } from "../src/adapters/chatgpt-web/usage";
 import type { CodexParsedRequest } from "../src/types";
+import { SUMMARY_PREFIX } from "../src/responses/compaction";
 
 function request(reasoning: "low" | "medium" | "high" | "xhigh" | "max"): CodexParsedRequest {
   return {
@@ -252,6 +253,61 @@ test("Web compaction trims only the oldest history until the browser request fit
   expect(untrimmed.text).toContain("oldest-static");
   expect(untrimmed.text).toContain("newer-static");
   expect(untrimmed.trimmedCompactionMessages).toBeUndefined();
+});
+
+for (const asParts of [false, true]) {
+  test(`fallback compaction preserves the cumulative checkpoint (${asParts ? "parts" : "string"})`, () => {
+    const compact = request("high");
+    compact._compactionRequest = true;
+    compact.context.systemPrompt = [];
+    const summary = `${SUMMARY_PREFIX}\n\nEarlier verified progress and original scope: ${"s".repeat(20_000)}`;
+    compact.context.messages = [
+      { role: "user", content: asParts ? [{ type: "text", text: summary }] : summary, timestamp: 1 },
+      { role: "toolResult", toolCallId: "old", toolName: "read", isError: false, content: `old-bulky-output-${"x".repeat(100_000)}`, timestamp: 2 },
+      { role: "assistant", content: [{ type: "text", text: "recent-verified-progress" }], timestamp: 3 },
+      { role: "user", content: "checkpoint-now", timestamp: 4 },
+    ];
+    const compiled = compileChatGptWebPrompt(compact, { localToolsEnabled: false, solAvailable: true, proAvailable: true });
+    expect(compiled.text).toContain("Earlier verified progress and original scope:");
+    expect(compiled.text).toContain("recent-verified-progress");
+    expect(compiled.text).not.toContain("old-bulky-output-");
+    expect(compiled.trimmedCompactionMessages).toBe(1);
+    expect(compiled.text).toContain("1 older history item(s) omitted");
+    expect(compiled.text).not.toContain("The task context is complete.");
+    expect(chatGptPromptJsonBytes(compiled.text)).toBeLessThanOrEqual(CHATGPT_COMPACTION_PROMPT_JSON_BYTE_BUDGET);
+  });
+}
+
+test("fallback compaction refuses to discard an oversized cumulative checkpoint", () => {
+  const compact = request("high");
+  compact._compactionRequest = true;
+  compact.context.systemPrompt = [];
+  compact.context.messages = [
+    { role: "user", content: `${SUMMARY_PREFIX}\n\n${"s".repeat(120_000)}`, timestamp: 1 },
+    { role: "user", content: "checkpoint-now", timestamp: 2 },
+  ];
+  expect(() => compileChatGptWebPrompt(compact, { localToolsEnabled: false, solAvailable: true, proAvailable: true }))
+    .toThrow("cumulative checkpoint and final compaction instruction");
+});
+
+test("fallback compaction keeps the newest checkpoint and preserves retained message order", () => {
+  const compact = request("high");
+  compact._compactionRequest = true;
+  compact.context.systemPrompt = [];
+  const newest = `${SUMMARY_PREFIX}\n\ncurrent-checkpoint-${"s".repeat(20_000)}`;
+  compact.context.messages = [
+    { role: "user", content: `${SUMMARY_PREFIX}\n\nsuperseded-checkpoint`, timestamp: 1 },
+    { role: "user", content: newest, timestamp: 2 },
+    { role: "toolResult", toolCallId: "old", toolName: "read", isError: false, content: "x".repeat(100_000), timestamp: 3 },
+    { role: "user", content: "checkpoint-now", timestamp: 4 },
+  ];
+  const compiled = compileChatGptWebPrompt(compact, { localToolsEnabled: false, solAvailable: true, proAvailable: true });
+  const envelope = JSON.parse(compiled.text.split("<codex_context_json>\n")[1]!.split("\n</codex_context_json>")[0]!);
+  expect(envelope.messages).toEqual([
+    { role: "user", content: newest },
+    { role: "user", content: "checkpoint-now" },
+  ]);
+  expect(compiled.trimmedCompactionMessages).toBe(2);
 });
 
 test("Bigger Context compaction preserves history above the retired inline byte budget", () => {


### PR DESCRIPTION
## What this changes

Fixes #447.

When an inline fallback compaction request exceeds its byte budget, trimming from the front can remove the cumulative checkpoint before a large recent tool result. The next summarizer loses the only surviving record of earlier progress, while the transport still claims the context is complete.

Keep the newest readable cumulative checkpoint and final compaction instruction, trimming other older messages in order. Disclose omitted history to the summarizer and fail explicitly if the checkpoint plus final instruction cannot fit. The byte limit, normal turns, multipart transport, image-reference rebuilding, and capability routing are preserved.

## Evidence

The synthetic reproduction in #447 loads the original v5.0.6 `prompt.ts` compiler with local release dependencies. A checkpoint followed by a large tool result loses its checkpoint under the original implementation, but retains it with this fix. No task contents or live model/tool calls are needed for that reproduction.

Four added regression cases cover string and text-part checkpoints, oversized required checkpoints, and newest-checkpoint selection with retained message order. The existing no-checkpoint trimming, image attachment, normal-turn, and multipart tests remain green.

Only `src/adapters/chatgpt-web/prompt.ts` and `tests/prompt-contract.test.ts` are changed. Implementation was prepared with Codex assistance; validation limits are listed below.

## Scope and invariants

- [x] I read and followed `CONTRIBUTING.md` within the validation limitations below.
- [x] This is a small, focused change with no unrelated cleanup or generated rewrite.
- [x] The change stays focused on ChatGPT web-backed Codex models; it does not add a generic provider or unrelated product surface.
- [x] Model, route, effort, connector, and capability selection remain explicit with no silent fallback or false-success path.
- [x] Full harness capability bindings and Browser-only isolation are unchanged.
- [x] Terms and trademark claims remain factual; this change is not marketed as a quota or rate-limit bypass.

## Verification

- [x] Ran `bun install --frozen-lockfile` in the repository root and `launcher/` using Bun 1.4.0. The launcher's Electron binary download did not finish; installation was then completed with `ELECTRON_SKIP_BINARY_DOWNLOAD=1`.
- [x] Ran `bun run verify` with Bun 1.4.0. **It does not pass in this environment:** after switching the per-process audit registry from a mirror returning HTTP 404 to npm's official registry, the audit reports existing locked dependencies described below.
- [x] Added focused regression tests. `bun test tests/prompt-contract.test.ts`: **25 pass, 0 fail**.
- [x] Root and launcher typechecks, launcher renderer build, runtime bundle build, third-party notices generation, and relocatable runtime smoke all passed when the remaining verification stages were run individually.
- [ ] Complete root and launcher test suites: root **694 pass, 3 fail**; launcher **181 pass, 3 fail, 1 skipped**. Failures are module-load errors reporting that Electron is not installed correctly after its binary download was skipped. They affect the three Zero Risk compaction cases and the launcher browser-host/control-server/turn-suspension test files. No assertions or dependencies were changed to suppress these failures.
- [x] Manually exercised the isolated before/after compiler reproduction with synthetic context.
- [ ] Real installed long-task compaction and continuation have **not** been rerun end to end. A locally built bundle was installed and its service restarted successfully; that health check is not claimed as end-to-end acceptance.
- [x] No browser UI selectors or launcher packaging source were changed. Platform packages were not built.
- [x] No browser state, credentials, Tunnel IDs, raw logs, generated artifacts, private paths, dependency updates, or version changes are committed.

### Existing dependency audit findings

The manifests and lockfiles are identical to base commit `e85e3693fdb4e3e033348c08df0298c20fcdb612`:

- Root: `hono@4.12.34`, three moderate advisories: GHSA-gqvv-2mrq-wpjv, GHSA-g6gw-c38x-mqfc, GHSA-crvj-82cr-hjcx.
- Launcher: `js-yaml@4.3.1` through electron-builder's dependency tree, one high advisory: GHSA-2883-xcg3-v3hh.

These dependency findings are left outside this focused fix. This PR remains a draft while full validation is incomplete.

## Platform or account validation

Local checks: macOS 26.5.2 arm64, Bun 1.4.0. Installed bridge: v5.0.6, Full harness, ChatGPT Web Pro. Original and patched compiler comparison uses synthetic inputs and no account access. Windows/Linux packaging and a fresh full browser/MCP compaction cycle: not run.

The separate missing browser-completion-marker and platform safety-check symptoms are not fixed or causally attributed by this PR. No safety checks or completion gates are weakened.
