### PR TITLE
fix: recognize Simplified Chinese stopped-thinking status

### DIFF
--- a/src/adapters/chatgpt-web/adapter-error.ts
+++ b/src/adapters/chatgpt-web/adapter-error.ts
@@ -52,7 +52,7 @@ export function chatGptTurnSupersededError(): ChatGptWebAdapterError {
 export function chatGptStoppedThinkingError(): ChatGptWebAdapterError {
   return new ChatGptWebAdapterError(
     "ChatGPT displayed 'Stopped thinking' and could not continue this response. "
-    + "A ChatGPT Web usage limit may have been reached. Check the ChatGPT tab for the exact reason before retrying.",
+    + "The status does not identify the cause. This turn will not be automatically sent again.",
     {
       status: 502,
       errorType: "server_error",

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -4065,6 +4065,7 @@ export class ChatGptBrowserWorker {
           complete: block.complete === true || index < blocks.length - 1,
         } : {}),
       }));
+      // CHATGPT_STOPPED_THINKING_BEGIN
       const stoppedThinkingVisible = (() => {
         // Only ChatGPT UI in the bound response may terminate the turn. A model quoting this
         // phrase in its answer or reasoning is ordinary content, not a stopped-thinking status.
@@ -4076,17 +4077,23 @@ export class ChatGptBrowserWorker {
           }
           return true;
         };
-        const ariaMatch = [...root.querySelectorAll<HTMLElement>('[aria-label="Stopped thinking"]')]
+        // Exact labels observed in the English and Simplified Chinese ChatGPT UI. A generic
+        // "stopped" match could turn ordinary answer text into a false upstream failure.
+        const stoppedLabels = new Set(["Stopped thinking", "已停止思考"]);
+        const ariaMatch = [...root.querySelectorAll<HTMLElement>(
+          '[aria-label="Stopped thinking"], [aria-label="已停止思考"]',
+        )]
           .some(isStatus);
         if (ariaMatch) return true;
         const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
         for (let node = walker.nextNode(); node; node = walker.nextNode()) {
-          if (node.textContent?.replace(/\s+/g, " ").trim() !== "Stopped thinking") continue;
+          if (!stoppedLabels.has(node.textContent?.replace(/\s+/g, " ").trim() ?? "")) continue;
           const parent = node.parentElement;
           if (parent && isStatus(parent)) return true;
         }
         return false;
       })();
+      // CHATGPT_STOPPED_THINKING_END
       return {
         key: observerKey,
         snapshot: {

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -3287,8 +3287,58 @@ test("visible DOM trace emits one complete commentary paragraph before the next 
 test("Stopped thinking is an explicit upstream error, not a user cancellation or a proven quota error", () => {
   const error = chatGptStoppedThinkingError();
   expect(error).toMatchObject({ status: 502, errorType: "server_error", code: "chatgpt_stopped_thinking", retryable: false });
-  expect(error.message).toContain("usage limit may have been reached");
+  expect(error.message).toContain("does not identify the cause");
+  expect(error.message).toContain("will not be automatically sent again");
+  expect(error.message).not.toContain("usage limit");
   expect(error.message).not.toContain("5 seconds");
+});
+
+test("the shipped stopped-thinking detector recognizes the Chinese status only in the bound visible UI", () => {
+  // Execute the production page.evaluate predicate against a real DOM, without opening ChatGPT.
+  const { createDocument } = require("@mixmark-io/domino") as {
+    createDocument: (html: string) => Document;
+  };
+  const worker = readFileSync("src/adapters/chatgpt-web/browser-worker.ts", "utf8");
+  const source = worker.split("// CHATGPT_STOPPED_THINKING_BEGIN")[1]?.split("// CHATGPT_STOPPED_THINKING_END")[0];
+  if (!source) throw new Error("stopped-thinking detector sentinels are missing");
+  const javascript = new Bun.Transpiler({ loader: "ts" }).transformSync(source);
+  const detect = new Function(
+    "root", "overlapsRenderedAnswer", "overlapsCommentary", "renderedInDom", "document", "NodeFilter",
+    `${javascript}; return stoppedThinkingVisible;`,
+  ) as (...args: unknown[]) => boolean;
+  const detected = (html: string): boolean => {
+    const document = createDocument(`<body>${html}</body>`);
+    const root = document.querySelector<HTMLElement>('[data-turn-id="current"]')!;
+    // Domino's NodeList is array-like rather than iterable; preserve its real selector behavior.
+    const queryAll = root.querySelectorAll.bind(root);
+    Object.defineProperty(root, "querySelectorAll", {
+      value: (selector: string) => Array.from(queryAll(selector)),
+    });
+    const overlaps = (selector: string) => (candidate: HTMLElement): boolean => (
+      Array.from(queryAll(selector)).some(element => element.contains(candidate) || candidate.contains(element))
+    );
+    return detect(root, overlaps(".answer"), overlaps(".commentary"),
+      (element: HTMLElement) => !element.hidden && element.style.display !== "none"
+        && element.style.visibility !== "hidden" && element.style.opacity !== "0",
+      document, { SHOW_TEXT: 4 });
+  };
+  expect(detected('<section data-turn-id="current"><button>已停止思考<svg></svg></button></section>')).toBeTrue();
+  expect(detected('<section data-turn-id="current"><button aria-label="已停止思考"></button></section>')).toBeTrue();
+  expect(detected('<section data-turn-id="current"><button>Stopped thinking</button></section>')).toBeTrue();
+  for (const content of [
+    '<div class="answer"><p>已停止思考</p></div>',
+    '<div class="commentary"><p>已停止思考</p></div>',
+    '<pre><code>已停止思考</code></pre>',
+    '<blockquote>已停止思考</blockquote>',
+    '<div hidden><button>已停止思考</button></div>',
+    '<div style="display:none"><button aria-label="已停止思考"></button></div>',
+    '<button>Pro 思考中</button>',
+    '<button>已思考</button>',
+  ]) {
+    expect(detected(`<section data-turn-id="current">${content}</section>`)).toBeFalse();
+  }
+  expect(detected('<section data-turn-id="old"><button>已停止思考</button></section>'
+    + '<section data-turn-id="current"><button>Pro 思考中</button></section>')).toBeFalse();
 });
 
 test("visible DOM trace keeps a complete action phrase instead of a nested count", () => {

--- a/tests/chatgpt-web-harness.test.ts
+++ b/tests/chatgpt-web-harness.test.ts
@@ -1221,9 +1221,17 @@ describe("ChatGPT outer-native harness v4", () => {
       const response = buildResponseJSON(events, CHATGPT_WEB_MODEL_ID);
       expect(response).toMatchObject({ status: "failed", retryable: false,
         error: { type: "server_error", code: "chatgpt_stopped_thinking" } });
-      expect(JSON.stringify(response)).toContain("usage limit may have been reached");
+      expect(JSON.stringify(response)).toContain("does not identify the cause");
+      expect(JSON.stringify(response)).not.toContain("usage limit");
       expect(browserStarts).toBe(1);
       expect(events.some(event => event.type === "done")).toBeFalse();
+
+      const replayEvents: AdapterEvent[] = [];
+      await createChatGptWebAdapter(provider).runTurn!(rawWireRequest(environmentXml),
+        { headers: new Headers() }, event => replayEvents.push(event));
+      expect(replayEvents.at(-1)).toMatchObject({ type: "error", code: "chatgpt_stopped_thinking", retryable: false });
+      expect(browserStarts).toBe(1);
+      expect(replayEvents.some(event => event.type === "done")).toBeFalse();
     } finally {
       worker.run = originalRun;
       await TurnBroker.forSocket(socketPath).close();


### PR DESCRIPTION
## What this changes

With the Simplified Chinese ChatGPT UI, a response can display `已停止思考` while Codex continues waiting. The stopped-state detector only recognized English `Stopped thinking`.

Recognize the exact observed Chinese label in the existing bound-response detector, preserving its visibility, answer, commentary, quotation, and code exclusions. Return the existing non-retryable `chatgpt_stopped_thinking` error. Also remove the speculative usage-limit explanation: this status alone does not identify why ChatGPT stopped.

Related to observations in #446, but **this does not fix or identify a ChatGPT safety rejection or the cause of an upstream stop**.

## Evidence

On macOS with installed v5.0.6, Full Harness / Codex Native2, ChatGPT Web Pro, and a Simplified Chinese UI:

- Before the patch, the current response had a visible button labeled `已停止思考`, the composer was no longer generating, and there was no final answer. The bridge kept waiting until the diagnostic tab was manually closed.
- With the patched helper, a benign local file read actually succeeded (exit 0; output matched a previously prepared random fixture). When ChatGPT subsequently showed the stopped state, the helper returned the typed failure and Codex ended the turn without manual cancellation or another browser send.

The DOM fixture reconstructs the observed current-response status button; it is not a raw browser dump. It executes the production detection predicate and covers Chinese text/aria labels, English, and negative cases for answer/commentary/code/blockquote/hidden/old-turn content. The harness regression also checks that replaying the same failed request does not start a second browser turn.

The installed reproduction included pre-existing local patches; this PR is isolated against upstream `e85e369` and contains only these four related source/test files. No account, repository contents, raw browser state, or runtime configuration is included.

## Scope and invariants

- [x] I read `CONTRIBUTING.md`; verification limitations are disclosed below.
- [x] Small, focused change; no unrelated cleanup, provider, dependency, version, or generated artifact changes.
- [x] Model, route, effort, connector, and capability selection remain explicit; no fallback or false success.
- [x] Full harness retains the same turn-bound tools; Browser-only gains no broker or connector.
- [x] No changes to safety metadata, permissions, or approval checks; no quota-bypass claim.

## Verification

- [x] Root `bun install --frozen-lockfile` with pinned Bun 1.4.0.
- [x] Launcher frozen install completed with `ELECTRON_SKIP_BINARY_DOWNLOAD=1` after the Electron binary download stalled. No lockfile changes.
- [x] `bun test tests/browser-worker-contract.test.ts tests/chatgpt-web-harness.test.ts`: **208 passed, 0 failed, 1,156 assertions**.
- [x] `bun run typecheck` and `git diff --check` passed.
- [x] Affected behavior tested through a real installed Codex integration, as described above.
- [x] No credentials, Tunnel IDs, private paths, raw logs, or generated artifacts committed.
- [ ] Full `bun run verify` passed. It was attempted: the configured npm mirror returned 404 for the audit endpoint. Re-running with the public npm registry reached the audit and stopped on the unchanged upstream `hono@4.12.34` dependency (three moderate advisories: GHSA-gqvv-2mrq-wpjv, GHSA-g6gw-c38x-mqfc, GHSA-crvj-82cr-hjcx). No audit finding was ignored and dependencies were not changed. Later verify stages were not run by that script.

## Platform or account validation

Manually exercised macOS arm64, ChatGPT Pro, Full Harness / Native2, through the installed launcher and Codex. Windows/Linux packaging and other account tiers were not run. No launcher UI or packaging code changed. The fix ends a stopped response correctly; it does not make a stopped response resume or produce a final answer.
