### PR TITLE
fix: record MCP calls before SDK input validation

### DIFF
--- a/src/adapters/chatgpt-web/mcp-diagnostics.ts
+++ b/src/adapters/chatgpt-web/mcp-diagnostics.ts
@@ -1,0 +1,141 @@
+import { createHash } from "node:crypto";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
+
+const PUBLIC_TOOLS = new Set([
+  "codex_turn_start", "codex_exec", "codex_write_stdin", "codex_apply_patch",
+  "codex_view_image", "codex_tool_inventory", "codex_tool_call", "codex_turn_complete",
+]);
+const ARGUMENT_KEYS = new Set([
+  "turn_token", "request_id", "cmd", "workdir", "yield_time_ms", "max_output_tokens", "tty",
+  "session_id", "chars", "patch", "path", "detail", "query", "offset", "limit", "include_schema",
+  "wire_name", "arguments", "input", "final_answer",
+]);
+
+function object(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown> : undefined;
+}
+
+function digest(value: string) {
+  return { chars: value.length, sha256: createHash("sha256").update(value).digest("hex") };
+}
+
+function valueShape(value: unknown) {
+  return {
+    type: value === null ? "null" : Array.isArray(value) ? "array" : typeof value,
+    ...(typeof value === "string" ? { chars: value.length } : {}),
+    ...(value && typeof value === "object" ? { json_bytes: Buffer.byteLength(JSON.stringify(value)) } : {}),
+  };
+}
+
+function safeWireName(value: unknown) {
+  if (typeof value !== "string") return { type: typeof value };
+  return /^[A-Za-z0-9_$.-]{1,200}$/.test(value) && !/(?:turn|binding|control|call)_[A-Za-z0-9_-]{16,}/.test(value)
+    ? value : digest(value);
+}
+
+function inventorySummary(result: Record<string, unknown>) {
+  const catalog = object(result.structuredContent);
+  if (!catalog || !Array.isArray(catalog.tools)) return { available: false };
+  return {
+    returned: catalog.tools.length,
+    total: typeof catalog.total === "number" ? catalog.total : null,
+    next_offset: typeof catalog.next_offset === "number" ? catalog.next_offset : null,
+    tools: catalog.tools.slice(0, 50).map(value => {
+      const tool = object(value) ?? {};
+      return {
+        wire_name: safeWireName(tool.wire_name),
+        kind: ["freeform", "tool_search", "function", "gateway"].includes(String(tool.kind)) ? tool.kind : "unknown",
+        description: digest(typeof tool.description === "string" ? tool.description : ""),
+        ...(tool.parameters !== undefined ? { schema: digest(JSON.stringify(tool.parameters)) } : {}),
+      };
+    }),
+  };
+}
+
+function errorSummary(value: unknown) {
+  const error = object(value) ?? {};
+  const text = typeof error.message === "string" ? error.message
+    : Array.isArray(error.content) ? error.content.map(item => object(item)?.text)
+      .filter((part): part is string => typeof part === "string").join("\n") : "";
+  // SDK messages can interpolate arbitrary argument paths/values. Only emit a fixed category;
+  // retain a fingerprint, never the message or a model-authored/tool-returned error body.
+  return {
+    category: /^(?:MCP error -32602: )?Input validation error: Invalid arguments for tool /.test(text)
+      ? "input_validation_error" : "unclassified_error",
+    ...(typeof error.code === "number" ? { code: error.code } : {}),
+    text: digest(text),
+  };
+}
+
+/** Observe the stdio boundary before SDK input validation, without changing the MCP contract. */
+export function instrumentChatGptMcpTransport(
+  transport: Transport,
+  write: (event: Record<string, unknown>) => void = event => console.error(`[chatgpt-web-mcp] transport=${JSON.stringify(event)}`),
+): Transport {
+  let sequence = 0;
+  const pending = new Map<string, { started: number; sequence: number; tool: unknown; inventory: boolean }>();
+  const emit = (event: Record<string, unknown>) => {
+    // A diagnostics sink failure must not reject or alter a tool invocation.
+    try { write({ at: new Date().toISOString(), ...event }); } catch { /* diagnostics only */ }
+  };
+  const requestKey = (id: string | number) => `${typeof id}:${id}`;
+  const rpcId = (id: string | number) => typeof id === "number" ? id : digest(id);
+  const onmessage = transport.onmessage;
+  transport.onmessage = (message, extra) => {
+    if ("method" in message && message.method === "tools/call" && "id" in message) {
+      const params = object(message.params) ?? {};
+      const args = object(params.arguments);
+      const tool = typeof params.name === "string" && PUBLIC_TOOLS.has(params.name) ? params.name
+        : typeof params.name === "string" ? digest(params.name) : { type: typeof params.name };
+      const key = requestKey(message.id);
+      const duplicate = pending.has(key);
+      // Bound bookkeeping if a client disappears without receiving its replies.
+      if (pending.size >= 1_024) pending.delete(pending.keys().next().value!);
+      const call = { started: performance.now(), sequence: ++sequence, tool, inventory: params.name === "codex_tool_inventory" };
+      pending.set(key, call);
+      emit({
+        event: "tool_call_received", rpc_id: rpcId(message.id), call_sequence: call.sequence, tool,
+        ...(duplicate ? { duplicate_pending_id: true } : {}),
+        arguments: args ? Object.entries(args).map(([key, value]) => ({
+          key: ARGUMENT_KEYS.has(key) ? key : digest(key), ...valueShape(value),
+          ...(key === "query" && typeof value === "string" ? { sha256: digest(value).sha256 } : {}),
+        })) : valueShape(params.arguments),
+      });
+    }
+    onmessage?.(message, extra);
+  };
+  const send = transport.send.bind(transport);
+  transport.send = async (message: JSONRPCMessage, options) => {
+    const id = "id" in message && (typeof message.id === "string" || typeof message.id === "number") ? message.id : undefined;
+    const key = id !== undefined ? requestKey(id) : undefined;
+    const call = key !== undefined && !("method" in message) ? pending.get(key) : undefined;
+    try {
+      await send(message, options);
+      if (call && id !== undefined) {
+        const result = "result" in message ? object(message.result) : undefined;
+        const isError = "error" in message || result?.isError === true;
+        emit({
+          event: "tool_call_replied", rpc_id: rpcId(id), call_sequence: call.sequence, tool: call.tool,
+          elapsed_ms: Math.round(performance.now() - call.started),
+          outcome: "error" in message ? "jsonrpc_error" : isError ? "tool_error" : "success",
+          ...(isError ? { error: errorSummary("error" in message ? message.error : result) } : {}),
+          ...(call.inventory && result && !isError ? { inventory: inventorySummary(result) } : {}),
+        });
+      }
+    } catch (error) {
+      if (call && id !== undefined) emit({
+        event: "tool_call_reply_send_failed", rpc_id: rpcId(id), call_sequence: call.sequence,
+        tool: call.tool, elapsed_ms: Math.round(performance.now() - call.started),
+        error: errorSummary({ message: error instanceof Error ? error.message : "" }),
+      });
+      throw error;
+    } finally {
+      if (call && key !== undefined) pending.delete(key);
+    }
+  };
+  const onclose = transport.onclose;
+  transport.onclose = () => { pending.clear(); onclose?.(); };
+  return transport;
+}

--- a/src/adapters/chatgpt-web/mcp-server.ts
+++ b/src/adapters/chatgpt-web/mcp-server.ts
@@ -7,6 +7,7 @@ import { VERSION } from "../../version";
 import type { ChatGptTurnEnvironment } from "./environment";
 import { CODEX_COMPACTION_CONTROL_WIRE_NAME } from "./native-compaction-control";
 import { callTurnBroker, TurnBrokerTimeoutError, type BrokerToolResult } from "./turn-broker";
+import { instrumentChatGptMcpTransport } from "./mcp-diagnostics";
 
 interface ClaimedTurn {
   bindingId: string;
@@ -932,5 +933,5 @@ export async function runChatGptMcpServer(options: {
     );
   }
 
-  await server.connect(new StdioServerTransport());
+  await server.connect(instrumentChatGptMcpTransport(new StdioServerTransport()));
 }

--- a/tests/mcp-diagnostics.test.ts
+++ b/tests/mcp-diagnostics.test.ts
@@ -1,0 +1,170 @@
+import { expect, test } from "bun:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
+import { createHash, randomBytes } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { instrumentChatGptMcpTransport } from "../src/adapters/chatgpt-web/mcp-diagnostics";
+import { TurnBroker } from "../src/adapters/chatgpt-web/turn-broker";
+
+const hash = (text: string) => createHash("sha256").update(text).digest("hex");
+
+function fakeTransport() {
+  const sent: JSONRPCMessage[] = [];
+  const received: JSONRPCMessage[] = [];
+  const transport: Transport = {
+    async start() {},
+    async close() { transport.onclose?.(); },
+    async send(message) { sent.push(message); },
+    onmessage: message => received.push(message),
+  };
+  return { transport, sent, received };
+}
+
+test("MCP boundary diagnostics omit secrets and preserve requests and replies", async () => {
+  const events: Array<Record<string, any>> = [];
+  const fake = fakeTransport();
+  const transport = instrumentChatGptMcpTransport(fake.transport, event => events.push(event));
+  const secret = "private-token-and-file-content-should-never-appear";
+  const request: JSONRPCMessage = {
+    jsonrpc: "2.0", id: `rpc-${secret}`, method: "tools/call",
+    params: { name: "codex_tool_inventory", arguments: {
+      turn_token: secret, query: secret, include_schema: true, [secret]: secret,
+    }, _meta: { subject: secret } },
+  };
+  transport.onmessage?.(request);
+  const reply: JSONRPCMessage = {
+    jsonrpc: "2.0", id: request.id,
+    result: { content: [{ type: "text", text: secret }], structuredContent: {
+      total: 3, next_offset: 1,
+      tools: [{ wire_name: "exec_command", kind: "function", description: secret,
+        parameters: { type: "object", properties: { cmd: { description: secret } } } }],
+    }, _meta: { subject: secret } },
+  };
+  await transport.send(reply);
+  expect(fake.received).toEqual([request]);
+  expect(fake.sent).toEqual([reply]);
+  expect(events).toHaveLength(2);
+  expect(events[0]).toMatchObject({
+    event: "tool_call_received", rpc_id: { sha256: hash(String(request.id)) }, call_sequence: 1,
+    tool: "codex_tool_inventory",
+  });
+  expect(events[0]!.arguments.find((arg: any) => arg.key === "query"))
+    .toMatchObject({ chars: secret.length, sha256: hash(secret) });
+  expect(events[1]).toMatchObject({
+    event: "tool_call_replied", call_sequence: 1, outcome: "success",
+    inventory: { returned: 1, total: 3, next_offset: 1, tools: [{
+      wire_name: "exec_command", kind: "function", description: { chars: secret.length, sha256: hash(secret) },
+    }] },
+  });
+  expect(events[1]!.elapsed_ms).toBeGreaterThanOrEqual(0);
+  expect(JSON.stringify(events)).not.toContain(secret);
+  expect(JSON.stringify(events)).not.toContain("subject");
+  expect(JSON.stringify(events)).not.toContain("content");
+});
+
+test("MCP boundary diagnostics classify errors without retaining arbitrary error text", async () => {
+  const events: Array<Record<string, any>> = [];
+  const { transport } = fakeTransport();
+  instrumentChatGptMcpTransport(transport, event => events.push(event));
+  const secret = "authorization=private-command-secret";
+  const errors = [
+    { jsonrpc: "2.0", id: 1, result: { isError: true, content: [{ type: "text", text:
+      `MCP error -32602: Input validation error: Invalid arguments for tool codex_exec: ${secret}` }] } },
+    { jsonrpc: "2.0", id: 2, error: { code: -32603, message: secret, data: { token: secret } } },
+  ] satisfies JSONRPCMessage[];
+  for (const reply of errors) {
+    transport.onmessage?.({ jsonrpc: "2.0", id: reply.id!, method: "tools/call", params: {
+      name: "codex_exec", arguments: { turn_token: secret, cmd: secret },
+    } });
+    await transport.send(reply);
+  }
+  expect(events[1]).toMatchObject({ outcome: "tool_error", error: { category: "input_validation_error" } });
+  expect(events[3]).toMatchObject({ outcome: "jsonrpc_error", error: { category: "unclassified_error", code: -32603 } });
+  expect(JSON.stringify(events)).not.toContain(secret);
+});
+
+test("MCP diagnostics sink and send failures do not change transport semantics", async () => {
+  const fake = fakeTransport();
+  instrumentChatGptMcpTransport(fake.transport, () => { throw new Error("sink unavailable"); });
+  const request: JSONRPCMessage = { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "codex_exec" } };
+  fake.transport.onmessage?.(request);
+  const reply: JSONRPCMessage = { jsonrpc: "2.0", id: 1, result: {} };
+  await fake.transport.send(reply);
+  expect(fake.received).toEqual([request]);
+  expect(fake.sent).toEqual([reply]);
+
+  const events: Array<Record<string, any>> = [];
+  const failed = fakeTransport();
+  const error = new Error("secret send failure");
+  failed.transport.send = async () => { throw error; };
+  instrumentChatGptMcpTransport(failed.transport, event => events.push(event));
+  failed.transport.onmessage?.(request);
+  await expect(failed.transport.send(reply)).rejects.toBe(error);
+  expect(events[1]).toMatchObject({ event: "tool_call_reply_send_failed", call_sequence: 1 });
+  expect(JSON.stringify(events)).not.toContain(error.message);
+});
+
+test("real MCP stdio logs input validation before claim and preserves inventory-to-exec", async () => {
+  const socketPath = join(tmpdir(), `cgw-diag-${randomBytes(5).toString("hex")}.sock`);
+  const broker = TurnBroker.forSocket(socketPath);
+  const description = "Private schema documentation must only appear as a fingerprint";
+  const token = await broker.register({
+    cwd: tmpdir(), roots: [tmpdir()], writableRoots: [],
+    sandboxPolicy: { type: "readOnly", networkAccess: false },
+    tools: [{ name: "exec_command", description, parameters: { type: "object" } }],
+  }, 60_000);
+  const transport = new StdioClientTransport({
+    command: process.execPath, args: ["src/cli.ts", "mcp", "--broker-socket", socketPath],
+    cwd: process.cwd(), stderr: "pipe",
+  });
+  let stderr = "";
+  transport.stderr?.on("data", chunk => { stderr += chunk.toString(); });
+  const client = new Client({ name: "mcp-boundary-diagnostics-test", version: "1" });
+  const events = () => stderr.split("\n").filter(line => line.startsWith("[chatgpt-web-mcp] transport="))
+    .map(line => JSON.parse(line.slice("[chatgpt-web-mcp] transport=".length)) as Record<string, any>);
+  const awaitEvents = async (count: number) => {
+    const deadline = Date.now() + 2_000;
+    while (events().length < count && Date.now() < deadline) await Bun.sleep(5);
+    expect(events()).toHaveLength(count);
+  };
+  try {
+    await client.connect(transport);
+    const invalid = await client.callTool({ name: "codex_exec", arguments: { turn_token: token } });
+    expect(invalid.isError).toBeTrue();
+    expect(JSON.stringify(invalid)).toContain("Input validation error");
+    await awaitEvents(2);
+    expect(stderr).not.toContain("scope=");
+    const [received, replied] = events();
+    expect(received).toMatchObject({ event: "tool_call_received", tool: "codex_exec" });
+    expect(replied).toMatchObject({
+      event: "tool_call_replied", rpc_id: received!.rpc_id, call_sequence: received!.call_sequence,
+      outcome: "tool_error", error: { category: "input_validation_error" },
+    });
+
+    const inventory = await client.callTool({ name: "codex_tool_inventory", arguments: {
+      turn_token: token, query: "exec_command", include_schema: true,
+    } });
+    expect(inventory.structuredContent).toMatchObject({ total: 1, tools: [{ wire_name: "exec_command" }] });
+    const command = "synthetic command: never executed by this test";
+    const execution = client.callTool({ name: "codex_exec", arguments: { turn_token: token, cmd: command } });
+    const [request] = await broker.nextToolBatch(token);
+    expect(request).toMatchObject({ wireName: "exec_command", arguments: { cmd: command } });
+    broker.completeTool(token, request!.callId, {
+      content: [{ type: "text", text: "private-file-result" }], structuredContent: { output: "private-file-result" },
+    });
+    expect((await execution).structuredContent).toEqual({ output: "private-file-result" });
+    await awaitEvents(6);
+    expect(events()[3]).toMatchObject({ outcome: "success", inventory: { returned: 1, total: 1, next_offset: null } });
+    expect(events()[5]).toMatchObject({ outcome: "success", tool: "codex_exec" });
+    for (const privateValue of [token, description, command, "private-file-result"]) {
+      expect(JSON.stringify(events())).not.toContain(privateValue);
+    }
+  } finally {
+    await client.close().catch(() => {});
+    broker.revoke(token);
+    await broker.close();
+  }
+});


### PR DESCRIPTION
## What this changes

Observe MCP `tools/call` requests at the stdio transport boundary, before the SDK validates their arguments. Pair each request with its reply and elapsed time, including SDK validation errors that never enter the tool handler.

Related to #446 for diagnostic visibility only. This does not fix or bypass upstream safety checks.

## Evidence

Before this change, calling `codex_exec` without `cmd` returned an SDK input-validation error without reaching `claimTurn`, so the existing handler log could not distinguish that failure from a request that never arrived.

The same local stdio reproduction now records an incoming call and its matching `tool_error / input_validation_error` reply. Valid inventory-to-exec routing remains unchanged. Installed macOS Full-mode probes also produced correlated inventory logs and a successful read of a synthetic diagnostic file. The webpage later stopped; that upstream cause remains unknown.

Logs contain argument names/types/sizes, timings and correlation identifiers. Inventory descriptions/schemas and query text are fingerprinted. Command text, tokens, file contents, complete tool results and identity metadata are not recorded. Unknown errors are retained only as length/hash; recognized SDK validation errors get a fixed category. Diagnostics sink failures do not change invocation results.

## Scope and invariants

- [x] I read and followed `CONTRIBUTING.md`.
- [x] This is a small, focused change with no unrelated cleanup or generated rewrite.
- [x] The change stays focused on ChatGPT web-backed Codex models; it does not add a generic provider or unrelated product surface.
- [x] Model, route, effort, connector, and capability selection remain explicit with no silent fallback or false-success path.
- [x] Every available Web effort retains the same turn-bound capability and Browser-only gains no broker or connector.
- [x] Terms and trademark claims remain factual; this change is not marketed as a quota or rate-limit bypass.

## Verification

- [x] Root `bun install --frozen-lockfile` passed. Launcher frozen installation completed with `ELECTRON_SKIP_BINARY_DOWNLOAD=1`; its initial default attempt failed downloading Electron with `TypeError: fetch failed`. Lockfiles are unchanged; an Electron binary download or package rebuild is not claimed.
- [ ] Full `bun run verify` passed. It was attempted once with pinned Bun 1.4.0. Version sync passed, then the audit step failed because the configured npm mirror returned HTTP 404 for its security-advisory endpoint. Later verify steps were not reached; full verification is incomplete.
- [x] Added focused regression coverage for pre-handler validation errors, unchanged inventory-to-exec routing, secret omission and diagnostics/send failure semantics.
- [x] Manually reproduced the missing-`cmd` case through a real local MCP stdio client.
- [x] Exercised diagnostics through an installed Codex/ChatGPT Full integration; no private logs are included.
- [x] No browser UI or launcher behavior changes are included in this PR.
- [x] No browser state, credentials, Tunnel IDs, raw logs, generated artifacts or private paths are committed.
- [x] No dependency update, release artifact or version change is included.

Additional checks in this isolated worktree:

- Six focused tests passed, 177 assertions: the four new diagnostics tests plus the complete MCP contract and direct-tool routing tests in `chatgpt-web-harness.test.ts`. The public connector ABI hash remains unchanged.
- `bun run typecheck` passed using this worktree's frozen dependency installation.
- `git diff --check` passed. Only the transport observer, its two-line MCP integration and focused tests are included.

The initial audit failure was `POST https://registry.npmmirror.com/-/npm/v1/security/advisories/bulk - 404`. One separate `bun audit` with a command-local `npm_config_registry=https://registry.npmjs.org` reached the official registry and reported three moderate advisories in the unchanged `hono@4.12.34` lock entry: GHSA-gqvv-2mrq-wpjv, GHSA-g6gw-c38x-mqfc and GHSA-crvj-82cr-hjcx. No persistent registry configuration, dependency or unrelated code change was made; the full verify run was not repeated.

## Platform or account validation

Installed macOS arm64, ChatGPT Web Pro in Full mode. Inventory and a synthetic local file read were exercised. The diagnostics are not evidence that an upstream stopped response or safety rejection has been resolved. Browser-only, other account tiers, Windows/Linux packaging and release builds were not run for this change.
