### PR TITLE
feat: add bounded native text read tool

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -108,6 +108,20 @@ Browser-only mode needs no connector. Full harness mode requires all of the foll
 Do not rename or refresh an old **Codex Native** connector. ChatGPT caches the public MCP contract by
 connector identity, so create **Codex Native2** as a new connector.
 
+### Bounded read-only text tool is missing
+
+Native2 exposes `codex_read_text_file` for regular UTF-8 text reads on POSIX systems with
+`/usr/bin/python3`. It accepts a path and byte range, uses a fixed read-only program through the
+current outer Codex command tool, and retains native sandbox and approval checks. A result marked
+`truncated` is incomplete; continue from `next_offset` when the task needs the remaining text.
+
+After updating the running MCP service, refresh the existing **Codex Native2** connector's tool
+list in ChatGPT settings and confirm that `codex_read_text_file` is listed. This is an additive
+Native2 contract update, not a migration of the old **Codex Native** connector. Windows or a missing
+required interpreter returns an explicit failure. The tool does not accept arbitrary commands,
+write files, or access the network; other command and write tools retain their existing capabilities.
+It does not disable upstream safety checks or justify routing a rejected read through another tool.
+
 ### ChatGPT shows `Error creating connector`
 
 1. Confirm that the Tunnel ID and the regular API key used by the launcher were created under the

--- a/src/adapters/chatgpt-web/mcp-server.ts
+++ b/src/adapters/chatgpt-web/mcp-server.ts
@@ -7,6 +7,7 @@ import { VERSION } from "../../version";
 import type { ChatGptTurnEnvironment } from "./environment";
 import { CODEX_COMPACTION_CONTROL_WIRE_NAME } from "./native-compaction-control";
 import { callTurnBroker, TurnBrokerTimeoutError, type BrokerToolResult } from "./turn-broker";
+import { nativeTextReadCommand } from "./native-text-read";
 
 interface ClaimedTurn {
   bindingId: string;
@@ -19,6 +20,7 @@ export type ChatGptMcpContract = "native" | "safe";
 const BRIDGE_TOOL_NAMES = new Set([
   "codex_turn_start",
   "codex_exec",
+  "codex_read_text_file",
   "codex_write_stdin",
   "codex_apply_patch",
   "codex_view_image",
@@ -607,6 +609,35 @@ export async function runChatGptMcpServer(options: {
       input: execGatewayProgram(nestedToolName, freeform, payload, bound.tools.map(wireName)),
     }, signal);
   };
+
+  server.registerTool(
+    "codex_read_text_file",
+    {
+      title: "Read a text file through the native Codex harness",
+      description: afterSafeStart(contract, "Read up to 65536 bytes from a regular UTF-8 file. Accepts a file path and byte range only; cannot run arbitrary commands, write files, or access the network. Uses a fixed Python 3 read-only program through the current POSIX native command tool, preserving the outer Codex sandbox and approval policy. Use next_offset for the next chunk; truncated means the file was not fully read."),
+      inputSchema: {
+        ...turnReferenceInput(contract),
+        path: z.string().min(1).max(16_384).refine(value => !value.includes("\0")),
+        offset: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER).default(0),
+        max_bytes: z.number().int().min(4).max(65_536).default(65_536),
+      },
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    },
+    async (input, extra) => withClaimedTurn(
+      "codex_read_text_file", turnReference(contract, input), extra,
+      async claimed => {
+        const bound = claimed.environment;
+        const cmd = nativeTextReadCommand(input.path, input.offset, input.max_bytes);
+        const execArguments = { cmd, workdir: bound.cwd, shell: "/bin/sh", login: false,
+          yield_time_ms: 10_000, max_output_tokens: 80_000 };
+        const tool = exactTool(bound, "exec_command");
+        return tool
+          ? invoke(claimed.bindingId, bound, tool, { arguments: execArguments }, extra.signal)
+          : invokeNestedNative(claimed.bindingId, bound, "exec_command", false,
+            { arguments: execArguments }, extra.signal);
+      },
+    ),
+  );
 
   server.registerTool(
     "codex_exec",

--- a/src/adapters/chatgpt-web/native-text-read.ts
+++ b/src/adapters/chatgpt-web/native-text-read.ts
@@ -1,0 +1,41 @@
+/** Fixed read-only program; arguments are data, never a model-authored command.
+ * Dispatch must still use the current native harness's command tool and policy. */
+const READ_PROGRAM = `import os, stat, sys, json, codecs
+fd = None
+try:
+    path, offset, limit = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
+    fd = os.open(path, os.O_RDONLY | os.O_NONBLOCK)
+    info = os.fstat(fd)
+    if not stat.S_ISREG(info.st_mode):
+        raise ValueError('Only regular text files are supported')
+    if offset > info.st_size:
+        raise ValueError('Offset exceeds file size')
+    os.lseek(fd, offset, os.SEEK_SET)
+    data = os.read(fd, limit)
+    final = offset + len(data) >= info.st_size
+    decoder = codecs.getincrementaldecoder('utf-8')('strict')
+    text = decoder.decode(data, final=final)
+    pending = len(decoder.getstate()[0])
+    consumed = len(data) - pending
+    if '\\x00' in text:
+        raise ValueError('Binary data is not supported')
+    print(json.dumps({'text': text, 'offset': offset, 'bytes_read': consumed,
+        'next_offset': offset + consumed, 'file_size': info.st_size,
+        'truncated': offset + consumed < info.st_size}, ensure_ascii=False))
+except Exception as error:
+    print(json.dumps({'error': type(error).__name__, 'message': str(error)}))
+    sys.exit(2)
+finally:
+    if fd is not None:
+        os.close(fd)
+`;
+
+function quote(value: string): string { return "'" + value.replaceAll("'", "'\\''") + "'"; }
+
+export function nativeTextReadCommand(path: string, offset = 0, maxBytes = 65_536): string {
+  if (process.platform === "win32") throw new Error("Native text reading currently requires a POSIX command shell");
+  if (!path || path.length > 16_384 || path.includes("\0")) throw new Error("Invalid text file path");
+  if (!Number.isSafeInteger(offset) || offset < 0) throw new Error("Invalid byte offset");
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 4 || maxBytes > 65_536) throw new Error("Read size must be 4 to 65536 bytes");
+  return `/usr/bin/python3 -I -S -B -c ${quote(READ_PROGRAM)} ${quote(path)} ${offset} ${maxBytes}`;
+}

--- a/src/adapters/chatgpt-web/prompt.ts
+++ b/src/adapters/chatgpt-web/prompt.ts
@@ -498,6 +498,7 @@ export function compileChatGptWebPrompt(
       "For local work required by the task, use the attached Codex Native tools directly according to their declared descriptions and schemas.",
       "Call a Codex Native tool only when the latest active request requires a local effect or fresh local evidence that is not already present in the supplied context; otherwise answer the request directly without a tool call.",
       "Use actual Codex Native results as evidence for local observations and effects.",
+      "When the attached codex_read_text_file tool is available, use it for regular UTF-8 text reads. It accepts a path and byte range, not a command; it still uses the current Codex sandbox and approvals. A truncated result is a partial read: continue from next_offset when the task requires the rest. Do not use another tool to evade a rejected read.",
       "A Codex Native MCP tool result may require context compaction. If it does, follow the compaction instructions in that result exactly.",
       "After a deterministic tool failure, update the working hypothesis from that result and inspect the relevant repository or environment before choosing a different next action; do not repeat the same call unless its inputs or observable state changed.",
       "Continue using the available tools until the requested work is complete and verified.",

--- a/tests/chatgpt-web-harness.test.ts
+++ b/tests/chatgpt-web-harness.test.ts
@@ -2620,6 +2620,7 @@ describe("ChatGPT outer-native harness v4", () => {
       expect(listed.tools.map(tool => tool.name).sort()).toEqual([
         "codex_apply_patch",
         "codex_exec",
+        "codex_read_text_file",
         "codex_tool_call",
         "codex_tool_inventory",
         "codex_view_image",
@@ -2636,7 +2637,7 @@ describe("ChatGPT outer-native harness v4", () => {
       // ChatGPT caches the complete tools/list contract under a connector identity.
       // An intentional hash change therefore requires an explicit connector refresh or identity migration.
       expect(createHash("sha256").update(canonicalJson(publicConnectorAbi)).digest("hex"))
-        .toBe("5cb59b378c7d1939e260a2b4a60f58e22da31208fe09c2cc17a2cf31eb5ff3ad");
+        .toBe("e14eec31c6479470244b33a810f4f476e111d97a9718a61f5d18d3ca63e56c6b");
       for (const tool of listed.tools) {
         const properties = tool.inputSchema.properties as Record<string, unknown>;
         expect(properties.turn_token).toEqual({ type: "string", minLength: 20, maxLength: 256 });
@@ -2648,6 +2649,9 @@ describe("ChatGPT outer-native harness v4", () => {
         destructiveHint: true,
         idempotentHint: false,
         openWorldHint: true,
+      });
+      expect(listed.tools.find(tool => tool.name === "codex_read_text_file")?.annotations).toEqual({
+        readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false,
       });
       expect(listed.tools.find(tool => tool.name === "codex_write_stdin")?.annotations).toMatchObject({
         readOnlyHint: false,
@@ -2679,6 +2683,28 @@ describe("ChatGPT outer-native harness v4", () => {
         idempotentHint: false,
         openWorldHint: true,
       });
+
+      if (process.platform !== "win32") {
+        const reading = call("codex_read_text_file", { turn_token: token, path: "text.txt", max_bytes: 16 });
+        const [request] = await broker.nextToolBatch(token);
+        expect(request).toMatchObject({ wireName: "exec", freeform: true });
+        const gatewayCalls: GatewayProgramCall[] = [];
+        await executeGatewayProgram(request!.input!, ["exec_command"], gatewayCalls);
+        expect(gatewayCalls).toHaveLength(1);
+        expect(gatewayCalls[0]).toMatchObject({ name: "exec_command", input: {
+          workdir: tempRoot, shell: "/bin/sh", login: false,
+        } });
+        expect((gatewayCalls[0]!.input as Record<string, unknown>).cmd)
+          .toContain("/usr/bin/python3 -I -S -B -c");
+        const rejectedCalls: GatewayProgramCall[] = [];
+        await expect(executeGatewayProgram(request!.input!, ["shell_command"], rejectedCalls))
+          .rejects.toThrow();
+        expect(rejectedCalls).toEqual([]);
+        broker.completeTool(token, request!.callId, {
+          isError: true, content: [{ type: "text", text: "native read denied" }],
+        });
+        expect((await reading).isError).toBeTrue();
+      }
 
       const firstExec = call("codex_exec", {
         turn_token: token,

--- a/tests/native-text-read.test.ts
+++ b/tests/native-text-read.test.ts
@@ -1,0 +1,93 @@
+import {test,expect} from 'bun:test';
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { randomBytes } from "node:crypto";
+import {mkdtempSync,writeFileSync,readFileSync,readdirSync,rmSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {nativeTextReadCommand} from '../src/adapters/chatgpt-web/native-text-read';
+import { TurnBroker } from "../src/adapters/chatgpt-web/turn-broker";
+
+const posixTest = process.platform === "win32" ? test.skip : test;
+
+const run=(path:string,offset=0,limit=65536)=>{
+ const result=Bun.spawnSync(['/bin/sh','-c',nativeTextReadCommand(path,offset,limit)]);
+ return {code:result.exitCode,value:JSON.parse(result.stdout.toString())};
+};
+posixTest('read-only text program preserves UTF-8 across bounded chunks and changes no files',()=>{
+ const root=mkdtempSync(join(tmpdir(),'native-reader-'));
+ try{
+  const path=join(root,'text.txt');const text='甲乙丙丁\n尾行';writeFileSync(path,text);
+  let output='',offset=0;
+  do{const r=run(path,offset,4);expect(r.code).toBe(0);output+=r.value.text;
+   expect(r.value.next_offset).toBeGreaterThan(offset);offset=r.value.next_offset;
+   if(!r.value.truncated)break;
+  }while(true);
+  expect(output).toBe(text);expect(readFileSync(path,'utf8')).toBe(text);
+  expect(readdirSync(root)).toEqual(['text.txt']);
+ }finally{rmSync(root,{recursive:true,force:true});}
+});
+posixTest('path is literal data even with quotes, backticks, substitutions, and newlines',()=>{
+ const root=mkdtempSync(join(tmpdir(),'native-reader-'));
+ try{
+  const path=join(root,"x' `touch PWNED` $(touch PWNED)\n.txt");writeFileSync(path,'literal');
+  expect(run(path)).toEqual({code:0,value:{text:'literal',offset:0,bytes_read:7,next_offset:7,file_size:7,truncated:false}});
+  expect(readdirSync(root)).toEqual([path.slice(root.length+1)]);
+ }finally{rmSync(root,{recursive:true,force:true});}
+});
+posixTest('rejects nonregular, binary, invalid UTF-8 files, and invalid ranges',()=>{
+ const root=mkdtempSync(join(tmpdir(),'native-reader-'));
+ try{
+  const path=join(root,'binary');writeFileSync(path,Buffer.from([0,1,2]));
+  expect(run(path).code).toBe(2);expect(run(root).code).toBe(2);
+  writeFileSync(path,Buffer.from([255]));expect(run(path).code).toBe(2);
+  expect(run(path,2).code).toBe(2);
+  expect(()=>nativeTextReadCommand('x\0y')).toThrow();
+  expect(()=>nativeTextReadCommand('x',-1)).toThrow();
+  expect(()=>nativeTextReadCommand('x',0,65537)).toThrow();
+ }finally{rmSync(root,{recursive:true,force:true});}
+});
+
+test("Windows fails explicitly rather than invoking a POSIX program with different quoting", () => {
+  if (process.platform === "win32") {
+    expect(() => nativeTextReadCommand("text.txt")).toThrow("requires a POSIX command shell");
+  } else {
+    expect(nativeTextReadCommand("text.txt")).toContain("/usr/bin/python3 -I -S -B");
+  }
+});
+
+posixTest("real MCP text read preserves trusted cwd and a native sandbox refusal", async () => {
+  const socketPath = join(tmpdir(), `cgw-reader-${randomBytes(5).toString("hex")}.sock`);
+  const broker = TurnBroker.forSocket(socketPath);
+  const token = await broker.register({
+    cwd: tmpdir(), roots: [tmpdir()], writableRoots: [],
+    sandboxPolicy: { type: "readOnly", networkAccess: false },
+    tools: [{ name: "exec_command", description: "Native command tool", parameters: { type: "object" } }],
+  }, 60_000);
+  const client = new Client({ name: "native-reader-test", version: "1" });
+  const transport = new StdioClientTransport({
+    command: process.execPath, args: ["src/cli.ts", "mcp", "--broker-socket", socketPath],
+    cwd: process.cwd(), stderr: "pipe",
+  });
+  try {
+    await client.connect(transport);
+    const reading = client.callTool({ name: "codex_read_text_file", arguments: {
+      turn_token: token, path: "text.txt", offset: 0, max_bytes: 16,
+    } });
+    const [request] = await broker.nextToolBatch(token);
+    expect(request).toMatchObject({ wireName: "exec_command", arguments: {
+      workdir: tmpdir(), shell: "/bin/sh", login: false, max_output_tokens: 80_000,
+    } });
+    expect(request!.arguments!.cmd).toBe(nativeTextReadCommand("text.txt", 0, 16));
+    broker.completeTool(token, request!.callId, {
+      isError: true, content: [{ type: "text", text: "native read denied" }],
+    });
+    const result = await reading;
+    expect(result.isError).toBeTrue();
+    expect(result.content).toEqual([{ type: "text", text: "native read denied" }]);
+  } finally {
+    await client.close().catch(() => {});
+    broker.revoke(token);
+    await broker.close();
+  }
+});


### PR DESCRIPTION
## What this changes

Regular UTF-8 file reads currently use command tools that truthfully advertise write and network capabilities. Add `codex_read_text_file`: a bounded path/byte-range interface backed by a fixed read-only Python program, routed through the current outer Codex command tool and its sandbox/approval policy.

Related to #446. This is not a claim that the upstream safety interruption is fully diagnosed or fixed. Generic command/write tools keep their existing annotations and capabilities.

## Evidence

An installed macOS Full-mode Pro probe using the previous generic command interface reported a safety rejection before any file-read command reached the local execution queue. That wording came from the model's final answer; the platform's raw rejection details remain unavailable.

After installing this tool and refreshing the existing Native2 connector, a real desktop Codex CLI task with `chatgpt-web/pro`, `ultra`, and a read-only sandbox read a synthetic random `fixture.txt`. Both native reads exited 0; the final answer exactly matched the previously withheld random text, and the browser turn completed normally. The model read twice despite the prompt asking for one call, so this is evidence of a working interface, not strict call-count compliance or a quota claim. macOS's system Python launcher emitted sandbox-denied cache warnings but completed the reads successfully; the sandbox was not relaxed.

Intermittent failures mean this before/after observation does not establish a unique cause or long-task reliability. No private logs, file contents, credentials, or local user paths are attached.

## Scope and invariants

- [x] I read and followed `CONTRIBUTING.md`, with incomplete full verification disclosed below.
- [x] This is a focused additive tool, documentation, and regression-test change. Diagnostics, launcher changes, provider changes, and unrelated local patches are excluded.
- [x] The change stays focused on ChatGPT web-backed Codex models.
- [x] Model, effort, connector, and route selection remain explicit; there is no silent fallback or false-success path.
- [x] The tool uses the existing turn claim and native registry; every Full-mode Web effort receives the same tool, and Browser-only gains no broker or connector.
- [x] No safety-check, authentication, native sandbox, or approval bypass is introduced.
- [x] Terms and trademark claims remain factual; this is not a quota or rate-limit bypass.

The fixed program accepts no command or executable argument, shell-quotes paths as data, opens ordinary files read-only/nonblocking, caps reads at 64 KiB, rejects NUL/invalid UTF-8/nonregular files, and preserves incomplete UTF-8 characters between chunks. Native dispatch forces `/bin/sh` without login profiles. A native refusal remains a tool error.

This intentionally requires POSIX and `/usr/bin/python3`; Windows fails explicitly. A nested harness with only `shell_command` is rejected because that interface cannot guarantee the required shell behavior. No interpreter is downloaded or installed.

The public tools/list ABI changes intentionally. After updating the running MCP service, refresh the existing **Codex Native2** connector and verify the new tool is listed. This does not migrate or rename an old **Codex Native** connector. Maintainer review of this additive ABI and platform scope is requested before making the draft ready.

## Verification

- [x] Root and launcher `bun install --frozen-lockfile` passed with pinned Bun 1.4.0. Launcher install used `ELECTRON_SKIP_BINARY_DOWNLOAD=1`; downloading Electron or building platform packages is not claimed.
- [x] `bun run verify` was attempted once. Version sync passed, then the pre-existing configured npm mirror returned HTTP 404 at `/-/npm/v1/security/advisories/bulk`. Later full verify stages were not reached; full verification is incomplete. No lockfile or registry setting was changed.
- [x] Five focused text-reader tests passed, 29 assertions: UTF-8 chunks, literal-path injection resistance, invalid inputs/files, explicit platform behavior, and a real MCP stdio native-refusal test.
- [x] The complete MCP stdio contract test passed, 141 assertions, including the intentional ABI hash, unchanged generic annotations, native gateway routing, refusal propagation, and rejection of an incompatible command interface.
- [x] All 21 existing prompt-contract tests passed, 165 assertions.
- [x] `bun run typecheck` and `git diff --check` passed.
- [x] Execution was tested through a real installed desktop Codex/ChatGPT Full integration, not only DEV simulation.
- [x] No ChatGPT browser selector or launcher behavior changes are included.
- [x] No browser state, credentials, Tunnel IDs, raw logs, private paths, release artifacts, dependencies, or version changes are committed.

## Platform or account validation

Installed macOS arm64, Full mode, ChatGPT Web Pro / ultra. POSIX command execution, refreshed connector discovery, synthetic local file reading, and final completion were exercised. Linux execution, Windows packaging, other account tiers, Browser-only live behavior, long-task durability, file editing, and release packages: not run for this change.
